### PR TITLE
Add model size routing to AnthropicClient

### DIFF
--- a/graphiti_core/llm_client/anthropic_client.py
+++ b/graphiti_core/llm_client/anthropic_client.py
@@ -65,7 +65,7 @@ AnthropicModel = Literal[
     'claude-2.0',
 ]
 
-DEFAULT_MODEL: AnthropicModel = 'claude-haiku-4-5-latest'
+DEFAULT_MODEL: AnthropicModel = 'claude-sonnet-4-5-latest'
 DEFAULT_SMALL_MODEL: AnthropicModel = 'claude-haiku-4-5-latest'
 
 # Maximum output tokens for different Anthropic models
@@ -153,11 +153,14 @@ class AnthropicClient(LLMClient):
             self.client = client
 
     def _get_model_for_size(self, model_size: ModelSize) -> str:
-        """Get the appropriate model name based on the requested size."""
+        """Get the appropriate model name based on the requested size.
+
+        small -> self.small_model (default: Haiku)
+        medium -> self.model (default: Sonnet)
+        """
         if model_size == ModelSize.small:
             return self.small_model or DEFAULT_SMALL_MODEL
-        else:
-            return self.model or DEFAULT_MODEL
+        return self.model or DEFAULT_MODEL
 
     def _extract_json_from_text(self, text: str) -> dict[str, typing.Any]:
         """Extract JSON from text content.

--- a/graphiti_core/utils/maintenance/edge_operations.py
+++ b/graphiti_core/utils/maintenance/edge_operations.py
@@ -492,9 +492,7 @@ async def resolve_extracted_edge(
     """
     if len(related_edges) == 0 and len(existing_edges) == 0:
         # Still extract custom attributes even when no dedup/invalidation is needed
-        edge_model = (
-            edge_type_candidates.get(extracted_edge.name) if edge_type_candidates else None
-        )
+        edge_model = edge_type_candidates.get(extracted_edge.name) if edge_type_candidates else None
         if edge_model is not None and len(edge_model.model_fields) != 0:
             edge_attributes_context = {
                 'fact': extracted_edge.fact,

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -324,6 +324,7 @@ async def _resolve_with_llm(
     llm_response = await llm_client.generate_response(
         prompt_library.dedupe_nodes.nodes(context),
         response_model=NodeResolutions,
+        model_size=ModelSize.small,
         prompt_name='dedupe_nodes.nodes',
     )
 

--- a/tests/llm_client/test_anthropic_client.py
+++ b/tests/llm_client/test_anthropic_client.py
@@ -23,7 +23,7 @@ import pytest
 from pydantic import BaseModel
 
 from graphiti_core.llm_client.anthropic_client import AnthropicClient
-from graphiti_core.llm_client.config import LLMConfig
+from graphiti_core.llm_client.config import LLMConfig, ModelSize
 from graphiti_core.llm_client.errors import RateLimitError, RefusalError
 from graphiti_core.prompts.models import Message
 
@@ -81,7 +81,7 @@ class TestAnthropicClientInitialization:
         config = LLMConfig(api_key='test_api_key')
         client = AnthropicClient(config=config, cache=False)
 
-        assert client.model == 'claude-haiku-4-5-latest'
+        assert client.model == 'claude-sonnet-4-5-latest'
 
     @patch.dict(os.environ, {'ANTHROPIC_API_KEY': 'env_api_key'})
     def test_init_without_config(self):
@@ -89,7 +89,7 @@ class TestAnthropicClientInitialization:
         client = AnthropicClient(cache=False)
 
         assert client.config.api_key == 'env_api_key'
-        assert client.model == 'claude-haiku-4-5-latest'
+        assert client.model == 'claude-sonnet-4-5-latest'
 
     def test_init_with_custom_client(self):
         """Test initialization with a custom AsyncAnthropic client."""
@@ -97,6 +97,49 @@ class TestAnthropicClientInitialization:
         client = AnthropicClient(client=mock_client)
 
         assert client.client == mock_client
+
+
+class TestAnthropicClientModelSizeRouting:
+    """Tests for model size routing."""
+
+    def test_get_model_for_size_small(self):
+        """Test that small size returns the small model."""
+        config = LLMConfig(api_key='test_api_key')
+        client = AnthropicClient(config=config, cache=False)
+
+        result = client._get_model_for_size(ModelSize.small)
+        assert result == 'claude-haiku-4-5-latest'
+
+    def test_get_model_for_size_medium(self):
+        """Test that medium size returns the default (larger) model."""
+        config = LLMConfig(api_key='test_api_key')
+        client = AnthropicClient(config=config, cache=False)
+
+        result = client._get_model_for_size(ModelSize.medium)
+        assert result == 'claude-sonnet-4-5-latest'
+
+    def test_small_model_default_on_init(self):
+        """Test that small_model is correctly defaulted during initialization."""
+        config = LLMConfig(api_key='test_api_key')
+        client = AnthropicClient(config=config, cache=False)
+
+        assert client.small_model == 'claude-haiku-4-5-latest'
+
+    def test_custom_small_model(self):
+        """Test that a custom small_model is respected."""
+        config = LLMConfig(api_key='test_api_key', small_model='claude-3-haiku-20240307')
+        client = AnthropicClient(config=config, cache=False)
+
+        result = client._get_model_for_size(ModelSize.small)
+        assert result == 'claude-3-haiku-20240307'
+
+    def test_custom_model_for_medium(self):
+        """Test that a custom model is used for medium size."""
+        config = LLMConfig(api_key='test_api_key', model='claude-3-5-sonnet-latest')
+        client = AnthropicClient(config=config, cache=False)
+
+        result = client._get_model_for_size(ModelSize.medium)
+        assert result == 'claude-3-5-sonnet-latest'
 
 
 class TestAnthropicClientGenerateResponse:


### PR DESCRIPTION
## Summary
- Add model size routing (`small`/`medium`) to AnthropicClient, allowing callers to request a model capability tier rather than a specific model name
- Maps size tiers to configurable models (default: Haiku for small, Sonnet for medium)
- Enables cost optimization by routing simpler prompts to smaller models

## Upstream
PR getzep/graphiti#1248

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (unit tests)
- [x] Model size routing tests for default and custom configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)