### PR TITLE
feat: freeform entity type classification when no entity_types provided

### DIFF
--- a/graphiti_core/prompts/extract_nodes.py
+++ b/graphiti_core/prompts/extract_nodes.py
@@ -99,6 +99,19 @@ def _entity_type_classification_instructions(context: dict[str, Any]) -> str:
    - Assign the appropriate `entity_type_id` for each one."""
 
 
+def _classification_instruction_inline(context: dict[str, Any]) -> str:
+    """Generate inline classification instruction for extract_json and extract_text prompts."""
+    if context.get('freeform_entity_types'):
+        return (
+            'For each entity extracted, assign a semantic `entity_type` label that best describes it '
+            '(e.g., Person, Organization, Software, Concept, Location, Event, Document).'
+        )
+    return (
+        'For each entity extracted, also determine its entity type based on the provided ENTITY TYPES '
+        'and their descriptions.\nIndicate the classified entity type by providing its entity_type_id.'
+    )
+
+
 def _entity_types_section(context: dict[str, Any]) -> str:
     """Generate the ENTITY TYPES section, omitting it entirely for freeform mode."""
     if context.get('freeform_entity_types'):
@@ -157,16 +170,7 @@ def extract_json(context: dict[str, Any]) -> list[Message]:
     sys_prompt = """You are an AI assistant that extracts entity nodes from JSON.
     Your primary task is to extract and classify relevant entities from JSON files"""
 
-    if context.get('freeform_entity_types'):
-        classification_instruction = (
-            'For each entity extracted, assign a semantic `entity_type` label that best describes it '
-            '(e.g., Person, Organization, Software, Concept, Location, Event, Document).'
-        )
-    else:
-        classification_instruction = (
-            'For each entity extracted, also determine its entity type based on the provided ENTITY TYPES '
-            'and their descriptions.\nIndicate the classified entity type by providing its entity_type_id.'
-        )
+    classification_instruction = _classification_instruction_inline(context)
 
     user_prompt = f"""
 {_entity_types_section(context)}
@@ -197,16 +201,7 @@ def extract_text(context: dict[str, Any]) -> list[Message]:
     sys_prompt = """You are an AI assistant that extracts entity nodes from text.
     Your primary task is to extract and classify the speaker and other significant entities mentioned in the provided text."""
 
-    if context.get('freeform_entity_types'):
-        classification_instruction = (
-            'For each entity extracted, assign a semantic `entity_type` label that best describes it '
-            '(e.g., Person, Organization, Software, Concept, Location, Event, Document).'
-        )
-    else:
-        classification_instruction = (
-            'For each entity extracted, also determine its entity type based on the provided ENTITY TYPES '
-            'and their descriptions.\nIndicate the classified entity type by providing its entity_type_id.'
-        )
+    classification_instruction = _classification_instruction_inline(context)
 
     user_prompt = f"""
 {_entity_types_section(context)}

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -17,7 +17,7 @@ limitations under the License.
 import logging
 from collections.abc import Awaitable, Callable
 from time import time
-from typing import Any
+from typing import Any, cast
 
 from pydantic import BaseModel
 
@@ -96,27 +96,34 @@ async def extract_nodes(
 
     # Extract entities
     if use_freeform:
-        extracted_entities_freeform = await _extract_nodes_single_freeform(
-            llm_client, episode, context
-        )
-        filtered_freeform = [e for e in extracted_entities_freeform if e.name.strip()]
-        end = time()
-        logger.debug(
-            f'Extracted {len(filtered_freeform)} entities (freeform) '
-            f'in {(end - start) * 1000:.0f} ms'
-        )
+        raw_entities = await _extract_nodes_single_freeform(llm_client, episode, context)
+        log_suffix = ' (freeform)'
+    else:
+        raw_entities = await _extract_nodes_single(llm_client, episode, context)
+        log_suffix = ''
+
+    # Filter empty names
+    filtered_entities = [e for e in raw_entities if e.name.strip()]
+
+    end = time()
+    logger.debug(
+        f'Extracted {len(filtered_entities)} entities{log_suffix} '
+        f'in {(end - start) * 1000:.0f} ms'
+    )
+
+    # Convert to EntityNode objects
+    if use_freeform:
         extracted_nodes = _create_entity_nodes_freeform(
-            filtered_freeform, excluded_entity_types, episode
+            cast(list[ExtractedEntityFreeform], filtered_entities),
+            excluded_entity_types,
+            episode,
         )
     else:
-        extracted_entities = await _extract_nodes_single(llm_client, episode, context)
-        filtered_entities = [e for e in extracted_entities if e.name.strip()]
-        end = time()
-        logger.debug(
-            f'Extracted {len(filtered_entities)} entities in {(end - start) * 1000:.0f} ms'
-        )
         extracted_nodes = _create_entity_nodes(
-            filtered_entities, entity_types_context, excluded_entity_types, episode
+            cast(list[ExtractedEntity], filtered_entities),
+            entity_types_context,
+            excluded_entity_types,
+            episode,
         )
 
     logger.debug(f'Extracted nodes: {[n.uuid for n in extracted_nodes]}')
@@ -240,6 +247,18 @@ def _create_entity_nodes(
     return extracted_nodes
 
 
+def _sanitize_label(label: str) -> str:
+    """Sanitize a freeform entity type label for safe use as a graph database label.
+
+    Replaces spaces with underscores and strips non-alphanumeric characters
+    to prevent Cypher injection and invalid label syntax.
+    """
+    # Replace spaces with underscores, then keep only alphanumeric + underscore
+    sanitized = label.replace(' ', '_')
+    sanitized = ''.join(c for c in sanitized if c.isalnum() or c == '_')
+    return sanitized.strip('_') or 'Entity'
+
+
 def _create_entity_nodes_freeform(
     extracted_entities: list[ExtractedEntityFreeform],
     excluded_entity_types: list[str] | None,
@@ -249,7 +268,7 @@ def _create_entity_nodes_freeform(
     extracted_nodes = []
 
     for extracted_entity in extracted_entities:
-        entity_type_name = extracted_entity.entity_type.strip() or 'Entity'
+        entity_type_name = _sanitize_label(extracted_entity.entity_type)
 
         # Check if this entity type should be excluded
         if excluded_entity_types and entity_type_name in excluded_entity_types:

--- a/tests/utils/maintenance/test_entity_extraction.py
+++ b/tests/utils/maintenance/test_entity_extraction.py
@@ -25,6 +25,7 @@ from graphiti_core.utils.datetime_utils import utc_now
 from graphiti_core.utils.maintenance.node_operations import (
     _build_entity_types_context,
     _extract_entity_summaries_batch,
+    _sanitize_label,
     extract_nodes,
 )
 
@@ -67,14 +68,18 @@ def _make_episode(
 class TestExtractNodesSmallInput:
     @pytest.mark.asyncio
     async def test_small_input_single_llm_call(self, monkeypatch):
-        """Small inputs should use a single LLM call without chunking."""
+        """Small inputs should use a single LLM call without chunking.
+
+        When no entity_types are provided, freeform mode is used,
+        so mock responses use entity_type (str) instead of entity_type_id (int).
+        """
         clients, llm_generate = _make_clients()
 
-        # Mock LLM response
+        # Mock LLM response (freeform mode — no entity_types provided)
         llm_generate.return_value = {
             'extracted_entities': [
-                {'name': 'Alice', 'entity_type_id': 0},
-                {'name': 'Bob', 'entity_type_id': 0},
+                {'name': 'Alice', 'entity_type': 'Person'},
+                {'name': 'Bob', 'entity_type': 'Person'},
             ]
         }
 
@@ -90,6 +95,10 @@ class TestExtractNodesSmallInput:
         # Verify results
         assert len(nodes) == 2
         assert {n.name for n in nodes} == {'Alice', 'Bob'}
+        # Both should have Person label from freeform classification
+        for node in nodes:
+            assert 'Person' in node.labels
+            assert 'Entity' in node.labels
 
         # LLM should be called exactly once
         llm_generate.assert_awaited_once()
@@ -168,11 +177,12 @@ class TestExtractNodesSmallInput:
         """Entities with empty names should be filtered out."""
         clients, llm_generate = _make_clients()
 
+        # Freeform mode (no entity_types provided)
         llm_generate.return_value = {
             'extracted_entities': [
-                {'name': 'Alice', 'entity_type_id': 0},
-                {'name': '', 'entity_type_id': 0},
-                {'name': '   ', 'entity_type_id': 0},
+                {'name': 'Alice', 'entity_type': 'Person'},
+                {'name': '', 'entity_type': 'Person'},
+                {'name': '   ', 'entity_type': 'Concept'},
             ]
         }
 
@@ -228,6 +238,46 @@ class TestExtractNodesPromptSelection:
 
         call_kwargs = llm_generate.call_args[1]
         assert call_kwargs.get('prompt_name') == 'extract_nodes.extract_message'
+
+    @pytest.mark.asyncio
+    async def test_freeform_uses_correct_response_model(self, monkeypatch):
+        """Freeform mode should use ExtractedEntitiesFreeform response model."""
+        from graphiti_core.prompts.extract_nodes import ExtractedEntitiesFreeform
+
+        clients, llm_generate = _make_clients()
+        llm_generate.return_value = {'extracted_entities': []}
+
+        episode = _make_episode(source=EpisodeType.text)
+
+        # No entity_types = freeform mode
+        await extract_nodes(clients, episode, previous_episodes=[])
+
+        call_kwargs = llm_generate.call_args[1]
+        assert call_kwargs.get('response_model') is ExtractedEntitiesFreeform
+
+    @pytest.mark.asyncio
+    async def test_constrained_uses_correct_response_model(self, monkeypatch):
+        """Constrained mode should use ExtractedEntities response model."""
+        from pydantic import BaseModel
+
+        from graphiti_core.prompts.extract_nodes import ExtractedEntities
+
+        class Person(BaseModel):
+            """A human person."""
+
+            pass
+
+        clients, llm_generate = _make_clients()
+        llm_generate.return_value = {'extracted_entities': []}
+
+        episode = _make_episode(source=EpisodeType.text)
+
+        await extract_nodes(
+            clients, episode, previous_episodes=[], entity_types={'Person': Person}
+        )
+
+        call_kwargs = llm_generate.call_args[1]
+        assert call_kwargs.get('response_model') is ExtractedEntities
 
 
 class TestBuildEntityTypesContext:
@@ -560,3 +610,100 @@ class TestExtractEntitySummariesBatch:
 
         # Should match despite case difference
         assert node.summary == 'Alice summary from LLM.'
+
+
+class TestFreeformEntityExtraction:
+    @pytest.mark.asyncio
+    async def test_freeform_assigns_semantic_labels(self):
+        """Freeform mode should assign LLM-provided type labels to entities."""
+        clients, llm_generate = _make_clients()
+
+        llm_generate.return_value = {
+            'extracted_entities': [
+                {'name': 'Alice', 'entity_type': 'Person'},
+                {'name': 'Acme Corp', 'entity_type': 'Organization'},
+                {'name': 'Python', 'entity_type': 'Software'},
+            ]
+        }
+
+        episode = _make_episode(content='Alice works at Acme Corp using Python.')
+
+        nodes = await extract_nodes(clients, episode, previous_episodes=[])
+
+        assert len(nodes) == 3
+        alice = next(n for n in nodes if n.name == 'Alice')
+        assert 'Person' in alice.labels
+        assert 'Entity' in alice.labels
+
+        acme = next(n for n in nodes if n.name == 'Acme Corp')
+        assert 'Organization' in acme.labels
+
+        python = next(n for n in nodes if n.name == 'Python')
+        assert 'Software' in python.labels
+
+    @pytest.mark.asyncio
+    async def test_freeform_excludes_entity_types(self):
+        """Freeform mode should support excluded_entity_types."""
+        clients, llm_generate = _make_clients()
+
+        llm_generate.return_value = {
+            'extracted_entities': [
+                {'name': 'Alice', 'entity_type': 'Person'},
+                {'name': 'Python', 'entity_type': 'Software'},
+            ]
+        }
+
+        episode = _make_episode(content='Alice uses Python.')
+
+        nodes = await extract_nodes(
+            clients,
+            episode,
+            previous_episodes=[],
+            excluded_entity_types=['Person'],
+        )
+
+        assert len(nodes) == 1
+        assert nodes[0].name == 'Python'
+
+    @pytest.mark.asyncio
+    async def test_freeform_empty_type_falls_back_to_entity(self):
+        """Empty or whitespace entity_type should fall back to 'Entity'."""
+        clients, llm_generate = _make_clients()
+
+        llm_generate.return_value = {
+            'extracted_entities': [
+                {'name': 'Alice', 'entity_type': ''},
+                {'name': 'Bob', 'entity_type': '   '},
+            ]
+        }
+
+        episode = _make_episode(content='Alice and Bob.')
+
+        nodes = await extract_nodes(clients, episode, previous_episodes=[])
+
+        assert len(nodes) == 2
+        for node in nodes:
+            assert node.labels == ['Entity']
+
+
+class TestSanitizeLabel:
+    def test_simple_label(self):
+        assert _sanitize_label('Person') == 'Person'
+
+    def test_spaces_replaced_with_underscores(self):
+        assert _sanitize_label('Machine Learning') == 'Machine_Learning'
+
+    def test_special_characters_removed(self):
+        assert _sanitize_label('Person:Malicious{uuid}') == 'PersonMaliciousuuid'
+
+    def test_cypher_injection_prevented(self):
+        assert _sanitize_label('Person}) DELETE n //') == 'Person_DELETE_n'
+
+    def test_empty_string_returns_entity(self):
+        assert _sanitize_label('') == 'Entity'
+
+    def test_only_special_chars_returns_entity(self):
+        assert _sanitize_label('!@#$%') == 'Entity'
+
+    def test_leading_trailing_underscores_stripped(self):
+        assert _sanitize_label(' _Person_ ') == 'Person'


### PR DESCRIPTION
## Summary

- When `entity_types` is not passed to `add_episode()`, entity extraction now uses freeform LLM classification (`entity_type: str`) instead of constraining all entities to the generic `Entity` label
- Mirrors how edge extraction already works — edges always get meaningful `relation_type` values via free-form LLM classification
- When `entity_types` IS provided, behavior is unchanged

## Problem

Without custom `entity_types`, the only type option was `{entity_type_id: 0, entity_type_name: 'Entity'}`. The LLM was told "Only use the provided ENTITY TYPES" so every entity got `labels: ['Entity']` — no semantic distinction between people, software, concepts, etc.

## Approach

- Added `ExtractedEntityFreeform` model with `entity_type: str` (free-form string, like edge's `relation_type`)
- Updated all three extraction prompts (message, text, JSON) to use freeform classification instructions when no custom types are provided
- Added `_create_entity_nodes_freeform()` that uses the LLM-assigned type name directly as a label
- `extract_nodes()` detects `entity_types is None` and switches to freeform mode automatically

## Test plan

- [x] `make lint` passes (ruff + pyright)
- [x] `make test` passes (128 unit tests, only pre-existing Neo4j connection error)
- [ ] Manual test: ingest text via `add_episode()` without `entity_types` and verify entities get semantic labels like `Person`, `Software`, `Concept`
- [ ] Verify existing behavior unchanged when `entity_types` dict is provided

## Refs

- Upstream issue: https://github.com/getzep/graphiti/issues/1308

🤖 Generated with [Claude Code](https://claude.com/claude-code)