### PR TITLE
Anthropic auto-caching, model size routing, and token tracking

### DIFF
--- a/graphiti_core/llm_client/anthropic_client.py
+++ b/graphiti_core/llm_client/anthropic_client.py
@@ -27,7 +27,6 @@ from ..prompts.models import Message
 from .client import LLMClient
 from .config import DEFAULT_MAX_TOKENS, LLMConfig, ModelSize
 from .errors import RateLimitError, RefusalError
-from .token_tracker import TokenUsage
 
 if TYPE_CHECKING:
     import anthropic
@@ -446,7 +445,14 @@ class AnthropicClient(LLMClient):
                     total_cache_creation_tokens += cache_creation_tokens
                     total_cache_read_tokens += cache_read_tokens
 
-                    # Record token usage with cache metrics and model for cost estimation
+                    # If we have a response_model, attempt to validate the response
+                    if response_model is not None:
+                        # Validate the response against the response_model
+                        model_instance = response_model(**response)
+                        response = model_instance.model_dump()
+
+                    # Record token usage once after successful completion
+                    # (including any retry attempts)
                     self.token_tracker.record(
                         prompt_name,
                         total_input_tokens,
@@ -456,14 +462,8 @@ class AnthropicClient(LLMClient):
                         model=resolved_model,
                     )
 
-                    # Log per-call cost details
-                    call_usage = TokenUsage(
-                        input_tokens=total_input_tokens,
-                        output_tokens=total_output_tokens,
-                        cache_creation_input_tokens=total_cache_creation_tokens,
-                        cache_read_input_tokens=total_cache_read_tokens,
-                    )
-                    estimated_cost = call_usage.estimate_cost(resolved_model)
+                    # Log token usage details
+                    retries_note = f' retries={retry_count}' if retry_count > 0 else ''
                     cache_status = (
                         f'cache_write={total_cache_creation_tokens}, '
                         f'cache_read={total_cache_read_tokens}'
@@ -471,18 +471,9 @@ class AnthropicClient(LLMClient):
                     logger.info(
                         f'LLM call [{prompt_name or "unknown"}] model={resolved_model} '
                         f'in={total_input_tokens} out={total_output_tokens} '
-                        f'{cache_status} '
-                        f'cost=${estimated_cost:.6f} '
-                        f'cumulative=${self.token_tracker.get_total_estimated_cost():.6f}'
+                        f'{cache_status}{retries_note}'
                     )
 
-                    # If we have a response_model, attempt to validate the response
-                    if response_model is not None:
-                        # Validate the response against the response_model
-                        model_instance = response_model(**response)
-                        return model_instance.model_dump()
-
-                    # If no validation needed, return the response
                     return response
 
                 except (RateLimitError, RefusalError):

--- a/graphiti_core/llm_client/anthropic_client.py
+++ b/graphiti_core/llm_client/anthropic_client.py
@@ -27,6 +27,7 @@ from ..prompts.models import Message
 from .client import LLMClient
 from .config import DEFAULT_MAX_TOKENS, LLMConfig, ModelSize
 from .errors import RateLimitError, RefusalError
+from .token_tracker import TokenUsage
 
 if TYPE_CHECKING:
     import anthropic
@@ -268,7 +269,7 @@ class AnthropicClient(LLMClient):
         response_model: type[BaseModel] | None = None,
         max_tokens: int | None = None,
         model_size: ModelSize = ModelSize.medium,
-    ) -> tuple[dict[str, typing.Any], int, int]:
+    ) -> tuple[dict[str, typing.Any], int, int, int, int]:
         """
         Generate a response from the Anthropic LLM using tool-based approach for all requests.
 
@@ -276,9 +277,11 @@ class AnthropicClient(LLMClient):
             messages: List of message objects to send to the LLM.
             response_model: Optional Pydantic model to use for structured output.
             max_tokens: Maximum number of tokens to generate.
+            model_size: Size hint for model selection.
 
         Returns:
-            Tuple of (response_dict, input_tokens, output_tokens).
+            Tuple of (response_dict, input_tokens, output_tokens,
+                       cache_creation_input_tokens, cache_read_input_tokens).
 
         Raises:
             RateLimitError: If the rate limit is exceeded.
@@ -299,8 +302,25 @@ class AnthropicClient(LLMClient):
         try:
             # Create the appropriate tool based on whether response_model is provided
             tools, tool_choice = self._create_tool(response_model)
+
+            # Add cache_control to the last tool so the entire tool definition set is cached.
+            # Anthropic caches the prefix: tools -> system -> messages, so marking the last
+            # tool caches all tool schemas for subsequent calls with the same tools.
+            if tools:
+                tools[-1]['cache_control'] = {'type': 'ephemeral'}  # type: ignore[typeddict-unknown-key]
+
+            # Use structured system content blocks with cache_control so the system
+            # prompt is included in the cached prefix (after tools).
+            system_content: list[dict[str, typing.Any]] = [
+                {
+                    'type': 'text',
+                    'text': system_message.content,
+                    'cache_control': {'type': 'ephemeral'},
+                }
+            ]
+
             result = await self.client.messages.create(
-                system=system_message.content,
+                system=system_content,  # type: ignore[arg-type]
                 max_tokens=max_creation_tokens,
                 temperature=self.temperature,
                 messages=user_messages_cast,
@@ -309,12 +329,18 @@ class AnthropicClient(LLMClient):
                 tool_choice=tool_choice,
             )
 
-            # Extract token usage from the response
+            # Extract token usage from the response, including cache metrics
             input_tokens = 0
             output_tokens = 0
+            cache_creation_input_tokens = 0
+            cache_read_input_tokens = 0
             if hasattr(result, 'usage') and result.usage:
                 input_tokens = getattr(result.usage, 'input_tokens', 0) or 0
                 output_tokens = getattr(result.usage, 'output_tokens', 0) or 0
+                cache_creation_input_tokens = (
+                    getattr(result.usage, 'cache_creation_input_tokens', 0) or 0
+                )
+                cache_read_input_tokens = getattr(result.usage, 'cache_read_input_tokens', 0) or 0
 
             # Extract the tool output from the response
             for content_item in result.content:
@@ -323,7 +349,13 @@ class AnthropicClient(LLMClient):
                         tool_args: dict[str, typing.Any] = content_item.input
                     else:
                         tool_args = json.loads(str(content_item.input))
-                    return tool_args, input_tokens, output_tokens
+                    return (
+                        tool_args,
+                        input_tokens,
+                        output_tokens,
+                        cache_creation_input_tokens,
+                        cache_read_input_tokens,
+                    )
 
             # If we didn't get a proper tool_use response, try to extract from text
             for content_item in result.content:
@@ -332,6 +364,8 @@ class AnthropicClient(LLMClient):
                         self._extract_json_from_text(content_item.text),
                         input_tokens,
                         output_tokens,
+                        cache_creation_input_tokens,
+                        cache_read_input_tokens,
                     )
                 else:
                     raise ValueError(
@@ -394,22 +428,62 @@ class AnthropicClient(LLMClient):
                 attributes['prompt.name'] = prompt_name
             span.add_attributes(attributes)
 
+            # Resolve the model that will actually be used (for logging/cost)
+            resolved_model = self._get_model_for_size(model_size)
+
             retry_count = 0
             max_retries = 2
             last_error: Exception | None = None
             total_input_tokens = 0
             total_output_tokens = 0
+            total_cache_creation_tokens = 0
+            total_cache_read_tokens = 0
 
             while retry_count <= max_retries:
                 try:
-                    response, input_tokens, output_tokens = await self._generate_response(
+                    (
+                        response,
+                        input_tokens,
+                        output_tokens,
+                        cache_creation_tokens,
+                        cache_read_tokens,
+                    ) = await self._generate_response(
                         messages, response_model, max_tokens, model_size
                     )
                     total_input_tokens += input_tokens
                     total_output_tokens += output_tokens
+                    total_cache_creation_tokens += cache_creation_tokens
+                    total_cache_read_tokens += cache_read_tokens
 
-                    # Record token usage
-                    self.token_tracker.record(prompt_name, total_input_tokens, total_output_tokens)
+                    # Record token usage with cache metrics and model for cost estimation
+                    self.token_tracker.record(
+                        prompt_name,
+                        total_input_tokens,
+                        total_output_tokens,
+                        cache_creation_input_tokens=total_cache_creation_tokens,
+                        cache_read_input_tokens=total_cache_read_tokens,
+                        model=resolved_model,
+                    )
+
+                    # Log per-call cost details
+                    call_usage = TokenUsage(
+                        input_tokens=total_input_tokens,
+                        output_tokens=total_output_tokens,
+                        cache_creation_input_tokens=total_cache_creation_tokens,
+                        cache_read_input_tokens=total_cache_read_tokens,
+                    )
+                    estimated_cost = call_usage.estimate_cost(resolved_model)
+                    cache_status = (
+                        f'cache_write={total_cache_creation_tokens}, '
+                        f'cache_read={total_cache_read_tokens}'
+                    )
+                    logger.info(
+                        f'LLM call [{prompt_name or "unknown"}] model={resolved_model} '
+                        f'in={total_input_tokens} out={total_output_tokens} '
+                        f'{cache_status} '
+                        f'cost=${estimated_cost:.6f} '
+                        f'cumulative=${self.token_tracker.get_total_estimated_cost():.6f}'
+                    )
 
                     # If we have a response_model, attempt to validate the response
                     if response_model is not None:

--- a/graphiti_core/llm_client/anthropic_client.py
+++ b/graphiti_core/llm_client/anthropic_client.py
@@ -303,24 +303,15 @@ class AnthropicClient(LLMClient):
             # Create the appropriate tool based on whether response_model is provided
             tools, tool_choice = self._create_tool(response_model)
 
-            # Add cache_control to the last tool so the entire tool definition set is cached.
-            # Anthropic caches the prefix: tools -> system -> messages, so marking the last
-            # tool caches all tool schemas for subsequent calls with the same tools.
-            if tools:
-                tools[-1]['cache_control'] = {'type': 'ephemeral'}  # type: ignore[typeddict-unknown-key]
-
-            # Use structured system content blocks with cache_control so the system
-            # prompt is included in the cached prefix (after tools).
-            system_content: list[dict[str, typing.Any]] = [
-                {
-                    'type': 'text',
-                    'text': system_message.content,
-                    'cache_control': {'type': 'ephemeral'},
-                }
-            ]
-
+            # Use top-level auto caching. This places a cache breakpoint on the last
+            # cacheable block in the request (typically the last user message), which
+            # means the entire prefix (tools + system + messages) is eligible for
+            # caching. This avoids the issue with explicit block-level cache_control
+            # where tools + system alone may fall below minimum cacheable thresholds
+            # (1024 tokens for Sonnet, 2048 for Sonnet 4.6, 4096 for Haiku).
             result = await self.client.messages.create(
-                system=system_content,  # type: ignore[arg-type]
+                cache_control={'type': 'ephemeral'},
+                system=system_message.content,
                 max_tokens=max_creation_tokens,
                 temperature=self.temperature,
                 messages=user_messages_cast,

--- a/graphiti_core/llm_client/anthropic_client.py
+++ b/graphiti_core/llm_client/anthropic_client.py
@@ -65,7 +65,7 @@ AnthropicModel = Literal[
     'claude-2.0',
 ]
 
-DEFAULT_MODEL: AnthropicModel = 'claude-haiku-4-5-latest'
+DEFAULT_MODEL: AnthropicModel = 'claude-sonnet-4-5-latest'
 DEFAULT_SMALL_MODEL: AnthropicModel = 'claude-haiku-4-5-latest'
 
 # Maximum output tokens for different Anthropic models
@@ -153,11 +153,14 @@ class AnthropicClient(LLMClient):
             self.client = client
 
     def _get_model_for_size(self, model_size: ModelSize) -> str:
-        """Get the appropriate model name based on the requested size."""
+        """Get the appropriate model name based on the requested size.
+
+        small -> self.small_model (default: Haiku)
+        medium -> self.model (default: Sonnet)
+        """
         if model_size == ModelSize.small:
             return self.small_model or DEFAULT_SMALL_MODEL
-        else:
-            return self.model or DEFAULT_MODEL
+        return self.model or DEFAULT_MODEL
 
     def _extract_json_from_text(self, text: str) -> dict[str, typing.Any]:
         """Extract JSON from text content.

--- a/graphiti_core/llm_client/anthropic_client.py
+++ b/graphiti_core/llm_client/anthropic_client.py
@@ -468,7 +468,7 @@ class AnthropicClient(LLMClient):
                         f'cache_write={total_cache_creation_tokens}, '
                         f'cache_read={total_cache_read_tokens}'
                     )
-                    logger.info(
+                    logger.debug(
                         f'LLM call [{prompt_name or "unknown"}] model={resolved_model} '
                         f'in={total_input_tokens} out={total_output_tokens} '
                         f'{cache_status}{retries_note}'

--- a/graphiti_core/llm_client/token_tracker.py
+++ b/graphiti_core/llm_client/token_tracker.py
@@ -69,11 +69,9 @@ class PromptTokenUsage:
     @property
     def cache_hit_rate(self) -> float:
         """Fraction of input tokens served from cache vs total input."""
-        total_input = (
-            self.total_input_tokens
-            + self.total_cache_creation_tokens
-            + self.total_cache_read_tokens
-        )
+        # cache_creation_input_tokens is a subset of input_tokens on cache-write calls,
+        # so only count input_tokens + cache_read_tokens to avoid double-counting.
+        total_input = self.total_input_tokens + self.total_cache_read_tokens
         if total_input == 0:
             return 0.0
         return self.total_cache_read_tokens / total_input
@@ -226,11 +224,7 @@ class TokenUsageTracker:
         total_calls = sum(u.call_count for u in usage.values())
         print('-' * 110)
         if has_cache:
-            total_all_input = (
-                total.input_tokens
-                + total.cache_creation_input_tokens
-                + total.cache_read_input_tokens
-            )
+            total_all_input = total.input_tokens + total.cache_read_input_tokens
             overall_hit_rate = (
                 total.cache_read_input_tokens / total_all_input if total_all_input > 0 else 0
             )

--- a/graphiti_core/llm_client/token_tracker.py
+++ b/graphiti_core/llm_client/token_tracker.py
@@ -14,8 +14,36 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from threading import Lock
+
+# Anthropic pricing per million tokens (USD)
+# Maps model prefix -> (input, output, cache_write, cache_read)
+ANTHROPIC_PRICING: dict[str, tuple[float, float, float, float]] = {
+    'claude-sonnet-4-5': (3.00, 15.00, 3.75, 0.30),
+    'claude-haiku-4-5': (1.00, 5.00, 1.25, 0.10),
+    'claude-3-7-sonnet': (3.00, 15.00, 3.75, 0.30),
+    'claude-3-5-sonnet': (3.00, 15.00, 3.75, 0.30),
+    'claude-3-5-haiku': (0.80, 4.00, 1.00, 0.08),
+    'claude-3-opus': (15.00, 75.00, 18.75, 1.50),
+    'claude-3-sonnet': (3.00, 15.00, 3.75, 0.30),
+    'claude-3-haiku': (0.25, 1.25, 0.30, 0.03),
+}
+
+# Fallback pricing (uses Haiku 4.5 rates as a sensible default)
+_DEFAULT_PRICING = (1.00, 5.00, 1.25, 0.10)
+
+
+def get_anthropic_pricing(model: str) -> tuple[float, float, float, float]:
+    """Get pricing for an Anthropic model by matching the longest prefix.
+
+    Returns:
+        Tuple of (input, output, cache_write, cache_read) prices per million tokens.
+    """
+    for prefix in sorted(ANTHROPIC_PRICING.keys(), key=len, reverse=True):
+        if model.startswith(prefix):
+            return ANTHROPIC_PRICING[prefix]
+    return _DEFAULT_PRICING
 
 
 @dataclass
@@ -24,10 +52,36 @@ class TokenUsage:
 
     input_tokens: int = 0
     output_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
 
     @property
     def total_tokens(self) -> int:
-        return self.input_tokens + self.output_tokens
+        return (
+            self.input_tokens
+            + self.output_tokens
+            + self.cache_creation_input_tokens
+            + self.cache_read_input_tokens
+        )
+
+    def estimate_cost(self, model: str) -> float:
+        """Estimate USD cost for this usage based on Anthropic pricing.
+
+        Args:
+            model: The Anthropic model name used for this call.
+
+        Returns:
+            Estimated cost in USD.
+        """
+        input_price, output_price, cache_write_price, cache_read_price = get_anthropic_pricing(
+            model
+        )
+        return (
+            self.input_tokens * input_price
+            + self.output_tokens * output_price
+            + self.cache_creation_input_tokens * cache_write_price
+            + self.cache_read_input_tokens * cache_read_price
+        ) / 1_000_000
 
 
 @dataclass
@@ -38,10 +92,19 @@ class PromptTokenUsage:
     call_count: int = 0
     total_input_tokens: int = 0
     total_output_tokens: int = 0
+    total_cache_creation_tokens: int = 0
+    total_cache_read_tokens: int = 0
+    total_estimated_cost: float = 0.0
+    models_used: dict[str, int] = field(default_factory=dict)
 
     @property
     def total_tokens(self) -> int:
-        return self.total_input_tokens + self.total_output_tokens
+        return (
+            self.total_input_tokens
+            + self.total_output_tokens
+            + self.total_cache_creation_tokens
+            + self.total_cache_read_tokens
+        )
 
     @property
     def avg_input_tokens(self) -> float:
@@ -51,6 +114,18 @@ class PromptTokenUsage:
     def avg_output_tokens(self) -> float:
         return self.total_output_tokens / self.call_count if self.call_count > 0 else 0
 
+    @property
+    def cache_hit_rate(self) -> float:
+        """Fraction of input tokens served from cache vs total input."""
+        total_input = (
+            self.total_input_tokens
+            + self.total_cache_creation_tokens
+            + self.total_cache_read_tokens
+        )
+        if total_input == 0:
+            return 0.0
+        return self.total_cache_read_tokens / total_input
+
 
 class TokenUsageTracker:
     """Thread-safe tracker for LLM token usage by prompt type."""
@@ -59,15 +134,37 @@ class TokenUsageTracker:
         self._usage: dict[str, PromptTokenUsage] = {}
         self._lock = Lock()
 
-    def record(self, prompt_name: str | None, input_tokens: int, output_tokens: int) -> None:
+    def record(
+        self,
+        prompt_name: str | None,
+        input_tokens: int,
+        output_tokens: int,
+        cache_creation_input_tokens: int = 0,
+        cache_read_input_tokens: int = 0,
+        model: str | None = None,
+    ) -> None:
         """Record token usage for a prompt.
 
         Args:
             prompt_name: Name of the prompt (e.g., 'extract_nodes.extract_message')
-            input_tokens: Number of input tokens used
+            input_tokens: Number of input tokens used (non-cached)
             output_tokens: Number of output tokens generated
+            cache_creation_input_tokens: Tokens written to Anthropic prompt cache
+            cache_read_input_tokens: Tokens read from Anthropic prompt cache
+            model: Model name used (for cost estimation)
         """
         key = prompt_name or 'unknown'
+
+        # Compute cost for this call
+        estimated_cost = 0.0
+        if model:
+            usage = TokenUsage(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cache_creation_input_tokens=cache_creation_input_tokens,
+                cache_read_input_tokens=cache_read_input_tokens,
+            )
+            estimated_cost = usage.estimate_cost(model)
 
         with self._lock:
             if key not in self._usage:
@@ -76,6 +173,11 @@ class TokenUsageTracker:
             self._usage[key].call_count += 1
             self._usage[key].total_input_tokens += input_tokens
             self._usage[key].total_output_tokens += output_tokens
+            self._usage[key].total_cache_creation_tokens += cache_creation_input_tokens
+            self._usage[key].total_cache_read_tokens += cache_read_input_tokens
+            self._usage[key].total_estimated_cost += estimated_cost
+            if model:
+                self._usage[key].models_used[model] = self._usage[key].models_used.get(model, 0) + 1
 
     def get_usage(self) -> dict[str, PromptTokenUsage]:
         """Get a copy of current token usage by prompt type."""
@@ -86,6 +188,10 @@ class TokenUsageTracker:
                     call_count=v.call_count,
                     total_input_tokens=v.total_input_tokens,
                     total_output_tokens=v.total_output_tokens,
+                    total_cache_creation_tokens=v.total_cache_creation_tokens,
+                    total_cache_read_tokens=v.total_cache_read_tokens,
+                    total_estimated_cost=v.total_estimated_cost,
+                    models_used=dict(v.models_used),
                 )
                 for k, v in self._usage.items()
             }
@@ -95,7 +201,19 @@ class TokenUsageTracker:
         with self._lock:
             total_input = sum(u.total_input_tokens for u in self._usage.values())
             total_output = sum(u.total_output_tokens for u in self._usage.values())
-            return TokenUsage(input_tokens=total_input, output_tokens=total_output)
+            total_cache_creation = sum(u.total_cache_creation_tokens for u in self._usage.values())
+            total_cache_read = sum(u.total_cache_read_tokens for u in self._usage.values())
+            return TokenUsage(
+                input_tokens=total_input,
+                output_tokens=total_output,
+                cache_creation_input_tokens=total_cache_creation,
+                cache_read_input_tokens=total_cache_read,
+            )
+
+    def get_total_estimated_cost(self) -> float:
+        """Get total estimated cost across all prompts."""
+        with self._lock:
+            return sum(u.total_estimated_cost for u in self._usage.values())
 
     def reset(self) -> None:
         """Reset all tracked usage."""
@@ -106,7 +224,8 @@ class TokenUsageTracker:
         """Print a formatted summary of token usage.
 
         Args:
-            sort_by: Sort key - 'total_tokens', 'input_tokens', 'output_tokens', 'call_count', or 'prompt_name'
+            sort_by: Sort key - 'total_tokens', 'input_tokens', 'output_tokens',
+                     'call_count', 'prompt_name', or 'cost'
         """
         usage = self.get_usage()
         if not usage:
@@ -120,33 +239,85 @@ class TokenUsageTracker:
             'output_tokens': lambda x: x[1].total_output_tokens,
             'call_count': lambda x: x[1].call_count,
             'prompt_name': lambda x: x[0],
+            'cost': lambda x: x[1].total_estimated_cost,
         }
         sort_fn = sort_keys.get(sort_by, sort_keys['total_tokens'])
         sorted_usage = sorted(usage.items(), key=sort_fn, reverse=(sort_by != 'prompt_name'))
 
-        # Print header
-        print('\n' + '=' * 100)
-        print('TOKEN USAGE SUMMARY')
-        print('=' * 100)
-        print(
-            f'{"Prompt Type":<45} {"Calls":>8} {"Input":>12} {"Output":>12} {"Total":>12} {"Avg In":>10} {"Avg Out":>10}'
+        has_cache = any(
+            u.total_cache_creation_tokens > 0 or u.total_cache_read_tokens > 0
+            for u in usage.values()
         )
-        print('-' * 100)
+
+        # Print header
+        print('\n' + '=' * 120)
+        print('TOKEN USAGE SUMMARY')
+        print('=' * 120)
+        if has_cache:
+            print(
+                f'{"Prompt Type":<40} {"Calls":>6} {"Input":>10} {"Output":>10} '
+                f'{"CacheW":>10} {"CacheR":>10} {"Hit%":>6} {"Cost($)":>10}'
+            )
+        else:
+            print(
+                f'{"Prompt Type":<40} {"Calls":>6} {"Input":>10} {"Output":>10} '
+                f'{"Total":>10} {"Avg In":>8} {"Avg Out":>8} {"Cost($)":>10}'
+            )
+        print('-' * 120)
 
         # Print each prompt's usage
-        for prompt_name, prompt_usage in sorted_usage:
-            print(
-                f'{prompt_name:<45} {prompt_usage.call_count:>8} {prompt_usage.total_input_tokens:>12,} '
-                f'{prompt_usage.total_output_tokens:>12,} {prompt_usage.total_tokens:>12,} '
-                f'{prompt_usage.avg_input_tokens:>10,.1f} {prompt_usage.avg_output_tokens:>10,.1f}'
-            )
+        for _prompt_name, prompt_usage in sorted_usage:
+            if has_cache:
+                print(
+                    f'{_prompt_name:<40} {prompt_usage.call_count:>6} '
+                    f'{prompt_usage.total_input_tokens:>10,} '
+                    f'{prompt_usage.total_output_tokens:>10,} '
+                    f'{prompt_usage.total_cache_creation_tokens:>10,} '
+                    f'{prompt_usage.total_cache_read_tokens:>10,} '
+                    f'{prompt_usage.cache_hit_rate:>5.0%} '
+                    f'{prompt_usage.total_estimated_cost:>10.6f}'
+                )
+            else:
+                print(
+                    f'{_prompt_name:<40} {prompt_usage.call_count:>6} '
+                    f'{prompt_usage.total_input_tokens:>10,} '
+                    f'{prompt_usage.total_output_tokens:>10,} '
+                    f'{prompt_usage.total_tokens:>10,} '
+                    f'{prompt_usage.avg_input_tokens:>8,.1f} '
+                    f'{prompt_usage.avg_output_tokens:>8,.1f} '
+                    f'{prompt_usage.total_estimated_cost:>10.6f}'
+                )
 
         # Print totals
         total = self.get_total_usage()
         total_calls = sum(u.call_count for u in usage.values())
-        print('-' * 100)
-        print(
-            f'{"TOTAL":<45} {total_calls:>8} {total.input_tokens:>12,} '
-            f'{total.output_tokens:>12,} {total.total_tokens:>12,}'
-        )
-        print('=' * 100 + '\n')
+        total_cost = sum(u.total_estimated_cost for u in usage.values())
+        print('-' * 120)
+        if has_cache:
+            total_all_input = (
+                total.input_tokens
+                + total.cache_creation_input_tokens
+                + total.cache_read_input_tokens
+            )
+            overall_hit_rate = (
+                total.cache_read_input_tokens / total_all_input if total_all_input > 0 else 0
+            )
+            print(
+                f'{"TOTAL":<40} {total_calls:>6} '
+                f'{total.input_tokens:>10,} '
+                f'{total.output_tokens:>10,} '
+                f'{total.cache_creation_input_tokens:>10,} '
+                f'{total.cache_read_input_tokens:>10,} '
+                f'{overall_hit_rate:>5.0%} '
+                f'{total_cost:>10.6f}'
+            )
+        else:
+            print(
+                f'{"TOTAL":<40} {total_calls:>6} '
+                f'{total.input_tokens:>10,} '
+                f'{total.output_tokens:>10,} '
+                f'{total.total_tokens:>10,} '
+                f'{"":>8} {"":>8} '
+                f'{total_cost:>10.6f}'
+            )
+        print('=' * 120 + '\n')

--- a/graphiti_core/llm_client/token_tracker.py
+++ b/graphiti_core/llm_client/token_tracker.py
@@ -17,34 +17,6 @@ limitations under the License.
 from dataclasses import dataclass, field
 from threading import Lock
 
-# Anthropic pricing per million tokens (USD)
-# Maps model prefix -> (input, output, cache_write, cache_read)
-ANTHROPIC_PRICING: dict[str, tuple[float, float, float, float]] = {
-    'claude-sonnet-4-5': (3.00, 15.00, 3.75, 0.30),
-    'claude-haiku-4-5': (1.00, 5.00, 1.25, 0.10),
-    'claude-3-7-sonnet': (3.00, 15.00, 3.75, 0.30),
-    'claude-3-5-sonnet': (3.00, 15.00, 3.75, 0.30),
-    'claude-3-5-haiku': (0.80, 4.00, 1.00, 0.08),
-    'claude-3-opus': (15.00, 75.00, 18.75, 1.50),
-    'claude-3-sonnet': (3.00, 15.00, 3.75, 0.30),
-    'claude-3-haiku': (0.25, 1.25, 0.30, 0.03),
-}
-
-# Fallback pricing (uses Haiku 4.5 rates as a sensible default)
-_DEFAULT_PRICING = (1.00, 5.00, 1.25, 0.10)
-
-
-def get_anthropic_pricing(model: str) -> tuple[float, float, float, float]:
-    """Get pricing for an Anthropic model by matching the longest prefix.
-
-    Returns:
-        Tuple of (input, output, cache_write, cache_read) prices per million tokens.
-    """
-    for prefix in sorted(ANTHROPIC_PRICING.keys(), key=len, reverse=True):
-        if model.startswith(prefix):
-            return ANTHROPIC_PRICING[prefix]
-    return _DEFAULT_PRICING
-
 
 @dataclass
 class TokenUsage:
@@ -64,25 +36,6 @@ class TokenUsage:
             + self.cache_read_input_tokens
         )
 
-    def estimate_cost(self, model: str) -> float:
-        """Estimate USD cost for this usage based on Anthropic pricing.
-
-        Args:
-            model: The Anthropic model name used for this call.
-
-        Returns:
-            Estimated cost in USD.
-        """
-        input_price, output_price, cache_write_price, cache_read_price = get_anthropic_pricing(
-            model
-        )
-        return (
-            self.input_tokens * input_price
-            + self.output_tokens * output_price
-            + self.cache_creation_input_tokens * cache_write_price
-            + self.cache_read_input_tokens * cache_read_price
-        ) / 1_000_000
-
 
 @dataclass
 class PromptTokenUsage:
@@ -94,7 +47,6 @@ class PromptTokenUsage:
     total_output_tokens: int = 0
     total_cache_creation_tokens: int = 0
     total_cache_read_tokens: int = 0
-    total_estimated_cost: float = 0.0
     models_used: dict[str, int] = field(default_factory=dict)
 
     @property
@@ -151,20 +103,9 @@ class TokenUsageTracker:
             output_tokens: Number of output tokens generated
             cache_creation_input_tokens: Tokens written to Anthropic prompt cache
             cache_read_input_tokens: Tokens read from Anthropic prompt cache
-            model: Model name used (for cost estimation)
+            model: Model name used for this call
         """
         key = prompt_name or 'unknown'
-
-        # Compute cost for this call
-        estimated_cost = 0.0
-        if model:
-            usage = TokenUsage(
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                cache_creation_input_tokens=cache_creation_input_tokens,
-                cache_read_input_tokens=cache_read_input_tokens,
-            )
-            estimated_cost = usage.estimate_cost(model)
 
         with self._lock:
             if key not in self._usage:
@@ -175,9 +116,10 @@ class TokenUsageTracker:
             self._usage[key].total_output_tokens += output_tokens
             self._usage[key].total_cache_creation_tokens += cache_creation_input_tokens
             self._usage[key].total_cache_read_tokens += cache_read_input_tokens
-            self._usage[key].total_estimated_cost += estimated_cost
             if model:
-                self._usage[key].models_used[model] = self._usage[key].models_used.get(model, 0) + 1
+                self._usage[key].models_used[model] = (
+                    self._usage[key].models_used.get(model, 0) + 1
+                )
 
     def get_usage(self) -> dict[str, PromptTokenUsage]:
         """Get a copy of current token usage by prompt type."""
@@ -190,7 +132,6 @@ class TokenUsageTracker:
                     total_output_tokens=v.total_output_tokens,
                     total_cache_creation_tokens=v.total_cache_creation_tokens,
                     total_cache_read_tokens=v.total_cache_read_tokens,
-                    total_estimated_cost=v.total_estimated_cost,
                     models_used=dict(v.models_used),
                 )
                 for k, v in self._usage.items()
@@ -210,11 +151,6 @@ class TokenUsageTracker:
                 cache_read_input_tokens=total_cache_read,
             )
 
-    def get_total_estimated_cost(self) -> float:
-        """Get total estimated cost across all prompts."""
-        with self._lock:
-            return sum(u.total_estimated_cost for u in self._usage.values())
-
     def reset(self) -> None:
         """Reset all tracked usage."""
         with self._lock:
@@ -225,7 +161,7 @@ class TokenUsageTracker:
 
         Args:
             sort_by: Sort key - 'total_tokens', 'input_tokens', 'output_tokens',
-                     'call_count', 'prompt_name', or 'cost'
+                     'call_count', or 'prompt_name'
         """
         usage = self.get_usage()
         if not usage:
@@ -239,7 +175,6 @@ class TokenUsageTracker:
             'output_tokens': lambda x: x[1].total_output_tokens,
             'call_count': lambda x: x[1].call_count,
             'prompt_name': lambda x: x[0],
-            'cost': lambda x: x[1].total_estimated_cost,
         }
         sort_fn = sort_keys.get(sort_by, sort_keys['total_tokens'])
         sorted_usage = sorted(usage.items(), key=sort_fn, reverse=(sort_by != 'prompt_name'))
@@ -250,20 +185,20 @@ class TokenUsageTracker:
         )
 
         # Print header
-        print('\n' + '=' * 120)
+        print('\n' + '=' * 110)
         print('TOKEN USAGE SUMMARY')
-        print('=' * 120)
+        print('=' * 110)
         if has_cache:
             print(
                 f'{"Prompt Type":<40} {"Calls":>6} {"Input":>10} {"Output":>10} '
-                f'{"CacheW":>10} {"CacheR":>10} {"Hit%":>6} {"Cost($)":>10}'
+                f'{"CacheW":>10} {"CacheR":>10} {"Hit%":>6}'
             )
         else:
             print(
                 f'{"Prompt Type":<40} {"Calls":>6} {"Input":>10} {"Output":>10} '
-                f'{"Total":>10} {"Avg In":>8} {"Avg Out":>8} {"Cost($)":>10}'
+                f'{"Total":>10} {"Avg In":>8} {"Avg Out":>8}'
             )
-        print('-' * 120)
+        print('-' * 110)
 
         # Print each prompt's usage
         for _prompt_name, prompt_usage in sorted_usage:
@@ -274,8 +209,7 @@ class TokenUsageTracker:
                     f'{prompt_usage.total_output_tokens:>10,} '
                     f'{prompt_usage.total_cache_creation_tokens:>10,} '
                     f'{prompt_usage.total_cache_read_tokens:>10,} '
-                    f'{prompt_usage.cache_hit_rate:>5.0%} '
-                    f'{prompt_usage.total_estimated_cost:>10.6f}'
+                    f'{prompt_usage.cache_hit_rate:>5.0%}'
                 )
             else:
                 print(
@@ -284,15 +218,13 @@ class TokenUsageTracker:
                     f'{prompt_usage.total_output_tokens:>10,} '
                     f'{prompt_usage.total_tokens:>10,} '
                     f'{prompt_usage.avg_input_tokens:>8,.1f} '
-                    f'{prompt_usage.avg_output_tokens:>8,.1f} '
-                    f'{prompt_usage.total_estimated_cost:>10.6f}'
+                    f'{prompt_usage.avg_output_tokens:>8,.1f}'
                 )
 
         # Print totals
         total = self.get_total_usage()
         total_calls = sum(u.call_count for u in usage.values())
-        total_cost = sum(u.total_estimated_cost for u in usage.values())
-        print('-' * 120)
+        print('-' * 110)
         if has_cache:
             total_all_input = (
                 total.input_tokens
@@ -308,8 +240,7 @@ class TokenUsageTracker:
                 f'{total.output_tokens:>10,} '
                 f'{total.cache_creation_input_tokens:>10,} '
                 f'{total.cache_read_input_tokens:>10,} '
-                f'{overall_hit_rate:>5.0%} '
-                f'{total_cost:>10.6f}'
+                f'{overall_hit_rate:>5.0%}'
             )
         else:
             print(
@@ -317,7 +248,6 @@ class TokenUsageTracker:
                 f'{total.input_tokens:>10,} '
                 f'{total.output_tokens:>10,} '
                 f'{total.total_tokens:>10,} '
-                f'{"":>8} {"":>8} '
-                f'{total_cost:>10.6f}'
+                f'{"":>8} {"":>8}'
             )
-        print('=' * 120 + '\n')
+        print('=' * 110 + '\n')

--- a/graphiti_core/utils/maintenance/edge_operations.py
+++ b/graphiti_core/utils/maintenance/edge_operations.py
@@ -492,9 +492,7 @@ async def resolve_extracted_edge(
     """
     if len(related_edges) == 0 and len(existing_edges) == 0:
         # Still extract custom attributes even when no dedup/invalidation is needed
-        edge_model = (
-            edge_type_candidates.get(extracted_edge.name) if edge_type_candidates else None
-        )
+        edge_model = edge_type_candidates.get(extracted_edge.name) if edge_type_candidates else None
         if edge_model is not None and len(edge_model.model_fields) != 0:
             edge_attributes_context = {
                 'fact': extracted_edge.fact,

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -324,6 +324,7 @@ async def _resolve_with_llm(
     llm_response = await llm_client.generate_response(
         prompt_library.dedupe_nodes.nodes(context),
         response_model=NodeResolutions,
+        model_size=ModelSize.small,
         prompt_name='dedupe_nodes.nodes',
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ Homepage = "https://help.getzep.com/graphiti/graphiti/overview"
 Repository = "https://github.com/getzep/graphiti"
 
 [project.optional-dependencies]
-anthropic = ["anthropic>=0.49.0"]
+anthropic = ["anthropic>=0.83.0"]
 groq = ["groq>=0.2.0"]
 google-genai = ["google-genai>=1.62.0"]
 kuzu = ["kuzu>=0.11.3"]
@@ -38,7 +38,7 @@ tracing = ["opentelemetry-api>=1.20.0", "opentelemetry-sdk>=1.20.0"]
 dev = [
     "pyright>=1.1.404",
     "groq>=0.2.0",
-    "anthropic>=0.49.0",
+    "anthropic>=0.83.0",
     "google-genai>=1.8.0",
     "falkordb>=1.1.2,<2.0.0",
     "kuzu>=0.11.3",

--- a/tests/llm_client/test_anthropic_client.py
+++ b/tests/llm_client/test_anthropic_client.py
@@ -36,6 +36,29 @@ class ResponseModel(BaseModel):
     optional_field: int = 0
 
 
+def _make_usage(
+    input_tokens=100,
+    output_tokens=50,
+    cache_creation_input_tokens=0,
+    cache_read_input_tokens=0,
+):
+    """Create a mock usage object with the expected Anthropic response fields."""
+    usage = MagicMock()
+    usage.input_tokens = input_tokens
+    usage.output_tokens = output_tokens
+    usage.cache_creation_input_tokens = cache_creation_input_tokens
+    usage.cache_read_input_tokens = cache_read_input_tokens
+    return usage
+
+
+def _make_response(content_items, usage=None):
+    """Create a mock Anthropic API response."""
+    resp = MagicMock()
+    resp.content = content_items
+    resp.usage = usage or _make_usage()
+    return resp
+
+
 @pytest.fixture
 def mock_async_anthropic():
     """Fixture to mock the AsyncAnthropic client."""
@@ -105,16 +128,12 @@ class TestAnthropicClientGenerateResponse:
     @pytest.mark.asyncio
     async def test_generate_response_with_tool_use(self, anthropic_client, mock_async_anthropic):
         """Test successful response generation with tool use."""
-        # Setup mock response
         content_item = MagicMock()
         content_item.type = 'tool_use'
         content_item.input = {'test_field': 'test_value'}
 
-        mock_response = MagicMock()
-        mock_response.content = [content_item]
-        mock_async_anthropic.messages.create.return_value = mock_response
+        mock_async_anthropic.messages.create.return_value = _make_response([content_item])
 
-        # Call method
         messages = [
             Message(role='system', content='System message'),
             Message(role='user', content='User message'),
@@ -123,7 +142,6 @@ class TestAnthropicClientGenerateResponse:
             messages=messages, response_model=ResponseModel
         )
 
-        # Assertions
         assert isinstance(result, dict)
         assert result['test_field'] == 'test_value'
         mock_async_anthropic.messages.create.assert_called_once()
@@ -133,16 +151,12 @@ class TestAnthropicClientGenerateResponse:
         self, anthropic_client, mock_async_anthropic
     ):
         """Test response generation when getting text response instead of tool use."""
-        # Setup mock response with text content
         content_item = MagicMock()
         content_item.type = 'text'
         content_item.text = '{"test_field": "extracted_value"}'
 
-        mock_response = MagicMock()
-        mock_response.content = [content_item]
-        mock_async_anthropic.messages.create.return_value = mock_response
+        mock_async_anthropic.messages.create.return_value = _make_response([content_item])
 
-        # Call method
         messages = [
             Message(role='system', content='System message'),
             Message(role='user', content='User message'),
@@ -151,9 +165,82 @@ class TestAnthropicClientGenerateResponse:
             messages=messages, response_model=ResponseModel
         )
 
-        # Assertions
         assert isinstance(result, dict)
         assert result['test_field'] == 'extracted_value'
+
+    @pytest.mark.asyncio
+    async def test_system_message_uses_cache_control(self, anthropic_client, mock_async_anthropic):
+        """Test that the system message is sent as a content block with cache_control."""
+        content_item = MagicMock()
+        content_item.type = 'tool_use'
+        content_item.input = {'test_field': 'value'}
+
+        mock_async_anthropic.messages.create.return_value = _make_response([content_item])
+
+        messages = [
+            Message(role='system', content='System message'),
+            Message(role='user', content='User message'),
+        ]
+        await anthropic_client.generate_response(messages=messages, response_model=ResponseModel)
+
+        call_kwargs = mock_async_anthropic.messages.create.call_args
+        # System should be a list of content blocks, not a plain string
+        system_arg = call_kwargs.kwargs.get('system') or call_kwargs[1].get('system')
+        assert isinstance(system_arg, list)
+        assert len(system_arg) == 1
+        assert system_arg[0]['type'] == 'text'
+        assert system_arg[0]['cache_control'] == {'type': 'ephemeral'}
+
+    @pytest.mark.asyncio
+    async def test_tool_has_cache_control(self, anthropic_client, mock_async_anthropic):
+        """Test that the last tool definition includes cache_control."""
+        content_item = MagicMock()
+        content_item.type = 'tool_use'
+        content_item.input = {'test_field': 'value'}
+
+        mock_async_anthropic.messages.create.return_value = _make_response([content_item])
+
+        messages = [
+            Message(role='system', content='System message'),
+            Message(role='user', content='User message'),
+        ]
+        await anthropic_client.generate_response(messages=messages, response_model=ResponseModel)
+
+        call_kwargs = mock_async_anthropic.messages.create.call_args
+        tools_arg = call_kwargs.kwargs.get('tools') or call_kwargs[1].get('tools')
+        assert tools_arg[-1]['cache_control'] == {'type': 'ephemeral'}
+
+    @pytest.mark.asyncio
+    async def test_cache_tokens_tracked(self, anthropic_client, mock_async_anthropic):
+        """Test that cache creation and read tokens are tracked."""
+        content_item = MagicMock()
+        content_item.type = 'tool_use'
+        content_item.input = {'test_field': 'value'}
+
+        usage = _make_usage(
+            input_tokens=50,
+            output_tokens=30,
+            cache_creation_input_tokens=500,
+            cache_read_input_tokens=0,
+        )
+        mock_async_anthropic.messages.create.return_value = _make_response(
+            [content_item], usage=usage
+        )
+
+        messages = [
+            Message(role='system', content='System message'),
+            Message(role='user', content='User message'),
+        ]
+        await anthropic_client.generate_response(
+            messages=messages,
+            response_model=ResponseModel,
+            prompt_name='test_prompt',
+        )
+
+        tracker_usage = anthropic_client.token_tracker.get_usage()
+        assert 'test_prompt' in tracker_usage
+        assert tracker_usage['test_prompt'].total_cache_creation_tokens == 500
+        assert tracker_usage['test_prompt'].total_cache_read_tokens == 0
 
     @pytest.mark.asyncio
     async def test_rate_limit_error(self, anthropic_client, mock_async_anthropic):
@@ -224,7 +311,6 @@ class TestAnthropicClientGenerateResponse:
     @pytest.mark.asyncio
     async def test_validation_error_retry(self, anthropic_client, mock_async_anthropic):
         """Test retry behavior on validation error."""
-        # First call returns invalid data, second call returns valid data
         content_item1 = MagicMock()
         content_item1.type = 'tool_use'
         content_item1.input = {'wrong_field': 'wrong_value'}
@@ -233,16 +319,11 @@ class TestAnthropicClientGenerateResponse:
         content_item2.type = 'tool_use'
         content_item2.input = {'test_field': 'correct_value'}
 
-        # Setup mock to return different responses on consecutive calls
-        mock_response1 = MagicMock()
-        mock_response1.content = [content_item1]
+        mock_async_anthropic.messages.create.side_effect = [
+            _make_response([content_item1]),
+            _make_response([content_item2]),
+        ]
 
-        mock_response2 = MagicMock()
-        mock_response2.content = [content_item2]
-
-        mock_async_anthropic.messages.create.side_effect = [mock_response1, mock_response2]
-
-        # Call method
         messages = [Message(role='user', content='Test message')]
         result = await anthropic_client.generate_response(messages, response_model=ResponseModel)
 

--- a/tests/llm_client/test_anthropic_client.py
+++ b/tests/llm_client/test_anthropic_client.py
@@ -169,8 +169,8 @@ class TestAnthropicClientGenerateResponse:
         assert result['test_field'] == 'extracted_value'
 
     @pytest.mark.asyncio
-    async def test_system_message_uses_cache_control(self, anthropic_client, mock_async_anthropic):
-        """Test that the system message is sent as a content block with cache_control."""
+    async def test_auto_caching_enabled(self, anthropic_client, mock_async_anthropic):
+        """Test that top-level cache_control is passed for auto caching."""
         content_item = MagicMock()
         content_item.type = 'tool_use'
         content_item.input = {'test_field': 'value'}
@@ -184,31 +184,18 @@ class TestAnthropicClientGenerateResponse:
         await anthropic_client.generate_response(messages=messages, response_model=ResponseModel)
 
         call_kwargs = mock_async_anthropic.messages.create.call_args
-        # System should be a list of content blocks, not a plain string
-        system_arg = call_kwargs.kwargs.get('system') or call_kwargs[1].get('system')
-        assert isinstance(system_arg, list)
-        assert len(system_arg) == 1
-        assert system_arg[0]['type'] == 'text'
-        assert system_arg[0]['cache_control'] == {'type': 'ephemeral'}
+        # Top-level cache_control should be passed for auto caching
+        cache_control_arg = call_kwargs.kwargs.get('cache_control')
+        assert cache_control_arg == {'type': 'ephemeral'}
 
-    @pytest.mark.asyncio
-    async def test_tool_has_cache_control(self, anthropic_client, mock_async_anthropic):
-        """Test that the last tool definition includes cache_control."""
-        content_item = MagicMock()
-        content_item.type = 'tool_use'
-        content_item.input = {'test_field': 'value'}
+        # System message should be a plain string (not structured content blocks)
+        system_arg = call_kwargs.kwargs.get('system')
+        assert isinstance(system_arg, str)
+        assert system_arg == 'System message'
 
-        mock_async_anthropic.messages.create.return_value = _make_response([content_item])
-
-        messages = [
-            Message(role='system', content='System message'),
-            Message(role='user', content='User message'),
-        ]
-        await anthropic_client.generate_response(messages=messages, response_model=ResponseModel)
-
-        call_kwargs = mock_async_anthropic.messages.create.call_args
-        tools_arg = call_kwargs.kwargs.get('tools') or call_kwargs[1].get('tools')
-        assert tools_arg[-1]['cache_control'] == {'type': 'ephemeral'}
+        # Tools should NOT have block-level cache_control
+        tools_arg = call_kwargs.kwargs.get('tools')
+        assert 'cache_control' not in tools_arg[-1]
 
     @pytest.mark.asyncio
     async def test_cache_tokens_tracked(self, anthropic_client, mock_async_anthropic):

--- a/tests/llm_client/test_anthropic_client.py
+++ b/tests/llm_client/test_anthropic_client.py
@@ -23,7 +23,7 @@ import pytest
 from pydantic import BaseModel
 
 from graphiti_core.llm_client.anthropic_client import AnthropicClient
-from graphiti_core.llm_client.config import LLMConfig
+from graphiti_core.llm_client.config import LLMConfig, ModelSize
 from graphiti_core.llm_client.errors import RateLimitError, RefusalError
 from graphiti_core.prompts.models import Message
 
@@ -104,7 +104,7 @@ class TestAnthropicClientInitialization:
         config = LLMConfig(api_key='test_api_key')
         client = AnthropicClient(config=config, cache=False)
 
-        assert client.model == 'claude-haiku-4-5-latest'
+        assert client.model == 'claude-sonnet-4-5-latest'
 
     @patch.dict(os.environ, {'ANTHROPIC_API_KEY': 'env_api_key'})
     def test_init_without_config(self):
@@ -112,7 +112,7 @@ class TestAnthropicClientInitialization:
         client = AnthropicClient(cache=False)
 
         assert client.config.api_key == 'env_api_key'
-        assert client.model == 'claude-haiku-4-5-latest'
+        assert client.model == 'claude-sonnet-4-5-latest'
 
     def test_init_with_custom_client(self):
         """Test initialization with a custom AsyncAnthropic client."""
@@ -120,6 +120,49 @@ class TestAnthropicClientInitialization:
         client = AnthropicClient(client=mock_client)
 
         assert client.client == mock_client
+
+
+class TestAnthropicClientModelSizeRouting:
+    """Tests for model size routing."""
+
+    def test_get_model_for_size_small(self):
+        """Test that small size returns the small model."""
+        config = LLMConfig(api_key='test_api_key')
+        client = AnthropicClient(config=config, cache=False)
+
+        result = client._get_model_for_size(ModelSize.small)
+        assert result == 'claude-haiku-4-5-latest'
+
+    def test_get_model_for_size_medium(self):
+        """Test that medium size returns the default (larger) model."""
+        config = LLMConfig(api_key='test_api_key')
+        client = AnthropicClient(config=config, cache=False)
+
+        result = client._get_model_for_size(ModelSize.medium)
+        assert result == 'claude-sonnet-4-5-latest'
+
+    def test_small_model_default_on_init(self):
+        """Test that small_model is correctly defaulted during initialization."""
+        config = LLMConfig(api_key='test_api_key')
+        client = AnthropicClient(config=config, cache=False)
+
+        assert client.small_model == 'claude-haiku-4-5-latest'
+
+    def test_custom_small_model(self):
+        """Test that a custom small_model is respected."""
+        config = LLMConfig(api_key='test_api_key', small_model='claude-3-haiku-20240307')
+        client = AnthropicClient(config=config, cache=False)
+
+        result = client._get_model_for_size(ModelSize.small)
+        assert result == 'claude-3-haiku-20240307'
+
+    def test_custom_model_for_medium(self):
+        """Test that a custom model is used for medium size."""
+        config = LLMConfig(api_key='test_api_key', model='claude-3-5-sonnet-latest')
+        client = AnthropicClient(config=config, cache=False)
+
+        result = client._get_model_for_size(ModelSize.medium)
+        assert result == 'claude-3-5-sonnet-latest'
 
 
 class TestAnthropicClientGenerateResponse:

--- a/tests/llm_client/test_token_tracker.py
+++ b/tests/llm_client/test_token_tracker.py
@@ -22,7 +22,6 @@ from graphiti_core.llm_client.token_tracker import (
     PromptTokenUsage,
     TokenUsage,
     TokenUsageTracker,
-    get_anthropic_pricing,
 )
 
 
@@ -48,53 +47,6 @@ class TestTokenUsage:
             cache_read_input_tokens=300,
         )
         assert usage.total_tokens == 650
-
-    def test_estimate_cost_haiku(self):
-        """Test cost estimation for Haiku 4.5."""
-        usage = TokenUsage(
-            input_tokens=1_000_000,
-            output_tokens=1_000_000,
-        )
-        # Haiku 4.5: $1/M input, $5/M output
-        cost = usage.estimate_cost('claude-haiku-4-5-latest')
-        assert cost == pytest.approx(6.0)
-
-    def test_estimate_cost_with_cache(self):
-        """Test cost estimation with cache tokens for Haiku 4.5."""
-        usage = TokenUsage(
-            input_tokens=0,
-            output_tokens=100_000,
-            cache_creation_input_tokens=500_000,
-            cache_read_input_tokens=500_000,
-        )
-        # Haiku 4.5: cache_write=$1.25/M, cache_read=$0.10/M, output=$5/M
-        expected = (500_000 * 1.25 + 500_000 * 0.10 + 100_000 * 5.0) / 1_000_000
-        cost = usage.estimate_cost('claude-haiku-4-5-latest')
-        assert cost == pytest.approx(expected)
-
-    def test_estimate_cost_sonnet(self):
-        """Test cost estimation for Sonnet 4.5."""
-        usage = TokenUsage(input_tokens=1_000_000, output_tokens=1_000_000)
-        # Sonnet 4.5: $3/M input, $15/M output
-        cost = usage.estimate_cost('claude-sonnet-4-5-latest')
-        assert cost == pytest.approx(18.0)
-
-
-class TestGetAnthropicPricing:
-    def test_known_model(self):
-        """Test pricing lookup for known models."""
-        pricing = get_anthropic_pricing('claude-haiku-4-5-latest')
-        assert pricing == (1.00, 5.00, 1.25, 0.10)
-
-    def test_pinned_model_version(self):
-        """Test pricing lookup for pinned model versions."""
-        pricing = get_anthropic_pricing('claude-sonnet-4-5-20250929')
-        assert pricing == (3.00, 15.00, 3.75, 0.30)
-
-    def test_unknown_model_returns_default(self):
-        """Test that unknown models get default pricing."""
-        pricing = get_anthropic_pricing('some-unknown-model')
-        assert pricing == (1.00, 5.00, 1.25, 0.10)
 
 
 class TestPromptTokenUsage:
@@ -225,20 +177,6 @@ class TestTokenUsageTracker:
         assert usage['extract_nodes'].total_cache_creation_tokens == 500
         assert usage['extract_nodes'].total_cache_read_tokens == 500
 
-    def test_record_with_model_tracks_cost(self):
-        """Test that recording with a model computes estimated cost."""
-        tracker = TokenUsageTracker()
-        tracker.record(
-            'extract_nodes',
-            1_000_000,
-            500_000,
-            model='claude-haiku-4-5-latest',
-        )
-
-        usage = tracker.get_usage()
-        # Haiku 4.5: $1/M input + $5/M output = $1 + $2.50 = $3.50
-        assert usage['extract_nodes'].total_estimated_cost == pytest.approx(3.50)
-
     def test_record_with_model_tracks_models_used(self):
         """Test that models_used is populated."""
         tracker = TokenUsageTracker()
@@ -251,14 +189,6 @@ class TestTokenUsageTracker:
             'claude-haiku-4-5-latest': 2,
             'claude-sonnet-4-5-latest': 1,
         }
-
-    def test_get_total_estimated_cost(self):
-        """Test cumulative cost across prompts."""
-        tracker = TokenUsageTracker()
-        tracker.record('a', 1_000_000, 0, model='claude-haiku-4-5-latest')  # $1
-        tracker.record('b', 1_000_000, 0, model='claude-haiku-4-5-latest')  # $1
-
-        assert tracker.get_total_estimated_cost() == pytest.approx(2.0)
 
     def test_get_usage_returns_copy(self):
         """Test that get_usage returns a copy, not the internal dict."""

--- a/tests/llm_client/test_token_tracker.py
+++ b/tests/llm_client/test_token_tracker.py
@@ -16,10 +16,13 @@ limitations under the License.
 
 from concurrent.futures import ThreadPoolExecutor
 
+import pytest
+
 from graphiti_core.llm_client.token_tracker import (
     PromptTokenUsage,
     TokenUsage,
     TokenUsageTracker,
+    get_anthropic_pricing,
 )
 
 
@@ -36,17 +39,76 @@ class TestTokenUsage:
         assert usage.output_tokens == 0
         assert usage.total_tokens == 0
 
+    def test_total_tokens_with_cache(self):
+        """Test that total_tokens includes cache tokens."""
+        usage = TokenUsage(
+            input_tokens=100,
+            output_tokens=50,
+            cache_creation_input_tokens=200,
+            cache_read_input_tokens=300,
+        )
+        assert usage.total_tokens == 650
+
+    def test_estimate_cost_haiku(self):
+        """Test cost estimation for Haiku 4.5."""
+        usage = TokenUsage(
+            input_tokens=1_000_000,
+            output_tokens=1_000_000,
+        )
+        # Haiku 4.5: $1/M input, $5/M output
+        cost = usage.estimate_cost('claude-haiku-4-5-latest')
+        assert cost == pytest.approx(6.0)
+
+    def test_estimate_cost_with_cache(self):
+        """Test cost estimation with cache tokens for Haiku 4.5."""
+        usage = TokenUsage(
+            input_tokens=0,
+            output_tokens=100_000,
+            cache_creation_input_tokens=500_000,
+            cache_read_input_tokens=500_000,
+        )
+        # Haiku 4.5: cache_write=$1.25/M, cache_read=$0.10/M, output=$5/M
+        expected = (500_000 * 1.25 + 500_000 * 0.10 + 100_000 * 5.0) / 1_000_000
+        cost = usage.estimate_cost('claude-haiku-4-5-latest')
+        assert cost == pytest.approx(expected)
+
+    def test_estimate_cost_sonnet(self):
+        """Test cost estimation for Sonnet 4.5."""
+        usage = TokenUsage(input_tokens=1_000_000, output_tokens=1_000_000)
+        # Sonnet 4.5: $3/M input, $15/M output
+        cost = usage.estimate_cost('claude-sonnet-4-5-latest')
+        assert cost == pytest.approx(18.0)
+
+
+class TestGetAnthropicPricing:
+    def test_known_model(self):
+        """Test pricing lookup for known models."""
+        pricing = get_anthropic_pricing('claude-haiku-4-5-latest')
+        assert pricing == (1.00, 5.00, 1.25, 0.10)
+
+    def test_pinned_model_version(self):
+        """Test pricing lookup for pinned model versions."""
+        pricing = get_anthropic_pricing('claude-sonnet-4-5-20250929')
+        assert pricing == (3.00, 15.00, 3.75, 0.30)
+
+    def test_unknown_model_returns_default(self):
+        """Test that unknown models get default pricing."""
+        pricing = get_anthropic_pricing('some-unknown-model')
+        assert pricing == (1.00, 5.00, 1.25, 0.10)
+
 
 class TestPromptTokenUsage:
     def test_total_tokens(self):
-        """Test that total_tokens correctly sums input and output tokens."""
+        """Test that total_tokens correctly sums all token types."""
         usage = PromptTokenUsage(
             prompt_name='test',
             call_count=5,
             total_input_tokens=1000,
             total_output_tokens=500,
+            total_cache_creation_tokens=200,
+            total_cache_read_tokens=300,
         )
-        assert usage.total_tokens == 1500
+        assert usage.total_tokens == 2000
 
     def test_avg_input_tokens(self):
         """Test average input tokens calculation."""
@@ -78,6 +140,22 @@ class TestPromptTokenUsage:
         )
         assert usage.avg_input_tokens == 0
         assert usage.avg_output_tokens == 0
+
+    def test_cache_hit_rate(self):
+        """Test cache hit rate calculation."""
+        usage = PromptTokenUsage(
+            prompt_name='test',
+            call_count=2,
+            total_input_tokens=100,
+            total_cache_creation_tokens=0,
+            total_cache_read_tokens=900,
+        )
+        assert usage.cache_hit_rate == pytest.approx(0.9)
+
+    def test_cache_hit_rate_zero(self):
+        """Test cache hit rate when no tokens exist."""
+        usage = PromptTokenUsage(prompt_name='test', call_count=0)
+        assert usage.cache_hit_rate == 0.0
 
 
 class TestTokenUsageTracker:
@@ -125,6 +203,63 @@ class TestTokenUsageTracker:
         assert 'dedupe_nodes' in usage
         assert 'extract_edges' in usage
 
+    def test_record_with_cache_tokens(self):
+        """Test recording cache creation and read tokens."""
+        tracker = TokenUsageTracker()
+        tracker.record(
+            'extract_nodes',
+            100,
+            50,
+            cache_creation_input_tokens=500,
+            cache_read_input_tokens=0,
+        )
+        tracker.record(
+            'extract_nodes',
+            100,
+            50,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=500,
+        )
+
+        usage = tracker.get_usage()
+        assert usage['extract_nodes'].total_cache_creation_tokens == 500
+        assert usage['extract_nodes'].total_cache_read_tokens == 500
+
+    def test_record_with_model_tracks_cost(self):
+        """Test that recording with a model computes estimated cost."""
+        tracker = TokenUsageTracker()
+        tracker.record(
+            'extract_nodes',
+            1_000_000,
+            500_000,
+            model='claude-haiku-4-5-latest',
+        )
+
+        usage = tracker.get_usage()
+        # Haiku 4.5: $1/M input + $5/M output = $1 + $2.50 = $3.50
+        assert usage['extract_nodes'].total_estimated_cost == pytest.approx(3.50)
+
+    def test_record_with_model_tracks_models_used(self):
+        """Test that models_used is populated."""
+        tracker = TokenUsageTracker()
+        tracker.record('test', 100, 50, model='claude-haiku-4-5-latest')
+        tracker.record('test', 100, 50, model='claude-haiku-4-5-latest')
+        tracker.record('test', 100, 50, model='claude-sonnet-4-5-latest')
+
+        usage = tracker.get_usage()
+        assert usage['test'].models_used == {
+            'claude-haiku-4-5-latest': 2,
+            'claude-sonnet-4-5-latest': 1,
+        }
+
+    def test_get_total_estimated_cost(self):
+        """Test cumulative cost across prompts."""
+        tracker = TokenUsageTracker()
+        tracker.record('a', 1_000_000, 0, model='claude-haiku-4-5-latest')  # $1
+        tracker.record('b', 1_000_000, 0, model='claude-haiku-4-5-latest')  # $1
+
+        assert tracker.get_total_estimated_cost() == pytest.approx(2.0)
+
     def test_get_usage_returns_copy(self):
         """Test that get_usage returns a copy, not the internal dict."""
         tracker = TokenUsageTracker()
@@ -147,6 +282,16 @@ class TestTokenUsageTracker:
         assert total.input_tokens == 450
         assert total.output_tokens == 225
         assert total.total_tokens == 675
+
+    def test_get_total_usage_with_cache(self):
+        """Test total usage includes cache tokens."""
+        tracker = TokenUsageTracker()
+        tracker.record('a', 100, 50, cache_creation_input_tokens=200, cache_read_input_tokens=300)
+
+        total = tracker.get_total_usage()
+        assert total.cache_creation_input_tokens == 200
+        assert total.cache_read_input_tokens == 300
+        assert total.total_tokens == 650
 
     def test_get_total_usage_empty(self):
         """Test getting total usage when no records exist."""

--- a/uv.lock
+++ b/uv.lock
@@ -171,7 +171,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.75.0"
+version = "0.84.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -183,9 +183,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/1f/08e95f4b7e2d35205ae5dcbb4ae97e7d477fc521c275c02609e2931ece2d/anthropic-0.75.0.tar.gz", hash = "sha256:e8607422f4ab616db2ea5baacc215dd5f028da99ce2f022e33c7c535b29f3dfb", size = 439565, upload-time = "2025-11-24T20:41:45.28Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/ea/0869d6df9ef83dcf393aeefc12dd81677d091c6ffc86f783e51cf44062f2/anthropic-0.84.0.tar.gz", hash = "sha256:72f5f90e5aebe62dca316cb013629cfa24996b0f5a4593b8c3d712bc03c43c37", size = 539457, upload-time = "2026-02-25T05:22:38.54Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/1c/1cd02b7ae64302a6e06724bf80a96401d5313708651d277b1458504a1730/anthropic-0.75.0-py3-none-any.whl", hash = "sha256:ea8317271b6c15d80225a9f3c670152746e88805a7a61e14d4a374577164965b", size = 388164, upload-time = "2025-11-24T20:41:43.587Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ca/218fa25002a332c0aa149ba18ffc0543175998b1f65de63f6d106689a345/anthropic-0.84.0-py3-none-any.whl", hash = "sha256:861c4c50f91ca45f942e091d83b60530ad6d4f98733bfe648065364da05d29e7", size = 455156, upload-time = "2026-02-25T05:22:40.468Z" },
 ]
 
 [[package]]
@@ -1005,8 +1005,8 @@ voyageai = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.49.0" },
-    { name = "anthropic", marker = "extra == 'dev'", specifier = ">=0.49.0" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.83.0" },
+    { name = "anthropic", marker = "extra == 'dev'", specifier = ">=0.83.0" },
     { name = "boto3", marker = "extra == 'dev'", specifier = ">=1.39.16" },
     { name = "boto3", marker = "extra == 'neo4j-opensearch'", specifier = ">=1.39.16" },
     { name = "boto3", marker = "extra == 'neptune'", specifier = ">=1.39.16" },


### PR DESCRIPTION
## Summary
- Add model size routing to AnthropicClient (`small`/`medium` mapped to configurable models — small uses a cheaper model like Haiku, medium uses the default model)
- Add Anthropic prompt caching using top-level `cache_control` parameter (SDK >=0.83.0)
- Add per-call token usage logging (debug level) with cache metrics (cache_write, cache_read counts)
- Add `TokenUsageTracker` for accumulated usage tracking by prompt type

## Upstream
PR getzep/graphiti#1286

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (unit tests)
- [x] Token tracking tests with thread safety verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)