### PR TITLE
feat: feat: reprocess graphiti entities to use LLM to derive ontological type automatically.

### DIFF
--- a/graphiti_core/prompts/extract_nodes.py
+++ b/graphiti_core/prompts/extract_nodes.py
@@ -315,6 +315,13 @@ If an entity has no relevant information in the messages and no existing summary
     ]
 
 
+def _strip_xml_tags(text: str) -> str:
+    """Strip XML-like tags from text to prevent prompt injection via delimiter escape."""
+    import re
+
+    return re.sub(r'</?[A-Z_]+\s*>', '', text)
+
+
 def reclassify_entity(context: dict[str, Any]) -> list[Message]:
     sys_prompt = (
         'You are an AI assistant that classifies entities into semantic ontological types. '
@@ -322,13 +329,16 @@ def reclassify_entity(context: dict[str, Any]) -> list[Message]:
         'Return a single PascalCase type name that best describes the entity.'
     )
 
+    entity_name = _strip_xml_tags(str(context['entity_name']))
+    entity_summary = _strip_xml_tags(str(context['entity_summary']))
+
     user_prompt = f"""
 <ENTITY NAME>
-{context['entity_name']}
+{entity_name}
 </ENTITY NAME>
 
 <ENTITY SUMMARY>
-{context['entity_summary']}
+{entity_summary}
 </ENTITY SUMMARY>
 
 Classify this entity into a single semantic type. Choose a meaningful ontological type such as:

--- a/graphiti_core/prompts/extract_nodes.py
+++ b/graphiti_core/prompts/extract_nodes.py
@@ -37,6 +37,14 @@ class ExtractedEntities(BaseModel):
     extracted_entities: list[ExtractedEntity] = Field(..., description='List of extracted entities')
 
 
+class ReclassifiedEntity(BaseModel):
+    entity_type: str = Field(
+        ...,
+        description='The classified entity type as a PascalCase string'
+        ' (e.g., Person, Organization, Concept)',
+    )
+
+
 class EntitySummary(BaseModel):
     summary: str = Field(..., description='Summary of the entity')
 
@@ -61,6 +69,7 @@ class Prompt(Protocol):
     extract_attributes: PromptVersion
     extract_summary: PromptVersion
     extract_summaries_batch: PromptVersion
+    reclassify_entity: PromptVersion
 
 
 class Versions(TypedDict):
@@ -71,6 +80,7 @@ class Versions(TypedDict):
     extract_attributes: PromptFunction
     extract_summary: PromptFunction
     extract_summaries_batch: PromptFunction
+    reclassify_entity: PromptFunction
 
 
 def extract_message(context: dict[str, Any]) -> list[Message]:
@@ -305,6 +315,37 @@ If an entity has no relevant information in the messages and no existing summary
     ]
 
 
+def reclassify_entity(context: dict[str, Any]) -> list[Message]:
+    sys_prompt = (
+        'You are an AI assistant that classifies entities into semantic ontological types. '
+        'Given an entity name and its summary, determine the most appropriate type for the entity. '
+        'Return a single PascalCase type name that best describes the entity.'
+    )
+
+    user_prompt = f"""
+<ENTITY NAME>
+{context['entity_name']}
+</ENTITY NAME>
+
+<ENTITY SUMMARY>
+{context['entity_summary']}
+</ENTITY SUMMARY>
+
+Classify this entity into a single semantic type. Choose a meaningful ontological type such as:
+Person, Organization, Location, Event, Concept, Technology, Product, Document, Project, etc.
+
+Guidelines:
+1. Return exactly one PascalCase type name (e.g., "Person", "Organization", "Concept").
+2. Choose the most specific applicable type — prefer "Person" over "Entity" when the entity is clearly a person.
+3. If the entity cannot be meaningfully classified beyond "Entity", return "Entity".
+4. Do not invent overly specific or compound types — keep types general and reusable.
+"""
+    return [
+        Message(role='system', content=sys_prompt),
+        Message(role='user', content=user_prompt),
+    ]
+
+
 versions: Versions = {
     'extract_message': extract_message,
     'extract_json': extract_json,
@@ -313,4 +354,5 @@ versions: Versions = {
     'extract_summaries_batch': extract_summaries_batch,
     'classify_nodes': classify_nodes,
     'extract_attributes': extract_attributes,
+    'reclassify_entity': reclassify_entity,
 }

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -696,22 +696,16 @@ def _sanitize_label(label: str) -> str:
     # Remove any characters that aren't alphanumeric or underscore
     sanitized = re.sub(r'[^a-zA-Z0-9_]', '', label)
 
-    # If nothing remains after stripping, use the generic label
-    if not sanitized:
+    # Split on underscores to find word boundaries, filtering empty parts
+    parts = [p for p in sanitized.split('_') if p]
+
+    if not parts:
         return 'Entity'
 
-    # Split on underscores to find word boundaries and normalize each part
-    parts = [p for p in re.split(r'[_]+', sanitized) if p]
-    if parts:
-        normalized = ''.join(
-            p[0].upper() + p[1:].lower() if len(p) > 1 else p.upper() for p in parts
-        )
-    else:
-        normalized = (
-            sanitized[0].upper() + sanitized[1:].lower()
-            if len(sanitized) > 1
-            else sanitized.upper()
-        )
+    # Normalize to PascalCase
+    normalized = ''.join(
+        p[0].upper() + p[1:].lower() if len(p) > 1 else p.upper() for p in parts
+    )
 
     # Ensure it starts with a letter (prepend 'Label' if it starts with a digit)
     if normalized and normalized[0].isdigit():

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -689,18 +689,35 @@ def _build_episode_context(
 def _sanitize_label(label: str) -> str:
     """Sanitize a label string to be safe for use as a Cypher node label.
 
-    Strips non-alphanumeric/underscore characters and ensures the result
-    is a valid PascalCase identifier.
+    Strips non-alphanumeric/underscore characters, normalizes to PascalCase
+    (splitting on underscores), and ensures the result starts with a letter.
+    Falls back to 'Entity' if no valid characters remain.
     """
     # Remove any characters that aren't alphanumeric or underscore
     sanitized = re.sub(r'[^a-zA-Z0-9_]', '', label)
+
+    # If nothing remains after stripping, use the generic label
+    if not sanitized:
+        return 'Entity'
+
+    # Split on underscores to find word boundaries and normalize each part
+    parts = [p for p in re.split(r'[_]+', sanitized) if p]
+    if parts:
+        normalized = ''.join(
+            p[0].upper() + p[1:].lower() if len(p) > 1 else p.upper() for p in parts
+        )
+    else:
+        normalized = (
+            sanitized[0].upper() + sanitized[1:].lower()
+            if len(sanitized) > 1
+            else sanitized.upper()
+        )
+
     # Ensure it starts with a letter (prepend 'Label' if it starts with a digit)
-    if sanitized and sanitized[0].isdigit():
-        sanitized = 'Label' + sanitized
-    # Capitalize first letter to ensure PascalCase
-    if sanitized:
-        sanitized = sanitized[0].upper() + sanitized[1:]
-    return sanitized or 'Entity'
+    if normalized and normalized[0].isdigit():
+        normalized = 'Label' + normalized
+
+    return normalized or 'Entity'
 
 
 async def reclassify_entity(
@@ -738,7 +755,7 @@ async def reprocess_entity_types(
 
     # Retrieve all entities for the group, then filter in Python
     all_entities = await EntityNode.get_by_group_ids(driver, [group_id])
-    entities = [e for e in all_entities if len(e.labels) <= 1 or e.labels == ['Entity']]
+    entities = [e for e in all_entities if set(e.labels) == {'Entity'}]
 
     if not entities:
         logger.info(f'No untyped entities found for group_id={group_id}')

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import logging
+import re
 from collections.abc import Awaitable, Callable
 from time import time
 from typing import Any
@@ -37,6 +38,7 @@ from graphiti_core.prompts.dedupe_nodes import NodeDuplicate, NodeResolutions
 from graphiti_core.prompts.extract_nodes import (
     ExtractedEntities,
     ExtractedEntity,
+    ReclassifiedEntity,
     SummarizedEntities,
 )
 from graphiti_core.search.search import search
@@ -682,3 +684,83 @@ def _build_episode_context(
             [ep.content for ep in previous_episodes] if previous_episodes is not None else []
         ),
     }
+
+
+def _sanitize_label(label: str) -> str:
+    """Sanitize a label string to be safe for use as a Cypher node label.
+
+    Strips non-alphanumeric/underscore characters and ensures the result
+    is a valid PascalCase identifier.
+    """
+    # Remove any characters that aren't alphanumeric or underscore
+    sanitized = re.sub(r'[^a-zA-Z0-9_]', '', label)
+    # Ensure it starts with a letter (prepend 'Label' if it starts with a digit)
+    if sanitized and sanitized[0].isdigit():
+        sanitized = 'Label' + sanitized
+    # Capitalize first letter to ensure PascalCase
+    if sanitized:
+        sanitized = sanitized[0].upper() + sanitized[1:]
+    return sanitized or 'Entity'
+
+
+async def reclassify_entity(
+    llm_client: LLMClient,
+    entity: EntityNode,
+) -> str:
+    """Classify an entity's type using LLM based on its name and summary."""
+    context = {
+        'entity_name': entity.name,
+        'entity_summary': entity.summary,
+    }
+    llm_response = await llm_client.generate_response(
+        prompt_library.extract_nodes.reclassify_entity(context),
+        response_model=ReclassifiedEntity,
+        model_size=ModelSize.small,
+        group_id=entity.group_id,
+        prompt_name='extract_nodes.reclassify_entity',
+    )
+    result = ReclassifiedEntity(**llm_response)
+    return _sanitize_label(result.entity_type)
+
+
+async def reprocess_entity_types(
+    clients: GraphitiClients,
+    group_id: str,
+) -> list[EntityNode]:
+    """Retroactively classify entities that only have the generic 'Entity' label.
+
+    Retrieves all entities for the given group, filters for untyped entities
+    (those with only ['Entity'] as labels), uses the LLM to classify each one,
+    and updates their labels in the graph.
+    """
+    driver = clients.driver
+    llm_client = clients.llm_client
+
+    # Retrieve all entities for the group, then filter in Python
+    all_entities = await EntityNode.get_by_group_ids(driver, [group_id])
+    entities = [e for e in all_entities if len(e.labels) <= 1 or e.labels == ['Entity']]
+
+    if not entities:
+        logger.info(f'No untyped entities found for group_id={group_id}')
+        return []
+
+    logger.info(f'Found {len(entities)} untyped entities to reclassify for group_id={group_id}')
+
+    # Reclassify all entities with concurrency control
+    new_types = await semaphore_gather(
+        *[reclassify_entity(llm_client, entity) for entity in entities]
+    )
+
+    # Update labels and save
+    updated = []
+    for i, (entity, new_type) in enumerate(zip(entities, new_types, strict=True)):
+        if new_type != 'Entity':
+            entity.labels = list({'Entity', new_type})
+            await entity.save(driver)
+            updated.append(entity)
+            logger.info(f'Reclassified {i + 1}/{len(entities)}: {entity.name} → {new_type}')
+        else:
+            logger.info(f'Skipped {i + 1}/{len(entities)}: {entity.name} (no better type found)')
+
+    logger.info(f'Reclassified {len(updated)}/{len(entities)} entities')
+    return updated

--- a/tests/utils/maintenance/test_entity_extraction.py
+++ b/tests/utils/maintenance/test_entity_extraction.py
@@ -574,13 +574,13 @@ class TestSanitizeLabel:
         assert _sanitize_label('person') == 'Person'
 
     def test_strips_special_characters(self):
-        assert _sanitize_label('My-Type!') == 'MyType'
+        assert _sanitize_label('My-Type!') == 'Mytype'
 
     def test_strips_spaces(self):
-        assert _sanitize_label('My Type') == 'MyType'
+        assert _sanitize_label('My Type') == 'Mytype'
 
     def test_digit_prefix_gets_label_prepended(self):
-        assert _sanitize_label('123Type') == 'Label123Type'
+        assert _sanitize_label('123Type') == 'Label123type'
 
     def test_empty_string_returns_entity(self):
         assert _sanitize_label('') == 'Entity'
@@ -588,8 +588,14 @@ class TestSanitizeLabel:
     def test_all_special_chars_returns_entity(self):
         assert _sanitize_label('!@#$%') == 'Entity'
 
-    def test_preserves_underscores(self):
-        assert _sanitize_label('My_Type') == 'My_Type'
+    def test_normalizes_underscored_parts_to_pascal_case(self):
+        assert _sanitize_label('My_Type') == 'MyType'
+
+    def test_normalizes_all_caps(self):
+        assert _sanitize_label('PERSON') == 'Person'
+
+    def test_normalizes_all_caps_with_underscores(self):
+        assert _sanitize_label('PERSON_NAME') == 'PersonName'
 
 
 class TestReclassifyEntity:

--- a/tests/utils/maintenance/test_entity_extraction.py
+++ b/tests/utils/maintenance/test_entity_extraction.py
@@ -597,6 +597,10 @@ class TestSanitizeLabel:
     def test_normalizes_all_caps_with_underscores(self):
         assert _sanitize_label('PERSON_NAME') == 'PersonName'
 
+    def test_underscore_only_returns_entity(self):
+        assert _sanitize_label('_') == 'Entity'
+        assert _sanitize_label('__') == 'Entity'
+
 
 class TestReclassifyEntity:
     @pytest.mark.asyncio

--- a/tests/utils/maintenance/test_entity_extraction.py
+++ b/tests/utils/maintenance/test_entity_extraction.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -25,7 +26,10 @@ from graphiti_core.utils.datetime_utils import utc_now
 from graphiti_core.utils.maintenance.node_operations import (
     _build_entity_types_context,
     _extract_entity_summaries_batch,
+    _sanitize_label,
     extract_nodes,
+    reclassify_entity,
+    reprocess_entity_types,
 )
 
 
@@ -560,3 +564,169 @@ class TestExtractEntitySummariesBatch:
 
         # Should match despite case difference
         assert node.summary == 'Alice summary from LLM.'
+
+
+class TestSanitizeLabel:
+    def test_basic_pascal_case(self):
+        assert _sanitize_label('Person') == 'Person'
+
+    def test_lowercase_capitalizes_first(self):
+        assert _sanitize_label('person') == 'Person'
+
+    def test_strips_special_characters(self):
+        assert _sanitize_label('My-Type!') == 'MyType'
+
+    def test_strips_spaces(self):
+        assert _sanitize_label('My Type') == 'MyType'
+
+    def test_digit_prefix_gets_label_prepended(self):
+        assert _sanitize_label('123Type') == 'Label123Type'
+
+    def test_empty_string_returns_entity(self):
+        assert _sanitize_label('') == 'Entity'
+
+    def test_all_special_chars_returns_entity(self):
+        assert _sanitize_label('!@#$%') == 'Entity'
+
+    def test_preserves_underscores(self):
+        assert _sanitize_label('My_Type') == 'My_Type'
+
+
+class TestReclassifyEntity:
+    @pytest.mark.asyncio
+    async def test_returns_sanitized_type(self):
+        """reclassify_entity should return the sanitized entity type from LLM."""
+        llm_client = MagicMock()
+        llm_generate = AsyncMock(return_value={'entity_type': 'Person'})
+        llm_client.generate_response = llm_generate
+
+        entity = _make_entity_node('Alice', summary='Alice is a software engineer.')
+
+        result = await reclassify_entity(llm_client, entity)
+
+        assert result == 'Person'
+        llm_generate.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_sanitizes_llm_response(self):
+        """reclassify_entity should sanitize unusual LLM responses."""
+        llm_client = MagicMock()
+        llm_generate = AsyncMock(return_value={'entity_type': 'my-custom type!'})
+        llm_client.generate_response = llm_generate
+
+        entity = _make_entity_node('Test', summary='A test entity.')
+
+        result = await reclassify_entity(llm_client, entity)
+
+        assert result == 'Mycustomtype'
+
+    @pytest.mark.asyncio
+    async def test_passes_name_and_summary_to_prompt(self):
+        """reclassify_entity should pass entity name and summary as context."""
+        llm_client = MagicMock()
+        llm_generate = AsyncMock(return_value={'entity_type': 'Person'})
+        llm_client.generate_response = llm_generate
+
+        entity = _make_entity_node('Alice', summary='Alice is the CEO of Acme Corp.')
+
+        await reclassify_entity(llm_client, entity)
+
+        # Verify the prompt was called (the first positional arg is the prompt messages)
+        call_args = llm_generate.call_args
+        prompt_messages = call_args[0][0]
+        # The user message should contain the entity name and summary
+        user_content = prompt_messages[1].content
+        assert 'Alice' in user_content
+        assert 'Alice is the CEO of Acme Corp.' in user_content
+
+
+class TestReprocessEntityTypes:
+    @pytest.mark.asyncio
+    async def test_reclassifies_untyped_entities(self):
+        """Should reclassify entities with only ['Entity'] labels."""
+        clients, llm_generate = _make_clients()
+        llm_generate.return_value = {'entity_type': 'Person'}
+
+        entity = _make_entity_node('Alice', summary='Alice is a person.')
+        mock_save = AsyncMock()
+
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(EntityNode, 'get_by_group_ids', AsyncMock(return_value=[entity]))
+            m.setattr(EntityNode, 'save', mock_save)
+
+            result = await reprocess_entity_types(clients, 'group')
+
+        assert len(result) == 1
+        assert 'Person' in result[0].labels
+        assert 'Entity' in result[0].labels
+        mock_save.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_already_typed_entities(self):
+        """Entities with semantic type labels should not be re-processed."""
+        clients, llm_generate = _make_clients()
+
+        typed_entity = _make_entity_node('Alice', summary='Alice is a person.')
+        typed_entity.labels = ['Entity', 'Person']
+
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(EntityNode, 'get_by_group_ids', AsyncMock(return_value=[typed_entity]))
+
+            result = await reprocess_entity_types(clients, 'group')
+
+        assert len(result) == 0
+        # LLM should not have been called
+        llm_generate.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skips_entity_type_fallback(self):
+        """Entities where LLM returns 'Entity' should not have labels updated."""
+        clients, llm_generate = _make_clients()
+        llm_generate.return_value = {'entity_type': 'Entity'}
+
+        entity = _make_entity_node('Unknown Thing', summary='Something generic.')
+        mock_save = AsyncMock()
+
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(EntityNode, 'get_by_group_ids', AsyncMock(return_value=[entity]))
+            m.setattr(EntityNode, 'save', mock_save)
+
+            result = await reprocess_entity_types(clients, 'group')
+
+        assert len(result) == 0
+        mock_save.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_empty_group_returns_empty(self):
+        """Empty group should return empty list without LLM calls."""
+        clients, llm_generate = _make_clients()
+
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(EntityNode, 'get_by_group_ids', AsyncMock(return_value=[]))
+
+            result = await reprocess_entity_types(clients, 'group')
+
+        assert result == []
+        llm_generate.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_logs_progress(self, caplog):
+        """Should log progress during reclassification."""
+        clients, llm_generate = _make_clients()
+        llm_generate.return_value = {'entity_type': 'Person'}
+
+        entity = _make_entity_node('Alice', summary='Alice is a person.')
+        mock_save = AsyncMock()
+
+        with (
+            pytest.MonkeyPatch.context() as m,
+            caplog.at_level(logging.INFO),
+        ):
+            m.setattr(EntityNode, 'get_by_group_ids', AsyncMock(return_value=[entity]))
+            m.setattr(EntityNode, 'save', mock_save)
+
+            await reprocess_entity_types(clients, 'group')
+
+        log_messages = [r.message for r in caplog.records]
+        assert any('Reclassified 1/1' in msg for msg in log_messages)
+        assert any('Alice' in msg for msg in log_messages)


### PR DESCRIPTION
Closes #5

# Reprocess Entity Types via LLM Classification — Implementation Plan

## Overview

Add a migration utility that retroactively classifies entities in existing graphs that only have the generic `Entity` label. The utility queries entities lacking a semantic type label, uses the entity's `name` + `summary` as context to ask the LLM for a freeform type classification, then updates the entity's labels in the graph.

## Current State Analysis

### Key Discoveries:
- Entity labels are stored as `list[str]` on `Node.labels` (`nodes.py:94`), e.g. `['Entity']` for untyped or `['Entity', 'Person']` for typed
- Labels are persisted via `EntityNode.save()` which builds a Cypher `SET n:Entity:TypeName` clause (`nodes.py:529-563`)
- The existing `classify_nodes` prompt (`prompts/extract_nodes.py:189-218`) requires episode context — not suitable for retroactive reclassification
- Entity classification at ingestion uses ID-based mapping via `_build_entity_types_context()` (`node_operations.py:106-131`) — reclassification needs freeform string-based classification instead
- `_sanitize_label()` already exists in `node_operations.py:250` (from PR #4) — reuse it directly
- `ExtractedEntityFreeform` already exists in `prompts/extract_nodes.py:36` (from PR #4) — use as pattern for the new response model
- Entity summaries are rich enough for classification (e.g., "Brett Adam is the creator of Liminis" clearly indicates Person)
- `semaphore_gather` in `helpers.py` provides existing concurrency control for parallel LLM calls

## Desired End State

After implementation:
1. A new `reprocess_entity_types()` standalone function in `node_operations.py` can be called to retroactively classify all untyped entities in a graph partition
2. Entities that previously had only `['Entity']` as labels will have semantic type labels like `['Entity', 'Person']`, `['Entity', 'Organization']`, etc.
3. Running `make check` passes (format, lint, test)

**Verification:** Call `reprocess_entity_types(clients, group_id='...')` on a graph with untyped entities and confirm that entities receive semantic type labels. Run unit tests to verify prompt construction and the overall flow.

## What We're NOT Doing

- **No iterative/cascading classification** — Each entity is classified independently; we don't reclassify based on neighbors' new types
- **No edge retrieval for context** — Using `name` + `summary` only; edge retrieval can be added in a follow-up if quality is poor
- **No progress callbacks** — Logging only via `logger.info`
- **No batch LLM classification** — Individual LLM calls per entity (with concurrency via `semaphore_gather`)
- **No server/MCP endpoint** — This is a core library function only; server integration is out of scope
- **No Graphiti class method** — This is a one-time migration utility; keep it as a standalone function in `node_operations.py` to avoid adding permanent API surface to the upstream class. Our service layer can call the function directly.

## Implementation Approach

The implementation follows existing codebase patterns: a standalone async function in `node_operations.py` that accepts `GraphitiClients`. A new freeform classification prompt is added to `extract_nodes.py`, with a response model following the existing `ExtractedEntityFreeform` pattern. The existing `_sanitize_label()` function (from PR #4) is reused for label sanitization.

---

### TASK 1: Add Reclassification Prompt and Response Model [HIGH PRIORITY]
**Status:** NOT STARTED
**Milestone:** New `reclassify_entity` prompt function and `ReclassifiedEntity` response model exist in extract_nodes.py

- [x] Create `ReclassifiedEntity` Pydantic response model with `entity_type: str` field, following the existing `ExtractedEntityFreeform` pattern at `prompts/extract_nodes.py:36`
- [x] Create `reclassify_entity` prompt function that takes `name` and `summary` context
- [x] Register in the `Prompt` protocol, `Versions` TypedDict, and `versions` dict
- [x] Ensure the prompt instructs the LLM to return a single PascalCase type name (e.g., "Person", "Organization", "Concept")

**Validation:** `make lint` passes; prompt function is callable and returns valid `list[Message]`

**Requirements from spec:**
- Entity classification based on entity's semantic footprint (name + summary)
- Freeform type classification (not ID-based)

**Files to Modify:**
- `graphiti_core/prompts/extract_nodes.py` — Add `ReclassifiedEntity` model (following `ExtractedEntityFreeform` pattern), `reclassify_entity` prompt function, update `Prompt` protocol, `Versions` TypedDict, and `versions` dict

**Implementation Details:**

`ReclassifiedEntity` model:
```python
class ReclassifiedEntity(BaseModel):
    entity_type: str = Field(..., description='The classified entity type as a PascalCase string (e.g., Person, Organization, Concept)')
```

`reclassify_entity` prompt — system prompt instructs classification based on entity name and summary only. User prompt provides the entity's name and summary, asks for a single-word PascalCase type. The prompt should emphasize choosing a semantically meaningful ontological type (Person, Organization, Location, Event, Concept, Technology, etc.).

---

### TASK 2: Add Core Reclassification Functions [HIGH PRIORITY]
**Status:** NOT STARTED
**Milestone:** `reclassify_entity()` and `reprocess_entity_types()` functions exist in node_operations.py and work end-to-end

- [x] Add `reclassify_entity(llm_client, entity)` — builds context, calls LLM with reclassify prompt, returns sanitized type string using existing `_sanitize_label()`
- [x] Add `reprocess_entity_types(clients, group_id)` — retrieves all entities via `get_by_group_ids`, filters in Python for untyped entities (those with only `['Entity']` label), reclassifies each via `semaphore_gather`, updates labels, saves to graph, returns updated entities
- [x] Log progress at INFO level: `"Reclassified {i}/{total}: {entity.name} → {new_type}"`

**Validation:** Unit tests mock LLM responses and verify label updates, `make lint` passes

**Requirements from spec:**
- Retrieve entities with only generic `Entity` label
- Classify each entity using LLM with name + summary context
- Update labels and persist via `save()`
- Log progress

**Files to Modify:**
- `graphiti_core/utils/maintenance/node_operations.py` — Add `reclassify_entity()` and `reprocess_entity_types()` functions

**Implementation Details:**

`reclassify_entity()`:
```python
async def reclassify_entity(
    llm_client: LLMClient,
    entity: EntityNode,
) -> str:
    context = {
        'entity_name': entity.name,
        'entity_summary': entity.summary,
    }
    llm_response = await llm_client.generate_response(
        prompt_library.extract_nodes.reclassify_entity(context),
        response_model=ReclassifiedEntity,
        model_size=ModelSize.small,
        group_id=entity.group_id,
        prompt_name='extract_nodes.reclassify_entity',
    )
    result = ReclassifiedEntity(**llm_response)
    return _sanitize_label(result.entity_type)
```

`reprocess_entity_types()`:
```python
async def reprocess_entity_types(
    clients: GraphitiClients,
    group_id: str,
) -> list[EntityNode]:
    driver = clients.driver
    llm_client = clients.llm_client

    # Retrieve all entities for the group, then filter in Python
    # This is simpler and works across all graph providers (Neo4j, FalkorDB, Kuzu)
    all_entities = await EntityNode.get_by_group_ids(driver, [group_id])
    entities = [e for e in all_entities if len(e.labels) <= 1 or e.labels == ['Entity']]

    if not entities:
        logger.info(f'No untyped entities found for group_id={group_id}')
        return []

    logger.info(f'Found {len(entities)} untyped entities to reclassify for group_id={group_id}')

    # Reclassify all entities with concurrency control
    new_types = await semaphore_gather(
        *[reclassify_entity(llm_client, entity) for entity in entities]
    )

    # Update labels and save
    updated = []
    for i, (entity, new_type) in enumerate(zip(entities, new_types, strict=True)):
        if new_type != 'Entity':
            entity.labels = list({'Entity', new_type})
            await entity.save(driver)
            updated.append(entity)
            logger.info(f'Reclassified {i+1}/{len(entities)}: {entity.name} → {new_type}')
        else:
            logger.info(f'Skipped {i+1}/{len(entities)}: {entity.name} (no better type found)')

    logger.info(f'Reclassified {len(updated)}/{len(entities)} entities')
    return updated
```

---

### TASK 3: Add Unit Tests [MEDIUM PRIORITY]
**Status:** NOT STARTED
**Milestone:** Unit tests for reclassification prompt and reprocessing flow added to existing test file

- [x] Test `reclassify_entity()` with mocked LLM response
- [x] Test `reprocess_entity_types()` end-to-end flow with mocked driver and LLM
- [x] Test that entities already typed (labels > 1) are not re-processed (filtered out)
- [x] Test that entities where LLM returns "Entity" are skipped (labels unchanged)
- [x] Test empty group returns empty list

**Validation:** `make test` passes

**Requirements from spec:**
- Verify reclassification logic works correctly

**Files to Modify:**
- `tests/utils/maintenance/test_entity_extraction.py` — Add reclassification test classes alongside existing `TestSanitizeLabel` and `TestFreeformEntityExtraction` tests

**Implementation Details:**

Follow the existing patterns in `test_entity_extraction.py`:
- Use `_make_clients()` helper with `GraphitiClients.model_construct()` and `AsyncMock`
- Mock `llm_client.generate_response` to return `{'entity_type': 'Person'}`
- Mock `EntityNode.get_by_group_ids` to return test entities
- Verify `entity.save()` is called with updated labels
- Use `@pytest.mark.asyncio` for async tests

Key test cases:
```python
class TestReclassifyEntity:
    async def test_returns_sanitized_type(self): ...
    async def test_passes_name_and_summary_to_prompt(self): ...

class TestReprocessEntityTypes:
    async def test_reclassifies_untyped_entities(self): ...
    async def test_skips_already_typed_entities(self): ...
    async def test_skips_entity_type_fallback(self): ...
    async def test_empty_group_returns_empty(self): ...
    async def test_logs_progress(self): ...
```

---

## Testing Strategy

### Unit Tests:
- Prompt construction (correct context passed to LLM)
- Reclassification flow with mocked LLM (labels updated correctly, save called)
- Filtering logic (only untyped entities processed)
- Skip logic (entities where LLM returns "Entity" are not updated)

### Integration Tests:
- Requires Neo4j/FalkorDB connection
- Insert entities with only `['Entity']` label, run `reprocess_entity_types()`, verify labels updated in DB
- These would be marked with `_int` suffix per project convention

### Manual Testing Steps:
1. Connect to a database with existing untyped entities
2. Call `reprocess_entity_types(clients, group_id='...')`
3. Verify in Neo4j Browser that entities now have semantic type labels
4. Check logs for reclassification progress messages
5. Run `make check` to verify format, lint, and tests pass

## Performance Considerations

- Uses `semaphore_gather` for concurrent LLM calls (default concurrency from `helpers.py`)
- Each entity requires one LLM call — for large graphs this may take time
- No batching of LLM calls (each entity classified individually for accuracy)
- `ModelSize.small` is used for the classification LLM call since it's a simple task

## Migration Notes

- This is a one-time migration utility, not part of the normal ingestion pipeline
- Safe to run multiple times — entities that already have semantic type labels are filtered out
- Does not modify entity `name`, `summary`, or `attributes` — only `labels`
- Existing edges and relationships are unaffected

---

*This PR uses iterative implementation. Tasks are completed one at a time.*


