### PR TITLE
feat: Add Write-Ahead Log (WAL) at FalkorDB driver layer for git-friendly backup

### DIFF
--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -79,8 +79,12 @@ logger = logging.getLogger(__name__)
 class FalkorDriverSession(GraphDriverSession):
     provider = GraphProvider.FALKORDB
 
-    def __init__(self, graph: FalkorGraph):
+    def __init__(
+        self, graph: FalkorGraph, wal: WalWriter | None = None, database: str | None = None
+    ):
         self.graph = graph
+        self._wal = wal
+        self._database = database
 
     async def __aenter__(self):
         return self
@@ -103,10 +107,20 @@ class FalkorDriverSession(GraphDriverSession):
             for cypher, params in query:
                 params = convert_datetimes_to_strings(params)
                 await self.graph.query(str(cypher), params)  # type: ignore[reportUnknownArgumentType]
+                # Log mutation to WAL after successful execution
+                if self._wal is not None:
+                    await self._wal.log_mutation(
+                        str(cypher), cast(dict[str, Any], params), database=self._database or ''
+                    )
         else:
             params = dict(kwargs)
             params = convert_datetimes_to_strings(params)
             await self.graph.query(str(query), params)  # type: ignore[reportUnknownArgumentType]
+            # Log mutation to WAL after successful execution
+            if self._wal is not None:
+                await self._wal.log_mutation(
+                    str(query), cast(dict[str, Any], params), database=self._database or ''
+                )
         # Assuming `graph.query` is async (ideal); otherwise, wrap in executor
         return None
 
@@ -277,7 +291,11 @@ class FalkorDriver(GraphDriver):
         return records, header, None
 
     def session(self, database: str | None = None) -> GraphDriverSession:
-        return FalkorDriverSession(self._get_graph(database))
+        return FalkorDriverSession(
+            self._get_graph(database),
+            wal=self._wal,
+            database=database or self._database,
+        )
 
     async def close(self) -> None:
         """Close the driver connection."""
@@ -352,14 +370,15 @@ class FalkorDriver(GraphDriver):
         """
         Returns a shallow copy of this driver with a different default database.
         Reuses the same connection (e.g. FalkorDB, Neo4j).
+        Cloned drivers share the same WAL writer instance.
         """
         if database == self._database:
             cloned = self
         elif database == self.default_group_id:
-            cloned = FalkorDriver(falkor_db=self.client)
+            cloned = FalkorDriver(falkor_db=self.client, wal_writer=self._wal)
         else:
             # Create a new instance of FalkorDriver with the same connection but a different database
-            cloned = FalkorDriver(falkor_db=self.client, database=database)
+            cloned = FalkorDriver(falkor_db=self.client, database=database, wal_writer=self._wal)
 
         return cloned
 

--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -370,15 +370,21 @@ class FalkorDriver(GraphDriver):
         """
         Returns a shallow copy of this driver with a different default database.
         Reuses the same connection (e.g. FalkorDB, Neo4j).
-        Cloned drivers share the same WAL writer instance.
+        Cloned drivers share the same WAL writer instance (reference counted).
         """
         if database == self._database:
             cloned = self
-        elif database == self.default_group_id:
-            cloned = FalkorDriver(falkor_db=self.client, wal_writer=self._wal)
         else:
-            # Create a new instance of FalkorDriver with the same connection but a different database
-            cloned = FalkorDriver(falkor_db=self.client, database=database, wal_writer=self._wal)
+            # Acquire a reference to the shared WAL before passing it to the clone
+            if self._wal is not None:
+                self._wal.acquire()
+
+            if database == self.default_group_id:
+                cloned = FalkorDriver(falkor_db=self.client, wal_writer=self._wal)
+            else:
+                cloned = FalkorDriver(
+                    falkor_db=self.client, database=database, wal_writer=self._wal
+                )
 
         return cloned
 

--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -110,7 +110,7 @@ class FalkorDriverSession(GraphDriverSession):
                 # Log mutation to WAL after successful execution
                 if self._wal is not None:
                     await self._wal.log_mutation(
-                        str(cypher), cast(dict[str, Any], params), database=self._database or ''
+                        str(cypher), cast(dict[str, Any], params), database=self._database
                     )
         else:
             params = dict(kwargs)
@@ -119,7 +119,7 @@ class FalkorDriverSession(GraphDriverSession):
             # Log mutation to WAL after successful execution
             if self._wal is not None:
                 await self._wal.log_mutation(
-                    str(query), cast(dict[str, Any], params), database=self._database or ''
+                    str(query), cast(dict[str, Any], params), database=self._database
                 )
         # Assuming `graph.query` is async (ideal); otherwise, wrap in executor
         return None

--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -364,7 +364,12 @@ class FalkorDriver(GraphDriver):
             + get_vector_indices(self.provider)
         )
         for query in index_queries:
-            await self.execute_query(query)
+            try:
+                await self.execute_query(query)
+            except Exception as e:
+                # Index creation is idempotent — transient connection errors
+                # or concurrent index builds are non-fatal
+                logger.warning(f'Index creation skipped (will retry on next startup): {e}')
 
     def clone(self, database: str) -> GraphDriver:
         """

--- a/graphiti_core/driver/falkordb_driver.py
+++ b/graphiti_core/driver/falkordb_driver.py
@@ -14,14 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from __future__ import annotations
+
 import asyncio
 import datetime
 import logging
-from typing import TYPE_CHECKING, Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from falkordb import Graph as FalkorGraph
     from falkordb.asyncio import FalkorDB
+
+    from graphiti_core.driver.wal import WalWriter
 else:
     try:
         from falkordb import Graph as FalkorGraph
@@ -120,6 +125,8 @@ class FalkorDriver(GraphDriver):
         password: str | None = None,
         falkor_db: FalkorDB | None = None,
         database: str = 'default_db',
+        wal_dir: str | Path | None = None,
+        wal_writer: WalWriter | None = None,
     ):
         """
         Initialize the FalkorDB driver.
@@ -135,6 +142,8 @@ class FalkorDriver(GraphDriver):
         password (str | None): The password for authentication (if required).
         falkor_db (FalkorDB | None): An existing FalkorDB instance to use instead of creating a new one.
         database (str): The name of the database to connect to. Defaults to 'default_db'.
+        wal_dir (str | Path | None): Directory for WAL files. If provided, enables WAL logging.
+        wal_writer (WalWriter | None): Existing WalWriter to reuse (for cloned drivers).
         """
         super().__init__()
         self._database = database
@@ -143,6 +152,15 @@ class FalkorDriver(GraphDriver):
             self.client = falkor_db
         else:
             self.client = FalkorDB(host=host, port=port, username=username, password=password)
+
+        # Initialize WAL writer
+        self._wal: WalWriter | None = None
+        if wal_writer is not None:
+            self._wal = wal_writer
+        elif wal_dir is not None:
+            from graphiti_core.driver.wal import WalWriter
+
+            self._wal = WalWriter(wal_dir)
 
         # Instantiate FalkorDB operations
         self._entity_node_ops = FalkorEntityNodeOperations()
@@ -235,6 +253,12 @@ class FalkorDriver(GraphDriver):
             logger.error(f'Error executing FalkorDB query: {e}\n{cypher_query_}\n{params}')
             raise
 
+        # Log mutation to WAL after successful execution
+        if self._wal is not None:
+            await self._wal.log_mutation(
+                cypher_query_, cast(dict[str, Any], params), database=self._database
+            )
+
         # Convert the result header to a list of strings
         header = [h[1] for h in result.header]
 
@@ -257,6 +281,10 @@ class FalkorDriver(GraphDriver):
 
     async def close(self) -> None:
         """Close the driver connection."""
+        # Close WAL writer if enabled
+        if self._wal is not None:
+            await self._wal.close()
+
         if hasattr(self.client, 'aclose'):
             await self.client.aclose()  # type: ignore[reportUnknownMemberType]
         elif hasattr(self.client.connection, 'aclose'):
@@ -320,7 +348,7 @@ class FalkorDriver(GraphDriver):
         for query in index_queries:
             await self.execute_query(query)
 
-    def clone(self, database: str) -> 'GraphDriver':
+    def clone(self, database: str) -> GraphDriver:
         """
         Returns a shallow copy of this driver with a different default database.
         Reuses the same connection (e.g. FalkorDB, Neo4j).

--- a/graphiti_core/driver/wal.py
+++ b/graphiti_core/driver/wal.py
@@ -180,7 +180,11 @@ class WalWriter:
         return self._wal_dir / f'{timestamp}_{self._session_id}_{self._file_seq:04d}.jsonl'
 
     def _ensure_file_open(self) -> None:
-        """Ensure we have an open file handle, creating a new file if needed."""
+        """Ensure we have an open file handle, creating a new file if needed.
+
+        Uses synchronous I/O — safe for local filesystem (microsecond-scale).
+        Would block the event loop on NFS or slow mounts.
+        """
         if self._file is None:
             filename = self._get_current_filename()
             # File stays open for multiple writes and is closed explicitly via close()

--- a/graphiti_core/driver/wal.py
+++ b/graphiti_core/driver/wal.py
@@ -76,6 +76,7 @@ class WalWriter:
         self._session_id = uuid.uuid4().hex[:6]
         self._file_seq = 0
         self._closed = False
+        self._ref_count = 1  # Reference counting for shared WAL instances
 
         # Create WAL directory if it doesn't exist
         self._wal_dir.mkdir(parents=True, exist_ok=True)
@@ -273,15 +274,35 @@ class WalWriter:
         else:
             return value
 
+    def acquire(self) -> None:
+        """
+        Increment the reference count for shared WAL instances.
+
+        Call this when sharing the WAL writer with a cloned driver so that
+        close() only truly closes when the last user releases its reference.
+        """
+        if self._closed:
+            raise RuntimeError('Cannot acquire a closed WAL writer')
+        self._ref_count += 1
+        logger.debug(f'WAL: Acquired reference, ref_count={self._ref_count}')
+
     async def close(self) -> None:
         """
-        Close the WAL writer.
+        Release one reference to the WAL writer.
 
-        Flushes any buffered data and closes the file handle.
-        This method is idempotent - calling it multiple times is safe.
+        The underlying file is only closed when the last reference is released.
+        This method is idempotent - calling it multiple times is safe (each call
+        decrements the reference count at most once, and extra calls after the
+        count reaches zero are no-ops).
         """
         async with self._lock:
             if self._closed:
+                return
+
+            self._ref_count -= 1
+            logger.debug(f'WAL: Released reference, ref_count={self._ref_count}')
+
+            if self._ref_count > 0:
                 return
 
             self._closed = True

--- a/graphiti_core/driver/wal.py
+++ b/graphiti_core/driver/wal.py
@@ -1,0 +1,308 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Mutation keywords that indicate a write operation (case-insensitive)
+_MUTATION_KEYWORDS = frozenset({'CREATE', 'MERGE', 'SET', 'DELETE', 'DETACH', 'DROP', 'REMOVE'})
+
+# Regex to strip string literals (single and double quoted, with escape handling)
+_STRING_LITERAL_PATTERN = re.compile(r"'(?:[^'\\]|\\.)*'|\"(?:[^\"\\]|\\.)*\"")
+
+# Index DDL patterns (case-insensitive)
+_INDEX_DDL_PATTERNS = [
+    re.compile(r'\bCREATE\s+(UNIQUE\s+)?INDEX\b', re.IGNORECASE),
+    re.compile(r'\bCREATE\s+FULLTEXT\s+INDEX\b', re.IGNORECASE),
+    re.compile(r'\bCREATE\s+VECTOR\s+INDEX\b', re.IGNORECASE),
+    re.compile(r'\bDROP\s+(FULLTEXT\s+)?INDEX\b', re.IGNORECASE),
+    re.compile(r'\bCALL\s+db\.idx\.fulltext\b', re.IGNORECASE),
+    re.compile(r'\bCALL\s+db\.indexes\b', re.IGNORECASE),
+]
+
+
+class WalWriter:
+    """
+    Write-ahead log for capturing FalkorDB mutations as replayable JSONL files.
+
+    Each WAL entry contains:
+    - seq: Monotonically increasing sequence number (global across all files)
+    - ts: ISO 8601 timestamp of when the mutation was logged
+    - db: Database name the mutation was executed against
+    - cypher: The Cypher query that was executed
+    - params: Query parameters (with datetimes converted to strings)
+
+    Files are rotated after max_events_per_file entries. File naming follows:
+    {timestamp}_{session_uuid_short}_{file_seq:04d}.jsonl
+    """
+
+    def __init__(self, wal_dir: str | Path, max_events_per_file: int = 10_000):
+        """
+        Initialize the WAL writer.
+
+        Args:
+            wal_dir: Directory to write WAL files to. Created if it doesn't exist.
+            max_events_per_file: Maximum number of events per file before rotation.
+        """
+        self._wal_dir = Path(wal_dir)
+        self._max_events = max_events_per_file
+        self._lock = asyncio.Lock()
+        self._file: Any = None  # File handle
+        self._current_seq = 0
+        self._events_in_file = 0
+        self._session_id = uuid.uuid4().hex[:6]
+        self._file_seq = 0
+        self._closed = False
+
+        # Create WAL directory if it doesn't exist
+        self._wal_dir.mkdir(parents=True, exist_ok=True)
+
+        # Scan existing files for sequence continuity
+        self._scan_existing_files()
+
+    def _scan_existing_files(self) -> None:
+        """Scan existing WAL files to determine the next sequence number."""
+        max_seq = -1
+        max_file_seq = -1
+
+        for wal_file in sorted(self._wal_dir.glob('*.jsonl')):
+            # Extract file sequence from filename
+            try:
+                parts = wal_file.stem.split('_')
+                if len(parts) >= 3:
+                    file_seq = int(parts[-1])
+                    max_file_seq = max(max_file_seq, file_seq)
+            except (ValueError, IndexError):
+                pass
+
+            # Read last line to get max sequence
+            try:
+                with open(wal_file, 'rb') as f:
+                    # Seek to end and read backwards to find last line
+                    f.seek(0, 2)  # Seek to end
+                    file_size = f.tell()
+                    if file_size == 0:
+                        continue
+
+                    # Read last chunk (usually enough for one line)
+                    chunk_size = min(8192, file_size)
+                    f.seek(file_size - chunk_size)
+                    chunk = f.read()
+
+                    # Find last complete line
+                    lines = chunk.split(b'\n')
+                    for line in reversed(lines):
+                        line = line.strip()
+                        if line:
+                            try:
+                                entry = json.loads(line)
+                                if 'seq' in entry:
+                                    max_seq = max(max_seq, entry['seq'])
+                                    break
+                            except json.JSONDecodeError:
+                                continue
+            except OSError as e:
+                logger.warning(f'Error reading WAL file {wal_file}: {e}')
+
+        # Set next sequence number and file sequence
+        self._current_seq = max_seq + 1
+        self._file_seq = max_file_seq + 1
+
+        if max_seq >= 0:
+            logger.info(
+                f'WAL: Resuming from sequence {self._current_seq}, file seq {self._file_seq}'
+            )
+
+    @staticmethod
+    def is_mutation(cypher: str) -> bool:
+        """
+        Detect if a Cypher query is a mutation (write operation).
+
+        Checks for mutation keywords (CREATE, MERGE, SET, DELETE, DETACH, DROP, REMOVE)
+        after stripping string literals to avoid false positives from values.
+
+        Args:
+            cypher: The Cypher query to check.
+
+        Returns:
+            True if the query contains mutation keywords, False otherwise.
+        """
+        # Strip string literals to avoid matching keywords in values
+        stripped = _STRING_LITERAL_PATTERN.sub('', cypher)
+
+        # Tokenize and check for mutation keywords (case-insensitive)
+        tokens = re.findall(r'\b[A-Za-z]+\b', stripped)
+        return any(token.upper() in _MUTATION_KEYWORDS for token in tokens)
+
+    @staticmethod
+    def is_index_ddl(cypher: str) -> bool:
+        """
+        Detect if a Cypher query is an index DDL operation.
+
+        Index operations are excluded from WAL since they're handled separately
+        by build_indices_and_constraints() during replay.
+
+        Args:
+            cypher: The Cypher query to check.
+
+        Returns:
+            True if the query is an index DDL operation, False otherwise.
+        """
+        return any(pattern.search(cypher) for pattern in _INDEX_DDL_PATTERNS)
+
+    def _get_current_filename(self) -> Path:
+        """Generate the current WAL filename."""
+        timestamp = datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')
+        return self._wal_dir / f'{timestamp}_{self._session_id}_{self._file_seq:04d}.jsonl'
+
+    def _ensure_file_open(self) -> None:
+        """Ensure we have an open file handle, creating a new file if needed."""
+        if self._file is None:
+            filename = self._get_current_filename()
+            # File stays open for multiple writes and is closed explicitly via close()
+            self._file = open(filename, 'a', encoding='utf-8')  # noqa: SIM115
+            self._events_in_file = 0
+            logger.debug(f'WAL: Opened new file {filename}')
+
+    def _rotate_file(self) -> None:
+        """Close current file and prepare for a new one."""
+        if self._file is not None:
+            self._file.flush()
+            self._file.close()
+            self._file = None
+            self._file_seq += 1
+            logger.debug(f'WAL: Rotated to file seq {self._file_seq}')
+
+    async def log_mutation(self, cypher: str, params: dict[str, Any], database: str) -> None:
+        """
+        Log a mutation to the WAL if it passes filtering.
+
+        Only logs queries that:
+        1. Are mutations (contain mutation keywords)
+        2. Are NOT index DDL operations
+
+        Args:
+            cypher: The Cypher query that was executed.
+            params: Query parameters (will be serialized to JSON).
+            database: Database name the query was executed against.
+        """
+        if self._closed:
+            logger.warning('WAL: Attempted to log to closed WAL writer')
+            return
+
+        # Filter: only log mutations, exclude index DDL
+        if not self.is_mutation(cypher) or self.is_index_ddl(cypher):
+            return
+
+        async with self._lock:
+            if self._closed:
+                return
+
+            # Rotate if needed
+            if self._events_in_file >= self._max_events:
+                self._rotate_file()
+
+            # Ensure file is open
+            self._ensure_file_open()
+
+            # Build entry
+            entry = {
+                'seq': self._current_seq,
+                'ts': datetime.now(timezone.utc).isoformat(),
+                'db': database,
+                'cypher': cypher,
+                'params': self._serialize_params(params),
+            }
+
+            # Write entry
+            try:
+                line = json.dumps(entry, ensure_ascii=False, separators=(',', ':'))
+                self._file.write(line + '\n')
+                self._file.flush()  # Ensure durability
+                self._current_seq += 1
+                self._events_in_file += 1
+            except (TypeError, ValueError) as e:
+                logger.error(f'WAL: Failed to serialize entry: {e}')
+                raise
+
+    @staticmethod
+    def _serialize_params(params: dict[str, Any]) -> dict[str, Any]:
+        """
+        Serialize parameters for JSON storage.
+
+        Handles datetime objects by converting to ISO format strings.
+        Lists (including embeddings) are kept as-is since JSON handles them natively.
+        """
+        result = {}
+        for key, value in params.items():
+            result[key] = WalWriter._serialize_value(value)
+        return result
+
+    @staticmethod
+    def _serialize_value(value: Any) -> Any:
+        """Recursively serialize a value for JSON storage."""
+        if isinstance(value, dict):
+            return {k: WalWriter._serialize_value(v) for k, v in value.items()}
+        elif isinstance(value, (list, tuple)):
+            return [WalWriter._serialize_value(item) for item in value]
+        elif isinstance(value, datetime):
+            return value.isoformat()
+        else:
+            return value
+
+    async def close(self) -> None:
+        """
+        Close the WAL writer.
+
+        Flushes any buffered data and closes the file handle.
+        This method is idempotent - calling it multiple times is safe.
+        """
+        async with self._lock:
+            if self._closed:
+                return
+
+            self._closed = True
+
+            if self._file is not None:
+                try:
+                    self._file.flush()
+                    self._file.close()
+                except OSError as e:
+                    logger.error(f'WAL: Error closing file: {e}')
+                finally:
+                    self._file = None
+
+            logger.debug(f'WAL: Closed writer, final seq {self._current_seq}')
+
+    @property
+    def current_sequence(self) -> int:
+        """Get the current sequence number (next to be written)."""
+        return self._current_seq
+
+    @property
+    def is_closed(self) -> bool:
+        """Check if the WAL writer has been closed."""
+        return self._closed

--- a/graphiti_core/driver/wal_dump.py
+++ b/graphiti_core/driver/wal_dump.py
@@ -1,0 +1,262 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+from graphiti_core.driver.wal import WalWriter
+
+logger = logging.getLogger(__name__)
+
+# Properties that are stored as vector embeddings in FalkorDB.
+# During replay these need vecf32() wrapping, but in the WAL they're
+# stored as plain float arrays and the replay handles conversion.
+_VECTOR_PROPERTIES = frozenset({'name_embedding', 'fact_embedding'})
+
+# Internal FalkorDB properties to exclude from dump
+_INTERNAL_PROPERTIES = frozenset({'__name_embedding_dim', '__fact_embedding_dim'})
+
+
+async def dump_wal(
+    host: str = 'localhost',
+    port: int = 6379,
+    database: str = 'default_db',
+    wal_dir: str | Path = '.',
+    max_events_per_file: int = 10_000,
+) -> int:
+    """
+    Dump the current state of a FalkorDB database as WAL entries.
+
+    Reads all nodes and relationships from the database and writes
+    them as MERGE/SET Cypher mutations to WAL files. The resulting
+    WAL can be replayed to reconstruct an equivalent database.
+
+    Nodes are dumped before relationships to ensure MATCH clauses
+    in edge mutations find their endpoints.
+
+    Args:
+        host: FalkorDB host.
+        port: FalkorDB port.
+        database: Database name to dump.
+        wal_dir: Directory to write WAL files to.
+        max_events_per_file: Max events per WAL file.
+
+    Returns:
+        Number of mutations written.
+    """
+    from graphiti_core.driver.falkordb_driver import FalkorDriver
+
+    driver = FalkorDriver(host=host, port=int(port), database=database)
+    wal = WalWriter(wal_dir, max_events_per_file=max_events_per_file)
+
+    count = 0
+
+    try:
+        # Phase 1: Dump all nodes
+        count += await _dump_nodes(driver, wal, database)
+
+        # Phase 2: Dump all relationships
+        count += await _dump_relationships(driver, wal, database)
+
+    finally:
+        await wal.close()
+        await driver.close()
+
+    logger.info('Dump complete: %d mutations written to %s', count, wal_dir)
+    return count
+
+
+async def _dump_nodes(driver: Any, wal: WalWriter, database: str) -> int:
+    """Dump all nodes as MERGE/SET WAL entries."""
+    result = await driver.execute_query(
+        'MATCH (n) RETURN id(n) AS _id, labels(n) AS _labels, properties(n) AS _props'
+    )
+    if not result:
+        return 0
+
+    records, _, _ = result
+    count = 0
+
+    for record in records:
+        labels = record['_labels']
+        props = record['_props']
+
+        # Filter internal properties
+        props = {k: v for k, v in props.items() if k not in _INTERNAL_PROPERTIES}
+
+        if not props.get('uuid'):
+            logger.warning('Skipping node without uuid: labels=%s', labels)
+            continue
+
+        # Build label string for Cypher (e.g., ":Entity:Person")
+        label_str = ':'.join(labels) if labels else 'Node'
+
+        # Separate vector properties for vecf32() wrapping
+        vector_props = {}
+        scalar_props = {}
+        for k, v in props.items():
+            if k in _VECTOR_PROPERTIES and v is not None:
+                vector_props[k] = v
+            else:
+                scalar_props[k] = v
+
+        # Build Cypher: MERGE on uuid, SET all properties
+        cypher = f'MERGE (n:{label_str} {{uuid: $uuid}}) SET n = $props'
+        params: dict[str, Any] = {'uuid': props['uuid'], 'props': scalar_props}
+
+        # Add vector properties with vecf32()
+        for vk, vv in vector_props.items():
+            cypher += f' SET n.{vk} = vecf32(${vk})'
+            params[vk] = vv
+
+        await wal.log_mutation(cypher, params, database=database)
+        count += 1
+
+    logger.info('Dumped %d nodes', count)
+    return count
+
+
+async def _dump_relationships(driver: Any, wal: WalWriter, database: str) -> int:
+    """Dump all relationships as MERGE/SET WAL entries."""
+    result = await driver.execute_query("""
+        MATCH (src)-[r]->(dst)
+        RETURN
+            type(r) AS _type,
+            src.uuid AS _src_uuid,
+            dst.uuid AS _dst_uuid,
+            properties(r) AS _props,
+            labels(src) AS _src_labels,
+            labels(dst) AS _dst_labels
+    """)
+    if not result:
+        return 0
+
+    records, _, _ = result
+    count = 0
+
+    for record in records:
+        rel_type = record['_type']
+        src_uuid = record['_src_uuid']
+        dst_uuid = record['_dst_uuid']
+        props = record['_props']
+        src_labels = record['_src_labels']
+        dst_labels = record['_dst_labels']
+
+        # Filter internal properties
+        props = {k: v for k, v in props.items() if k not in _INTERNAL_PROPERTIES}
+
+        if not src_uuid or not dst_uuid:
+            logger.warning('Skipping relationship without endpoint uuids: type=%s', rel_type)
+            continue
+
+        # Use first label for MATCH (sufficient for uuid lookup)
+        src_label = src_labels[0] if src_labels else 'Node'
+        dst_label = dst_labels[0] if dst_labels else 'Node'
+
+        # Separate vector properties
+        vector_props = {}
+        scalar_props = {}
+        for k, v in props.items():
+            if k in _VECTOR_PROPERTIES and v is not None:
+                vector_props[k] = v
+            else:
+                scalar_props[k] = v
+
+        # Build MERGE key — use uuid if available, otherwise match on endpoints
+        if props.get('uuid'):
+            merge_key = '{uuid: $uuid}'
+            params: dict[str, Any] = {
+                'src_uuid': src_uuid,
+                'dst_uuid': dst_uuid,
+                'uuid': props['uuid'],
+                'props': scalar_props,
+            }
+        else:
+            merge_key = ''
+            params = {
+                'src_uuid': src_uuid,
+                'dst_uuid': dst_uuid,
+                'props': scalar_props,
+            }
+
+        cypher = (
+            f'MATCH (src:{src_label} {{uuid: $src_uuid}}) '
+            f'MATCH (dst:{dst_label} {{uuid: $dst_uuid}}) '
+            f'MERGE (src)-[r:{rel_type} {merge_key}]->(dst) '
+            f'SET r = $props'
+        )
+
+        # Add vector properties with vecf32()
+        for vk, vv in vector_props.items():
+            cypher += f' SET r.{vk} = vecf32(${vk})'
+            params[vk] = vv
+
+        await wal.log_mutation(cypher, params, database=database)
+        count += 1
+
+    logger.info('Dumped %d relationships', count)
+    return count
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description='Dump a FalkorDB database to WAL files for backup or migration',
+    )
+    parser.add_argument('wal_dir', help='Directory to write WAL .jsonl files')
+    parser.add_argument('--host', default='localhost', help='FalkorDB host (default: localhost)')
+    parser.add_argument('--port', type=int, default=6379, help='FalkorDB port (default: 6379)')
+    parser.add_argument(
+        '--database', default='default_db', help='Database name to dump (default: default_db)'
+    )
+    parser.add_argument(
+        '--max-events-per-file',
+        type=int,
+        default=10_000,
+        help='Max events per WAL file (default: 10000)',
+    )
+    parser.add_argument('--verbose', '-v', action='store_true', help='Enable verbose logging')
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format='%(asctime)s %(levelname)s %(name)s: %(message)s',
+    )
+
+    try:
+        count = asyncio.run(
+            dump_wal(
+                host=args.host,
+                port=args.port,
+                database=args.database,
+                wal_dir=args.wal_dir,
+                max_events_per_file=args.max_events_per_file,
+            )
+        )
+        print(f'Dumped {count} mutations.')
+    except KeyboardInterrupt:
+        print('\nInterrupted.')
+        sys.exit(130)
+
+
+if __name__ == '__main__':
+    main()

--- a/graphiti_core/driver/wal_replay.py
+++ b/graphiti_core/driver/wal_replay.py
@@ -30,6 +30,25 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _scan_databases(wal_files: list[Path], default: str) -> set[str]:
+    """Scan WAL files for all distinct database names."""
+    databases: set[str] = set()
+    for wal_file in wal_files:
+        with open(wal_file, encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                    databases.add(entry.get('db', default))
+                except json.JSONDecodeError:
+                    continue
+    if not databases:
+        databases.add(default)
+    return databases
+
+
 async def replay_wal(
     wal_dir: str | Path,
     host: str = 'localhost',
@@ -74,12 +93,17 @@ async def replay_wal(
         if not dry_run:
             from graphiti_core.driver.falkordb_driver import FalkorDriver
 
+            # Scan WAL for all distinct databases so we can build indices on each
+            databases = _scan_databases(wal_files, default=database)
+
             # Create driver WITHOUT WAL to avoid re-logging replayed mutations
             driver = FalkorDriver(host=host, port=int(port), database=database)
 
-            # Build indices first — WAL excludes index DDL
-            logger.info('Building indices and constraints...')
-            await driver.build_indices_and_constraints()
+            # Build indices on every database found in the WAL
+            for db_name in databases:
+                logger.info('Building indices and constraints on %s...', db_name)
+                db_driver = driver if db_name == database else driver.clone(db_name)
+                await db_driver.build_indices_and_constraints()
 
         for wal_file in wal_files:
             logger.info('Replaying %s...', wal_file.name)

--- a/graphiti_core/driver/wal_replay.py
+++ b/graphiti_core/driver/wal_replay.py
@@ -1,0 +1,187 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from graphiti_core.driver.falkordb_driver import FalkorDriver
+
+logger = logging.getLogger(__name__)
+
+
+async def replay_wal(
+    wal_dir: str | Path,
+    host: str = 'localhost',
+    port: int = 6379,
+    database: str = 'default_db',
+    from_seq: int = 0,
+    dry_run: bool = False,
+) -> int:
+    """
+    Replay WAL files to reconstruct a FalkorDB database.
+
+    Reads all JSONL files from the WAL directory in filename order,
+    executes each mutation against the target database, and skips
+    events with seq < from_seq for partial replay / resume.
+
+    Args:
+        wal_dir: Directory containing WAL .jsonl files.
+        host: FalkorDB host.
+        port: FalkorDB port.
+        database: Target database name. If None, uses the db field from each WAL event.
+        from_seq: Skip events with seq < from_seq (for partial replay).
+        dry_run: If True, parse and validate but don't execute mutations.
+
+    Returns:
+        Number of mutations replayed.
+    """
+    wal_path = Path(wal_dir)
+    if not wal_path.is_dir():
+        raise FileNotFoundError(f'WAL directory not found: {wal_path}')
+
+    wal_files = sorted(wal_path.glob('*.jsonl'))
+    if not wal_files:
+        logger.info('No WAL files found in %s', wal_path)
+        return 0
+
+    driver: FalkorDriver | None = None
+    replayed = 0
+    skipped = 0
+    errors = 0
+
+    try:
+        if not dry_run:
+            from graphiti_core.driver.falkordb_driver import FalkorDriver
+
+            # Create driver WITHOUT WAL to avoid re-logging replayed mutations
+            driver = FalkorDriver(host=host, port=int(port), database=database)
+
+            # Build indices first — WAL excludes index DDL
+            logger.info('Building indices and constraints...')
+            await driver.build_indices_and_constraints()
+
+        for wal_file in wal_files:
+            logger.info('Replaying %s...', wal_file.name)
+
+            with open(wal_file, encoding='utf-8') as f:
+                for line_num, line in enumerate(f, 1):
+                    line = line.strip()
+                    if not line:
+                        continue
+
+                    try:
+                        entry = json.loads(line)
+                    except json.JSONDecodeError as e:
+                        logger.error('Parse error in %s:%d: %s', wal_file.name, line_num, e)
+                        errors += 1
+                        continue
+
+                    seq = entry.get('seq', -1)
+                    if seq < from_seq:
+                        skipped += 1
+                        continue
+
+                    cypher = entry['cypher']
+                    params = entry.get('params', {})
+                    event_db = entry.get('db', database)
+
+                    if dry_run:
+                        logger.debug('DRY RUN seq=%d db=%s: %s', seq, event_db, cypher[:80])
+                        replayed += 1
+                        continue
+
+                    try:
+                        # Use the event's db field to target the correct database
+                        assert driver is not None
+                        graph = driver._get_graph(event_db)
+                        await graph.query(cypher, params)  # type: ignore[reportUnknownMemberType]
+                        replayed += 1
+                    except Exception as e:
+                        logger.error('Replay error at seq=%d: %s\n  %s', seq, e, cypher[:200])
+                        errors += 1
+
+    finally:
+        if driver is not None:
+            await driver.close()
+
+    logger.info(
+        'Replay complete: %d replayed, %d skipped (seq < %d), %d errors',
+        replayed,
+        skipped,
+        from_seq,
+        errors,
+    )
+    return replayed
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description='Replay graphiti WAL files to reconstruct a FalkorDB database',
+    )
+    parser.add_argument('wal_dir', help='Directory containing WAL .jsonl files')
+    parser.add_argument('--host', default='localhost', help='FalkorDB host (default: localhost)')
+    parser.add_argument('--port', type=int, default=6379, help='FalkorDB port (default: 6379)')
+    parser.add_argument(
+        '--database', default='default_db', help='Target database name (default: default_db)'
+    )
+    parser.add_argument(
+        '--from-seq',
+        type=int,
+        default=0,
+        help='Skip events with seq < FROM_SEQ (default: 0)',
+    )
+    parser.add_argument(
+        '--dry-run', action='store_true', help='Parse and validate without executing mutations'
+    )
+    parser.add_argument('--verbose', '-v', action='store_true', help='Enable verbose logging')
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format='%(asctime)s %(levelname)s %(name)s: %(message)s',
+    )
+
+    try:
+        count = asyncio.run(
+            replay_wal(
+                wal_dir=args.wal_dir,
+                host=args.host,
+                port=args.port,
+                database=args.database,
+                from_seq=args.from_seq,
+                dry_run=args.dry_run,
+            )
+        )
+        print(f'Replayed {count} mutations.')
+    except FileNotFoundError as e:
+        print(f'Error: {e}', file=sys.stderr)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print('\nInterrupted.')
+        sys.exit(130)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/driver/test_falkordb_driver.py
+++ b/tests/driver/test_falkordb_driver.py
@@ -619,6 +619,45 @@ class TestCloneWithWal:
 
     @pytest.mark.asyncio
     @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    async def test_clone_close_does_not_kill_parent_wal(self, tmp_path):
+        """Test that closing a clone doesn't close the shared WAL for the parent."""
+        wal_dir = tmp_path / 'wal'
+        mock_client = MagicMock()
+        mock_graph = MagicMock()
+        mock_result = MagicMock()
+        mock_result.header = []
+        mock_result.result_set = []
+        mock_graph.query = AsyncMock(return_value=mock_result)
+        mock_client.select_graph.return_value = mock_graph
+        mock_client.aclose = AsyncMock()
+
+        with patch('graphiti_core.driver.falkordb_driver.FalkorDB'):
+            driver = FalkorDriver(wal_dir=str(wal_dir), database='db1')
+        driver.client = mock_client
+
+        cloned = driver.clone('db2')
+        cloned.client = mock_client
+
+        # Close the clone — should NOT close the shared WAL
+        await cloned.close()
+
+        # Parent should still be able to log mutations
+        await driver.execute_query('CREATE (n:AfterCloneClose)')
+        await driver.close()
+
+        import json
+
+        wal_files = list(wal_dir.glob('*.jsonl'))
+        assert len(wal_files) == 1
+
+        with open(wal_files[0]) as f:
+            entries = [json.loads(line) for line in f]
+
+        assert len(entries) == 1
+        assert entries[0]['cypher'] == 'CREATE (n:AfterCloneClose)'
+
+    @pytest.mark.asyncio
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
     async def test_cloned_driver_logs_to_same_wal(self, tmp_path):
         """Test that cloned drivers write to the same WAL files."""
         wal_dir = tmp_path / 'wal'

--- a/tests/driver/test_falkordb_driver.py
+++ b/tests/driver/test_falkordb_driver.py
@@ -403,6 +403,68 @@ class TestWalIntegration:
             self.driver = FalkorDriver()
         self.driver.client = self.mock_client
 
+    @pytest.mark.asyncio
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    async def test_execute_query_logs_mutations_to_wal(self, tmp_path):
+        """Test that execute_query() logs mutations to WAL."""
+        wal_dir = tmp_path / 'wal'
+        mock_client = MagicMock()
+        mock_graph = MagicMock()
+        mock_result = MagicMock()
+        mock_result.header = [('col', 'n')]
+        mock_result.result_set = []
+        mock_graph.query = AsyncMock(return_value=mock_result)
+        mock_client.select_graph.return_value = mock_graph
+        mock_client.aclose = AsyncMock()
+
+        with patch('graphiti_core.driver.falkordb_driver.FalkorDB'):
+            driver = FalkorDriver(wal_dir=str(wal_dir), database='test_db')
+        driver.client = mock_client
+
+        await driver.execute_query('MERGE (n:Entity {uuid: $uuid}) SET n.name = $name', uuid='abc', name='Alice')
+
+        await driver.close()
+
+        import json
+
+        wal_files = list(wal_dir.glob('*.jsonl'))
+        assert len(wal_files) == 1
+
+        with open(wal_files[0]) as f:
+            entry = json.loads(f.readline())
+        assert entry['cypher'] == 'MERGE (n:Entity {uuid: $uuid}) SET n.name = $name'
+        assert entry['params']['uuid'] == 'abc'
+        assert entry['params']['name'] == 'Alice'
+        assert entry['db'] == 'test_db'
+
+    @pytest.mark.asyncio
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    async def test_execute_query_skips_read_only_wal(self, tmp_path):
+        """Test that execute_query() does NOT log read-only queries to WAL."""
+        wal_dir = tmp_path / 'wal'
+        mock_client = MagicMock()
+        mock_graph = MagicMock()
+        mock_result = MagicMock()
+        mock_result.header = []
+        mock_result.result_set = []
+        mock_graph.query = AsyncMock(return_value=mock_result)
+        mock_client.select_graph.return_value = mock_graph
+        mock_client.aclose = AsyncMock()
+
+        with patch('graphiti_core.driver.falkordb_driver.FalkorDB'):
+            driver = FalkorDriver(wal_dir=str(wal_dir))
+        driver.client = mock_client
+
+        await driver.execute_query('MATCH (n) RETURN n')
+
+        await driver.close()
+
+        wal_files = list(wal_dir.glob('*.jsonl'))
+        if wal_files:
+            with open(wal_files[0]) as f:
+                content = f.read().strip()
+            assert content == '', 'Read-only query should not be logged to WAL'
+
     @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
     def test_session_receives_wal_from_driver(self, tmp_path):
         """Test that session receives WAL writer from parent driver."""

--- a/tests/driver/test_falkordb_driver.py
+++ b/tests/driver/test_falkordb_driver.py
@@ -390,3 +390,209 @@ class TestFalkorDriverIntegration:
 
         except Exception as e:
             pytest.skip(f'FalkorDB not available for integration test: {e}')
+
+
+class TestWalIntegration:
+    """Test WAL integration with FalkorDB driver and session."""
+
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.mock_client = MagicMock()
+        with patch('graphiti_core.driver.falkordb_driver.FalkorDB'):
+            self.driver = FalkorDriver()
+        self.driver.client = self.mock_client
+
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    def test_session_receives_wal_from_driver(self, tmp_path):
+        """Test that session receives WAL writer from parent driver."""
+        wal_dir = tmp_path / 'wal'
+        mock_graph = MagicMock()
+        self.mock_client.select_graph.return_value = mock_graph
+
+        # Create driver with WAL enabled
+        with patch('graphiti_core.driver.falkordb_driver.FalkorDB'):
+            driver = FalkorDriver(wal_dir=str(wal_dir))
+        driver.client = self.mock_client
+
+        # Create session and verify it receives WAL
+        session = driver.session()
+        assert session._wal is driver._wal
+        assert session._database == 'default_db'
+
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    def test_session_receives_custom_database(self, tmp_path):
+        """Test that session receives custom database name."""
+        wal_dir = tmp_path / 'wal'
+        mock_graph = MagicMock()
+        self.mock_client.select_graph.return_value = mock_graph
+
+        with patch('graphiti_core.driver.falkordb_driver.FalkorDB'):
+            driver = FalkorDriver(wal_dir=str(wal_dir))
+        driver.client = self.mock_client
+
+        session = driver.session(database='custom_db')
+        assert session._database == 'custom_db'
+
+    @pytest.mark.asyncio
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    async def test_session_run_logs_mutations_to_wal(self, tmp_path):
+        """Test that session.run() logs mutations to WAL."""
+        wal_dir = tmp_path / 'wal'
+        mock_graph = MagicMock()
+        mock_graph.query = AsyncMock()
+        mock_client = MagicMock()
+        mock_client.select_graph.return_value = mock_graph
+        mock_client.aclose = AsyncMock()
+
+        with patch('graphiti_core.driver.falkordb_driver.FalkorDB'):
+            driver = FalkorDriver(wal_dir=str(wal_dir))
+        driver.client = mock_client
+
+        session = driver.session()
+        await session.run('CREATE (n:Test {name: $name})', name='test')
+
+        # Verify WAL was logged to
+        await driver.close()
+
+        # Check WAL files
+        wal_files = list(wal_dir.glob('*.jsonl'))
+        assert len(wal_files) == 1
+
+        import json
+
+        with open(wal_files[0]) as f:
+            entry = json.loads(f.readline())
+        assert entry['cypher'] == 'CREATE (n:Test {name: $name})'
+        assert entry['params']['name'] == 'test'
+
+    @pytest.mark.asyncio
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    async def test_session_run_list_logs_mutations_to_wal(self, tmp_path):
+        """Test that session.run() with list queries logs mutations to WAL."""
+        wal_dir = tmp_path / 'wal'
+        mock_graph = MagicMock()
+        mock_graph.query = AsyncMock()
+        mock_client = MagicMock()
+        mock_client.select_graph.return_value = mock_graph
+        mock_client.aclose = AsyncMock()
+
+        with patch('graphiti_core.driver.falkordb_driver.FalkorDB'):
+            driver = FalkorDriver(wal_dir=str(wal_dir))
+        driver.client = mock_client
+
+        session = driver.session()
+        queries = [
+            ('CREATE (n:Test1)', {}),
+            ('MATCH (n) RETURN n', {}),  # Read - should not be logged
+            ('CREATE (n:Test2)', {}),
+        ]
+        await session.run(queries)
+
+        await driver.close()
+
+        # Check WAL files
+        import json
+
+        wal_files = list(wal_dir.glob('*.jsonl'))
+        assert len(wal_files) == 1
+
+        with open(wal_files[0]) as f:
+            entries = [json.loads(line) for line in f]
+
+        # Only CREATE statements should be logged (2 out of 3)
+        assert len(entries) == 2
+        assert entries[0]['cypher'] == 'CREATE (n:Test1)'
+        assert entries[1]['cypher'] == 'CREATE (n:Test2)'
+
+
+class TestCloneWithWal:
+    """Test clone() method with WAL sharing."""
+
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    def test_clone_shares_wal_instance(self, tmp_path):
+        """Test that cloned driver shares the same WAL writer."""
+        wal_dir = tmp_path / 'wal'
+        mock_client = MagicMock()
+
+        with patch('graphiti_core.driver.falkordb_driver.FalkorDB'):
+            driver = FalkorDriver(wal_dir=str(wal_dir))
+        driver.client = mock_client
+
+        cloned = driver.clone('other_db')
+
+        # Verify cloned driver has the same WAL instance
+        assert cloned._wal is driver._wal
+        assert cloned._database == 'other_db'
+
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    def test_clone_same_database_returns_self(self, tmp_path):
+        """Test that cloning with same database returns self."""
+        wal_dir = tmp_path / 'wal'
+        mock_client = MagicMock()
+
+        with patch('graphiti_core.driver.falkordb_driver.FalkorDB'):
+            driver = FalkorDriver(wal_dir=str(wal_dir), database='test_db')
+        driver.client = mock_client
+
+        cloned = driver.clone('test_db')
+
+        assert cloned is driver
+
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    def test_clone_default_group_id_shares_wal(self, tmp_path):
+        """Test that cloning with default_group_id shares WAL."""
+        wal_dir = tmp_path / 'wal'
+        mock_client = MagicMock()
+
+        with patch('graphiti_core.driver.falkordb_driver.FalkorDB'):
+            driver = FalkorDriver(wal_dir=str(wal_dir), database='test_db')
+        driver.client = mock_client
+
+        # Clone with default_group_id
+        cloned = driver.clone(FalkorDriver.default_group_id)
+
+        assert cloned._wal is driver._wal
+        assert cloned._database == 'default_db'  # Default database
+
+    @pytest.mark.asyncio
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    async def test_cloned_driver_logs_to_same_wal(self, tmp_path):
+        """Test that cloned drivers write to the same WAL files."""
+        wal_dir = tmp_path / 'wal'
+        mock_client = MagicMock()
+        mock_graph = MagicMock()
+        mock_result = MagicMock()
+        mock_result.header = []
+        mock_result.result_set = []
+        mock_graph.query = AsyncMock(return_value=mock_result)
+        mock_client.select_graph.return_value = mock_graph
+        mock_client.aclose = AsyncMock()
+
+        with patch('graphiti_core.driver.falkordb_driver.FalkorDB'):
+            driver = FalkorDriver(wal_dir=str(wal_dir), database='db1')
+        driver.client = mock_client
+
+        cloned = driver.clone('db2')
+        cloned.client = mock_client
+
+        # Execute mutations on both drivers
+        await driver.execute_query('CREATE (n:FromOriginal)')
+        await cloned.execute_query('CREATE (n:FromCloned)')
+
+        await driver.close()
+
+        # Check WAL files
+        import json
+
+        wal_files = list(wal_dir.glob('*.jsonl'))
+        assert len(wal_files) == 1
+
+        with open(wal_files[0]) as f:
+            entries = [json.loads(line) for line in f]
+
+        assert len(entries) == 2
+        # Verify both entries are in the same WAL with their respective databases
+        dbs = [e['db'] for e in entries]
+        assert 'db1' in dbs
+        assert 'db2' in dbs

--- a/tests/driver/test_wal.py
+++ b/tests/driver/test_wal.py
@@ -158,12 +158,12 @@ class TestWalWriter:
         return tmp_path / 'wal'
 
     @pytest.fixture
-    def wal_writer(self, wal_dir):
+    async def wal_writer(self, wal_dir):
         """Create a WalWriter instance."""
         writer = WalWriter(wal_dir, max_events_per_file=5)
         yield writer
         # Cleanup - close if not already closed
-        asyncio.get_event_loop().run_until_complete(writer.close())
+        await writer.close()
 
     @pytest.mark.asyncio
     async def test_creates_wal_directory(self, wal_dir):

--- a/tests/driver/test_wal.py
+++ b/tests/driver/test_wal.py
@@ -1,0 +1,480 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import asyncio
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from graphiti_core.driver.wal import WalWriter
+
+
+class TestIsMutation:
+    """Test WalWriter.is_mutation() query classification."""
+
+    def test_match_only_is_not_mutation(self):
+        """MATCH-only queries are reads, not mutations."""
+        assert WalWriter.is_mutation('MATCH (n) RETURN n') is False
+        assert WalWriter.is_mutation('MATCH (n:Person) WHERE n.name = "test" RETURN n') is False
+
+    def test_create_is_mutation(self):
+        """CREATE queries are mutations."""
+        assert WalWriter.is_mutation('CREATE (n:Person {name: "test"})') is True
+        assert WalWriter.is_mutation('MATCH (a) CREATE (b)-[:KNOWS]->(a)') is True
+
+    def test_merge_is_mutation(self):
+        """MERGE queries are mutations."""
+        assert WalWriter.is_mutation('MERGE (n:Person {name: "test"})') is True
+        assert WalWriter.is_mutation('MATCH (a) MERGE (a)-[:KNOWS]->(b)') is True
+
+    def test_set_is_mutation(self):
+        """SET queries are mutations."""
+        assert WalWriter.is_mutation('MATCH (n) SET n.name = "test"') is True
+        assert WalWriter.is_mutation('MATCH (n) SET n += {age: 30}') is True
+
+    def test_delete_is_mutation(self):
+        """DELETE queries are mutations."""
+        assert WalWriter.is_mutation('MATCH (n) DELETE n') is True
+        assert WalWriter.is_mutation('MATCH (n:Person) WHERE n.age < 18 DELETE n') is True
+
+    def test_detach_delete_is_mutation(self):
+        """DETACH DELETE queries are mutations."""
+        assert WalWriter.is_mutation('MATCH (n) DETACH DELETE n') is True
+
+    def test_drop_is_mutation(self):
+        """DROP queries are mutations."""
+        assert WalWriter.is_mutation('DROP INDEX idx_name') is True
+
+    def test_remove_is_mutation(self):
+        """REMOVE queries are mutations."""
+        assert WalWriter.is_mutation('MATCH (n) REMOVE n.name') is True
+        assert WalWriter.is_mutation('MATCH (n) REMOVE n:Label') is True
+
+    def test_keyword_in_string_is_not_mutation(self):
+        """Keywords inside string literals should not trigger false positives."""
+        assert WalWriter.is_mutation("MATCH (n) WHERE n.name = 'CREATE'") is False
+        assert WalWriter.is_mutation('MATCH (n) WHERE n.action = "DELETE"') is False
+        assert WalWriter.is_mutation("MATCH (n) WHERE n.data = 'SET value'") is False
+
+    def test_case_insensitive_detection(self):
+        """Mutation keywords should be detected case-insensitively."""
+        assert WalWriter.is_mutation('create (n:Test)') is True
+        assert WalWriter.is_mutation('Create (n:Test)') is True
+        assert WalWriter.is_mutation('MATCH (n) set n.x = 1') is True
+        assert WalWriter.is_mutation('match (n) Delete n') is True
+
+    def test_complex_queries(self):
+        """Test complex multi-clause queries."""
+        # MATCH + CREATE
+        assert WalWriter.is_mutation('MATCH (a:Person) CREATE (a)-[:KNOWS]->(b:Person)') is True
+        # MATCH + MERGE + SET
+        assert (
+            WalWriter.is_mutation('MATCH (n) MERGE (m:Test) ON CREATE SET m.created = true') is True
+        )
+        # Multiple operations
+        assert (
+            WalWriter.is_mutation(
+                'MATCH (a), (b) WHERE a.id = 1 AND b.id = 2 CREATE (a)-[:REL]->(b) SET a.linked = true'
+            )
+            is True
+        )
+
+
+class TestIsIndexDDL:
+    """Test WalWriter.is_index_ddl() index detection."""
+
+    def test_create_index_is_ddl(self):
+        """CREATE INDEX queries are DDL."""
+        assert WalWriter.is_index_ddl('CREATE INDEX FOR (n:Person) ON (n.name)') is True
+        assert WalWriter.is_index_ddl('CREATE INDEX idx_name FOR (n:Person) ON (n.name)') is True
+
+    def test_create_unique_index_is_ddl(self):
+        """CREATE UNIQUE INDEX queries are DDL."""
+        assert WalWriter.is_index_ddl('CREATE UNIQUE INDEX FOR (n:Person) ON (n.id)') is True
+
+    def test_create_fulltext_index_is_ddl(self):
+        """CREATE FULLTEXT INDEX queries are DDL."""
+        assert (
+            WalWriter.is_index_ddl('CREATE FULLTEXT INDEX FOR (n:Person) ON (n.name, n.bio)')
+            is True
+        )
+
+    def test_create_vector_index_is_ddl(self):
+        """CREATE VECTOR INDEX queries are DDL."""
+        assert WalWriter.is_index_ddl('CREATE VECTOR INDEX FOR (n:Person) ON (n.embedding)') is True
+
+    def test_drop_index_is_ddl(self):
+        """DROP INDEX queries are DDL."""
+        assert WalWriter.is_index_ddl('DROP INDEX idx_name') is True
+        assert WalWriter.is_index_ddl('DROP INDEX ON :Person(name)') is True
+
+    def test_drop_fulltext_index_is_ddl(self):
+        """DROP FULLTEXT INDEX queries are DDL."""
+        assert WalWriter.is_index_ddl('DROP FULLTEXT INDEX FOR (n:Person) ON (n.name)') is True
+
+    def test_call_db_idx_fulltext_is_ddl(self):
+        """CALL db.idx.fulltext queries are DDL."""
+        assert (
+            WalWriter.is_index_ddl("CALL db.idx.fulltext.createNodeIndex('Person', 'name')") is True
+        )
+
+    def test_call_db_indexes_is_ddl(self):
+        """CALL db.indexes() queries are DDL."""
+        assert WalWriter.is_index_ddl('CALL db.indexes()') is True
+
+    def test_regular_mutations_are_not_ddl(self):
+        """Regular mutation queries are not DDL."""
+        assert WalWriter.is_index_ddl('CREATE (n:Person {name: "test"})') is False
+        assert WalWriter.is_index_ddl('MERGE (n:Person {id: 1})') is False
+        assert WalWriter.is_index_ddl('MATCH (n) DELETE n') is False
+
+    def test_case_insensitive_detection(self):
+        """Index DDL should be detected case-insensitively."""
+        assert WalWriter.is_index_ddl('create index FOR (n:Test) ON (n.id)') is True
+        assert WalWriter.is_index_ddl('Create Fulltext Index FOR (n:Test) ON (n.name)') is True
+        assert WalWriter.is_index_ddl('drop index idx_name') is True
+
+
+class TestWalWriter:
+    """Test WalWriter file operations, rotation, and sequence handling."""
+
+    @pytest.fixture
+    def wal_dir(self, tmp_path):
+        """Create a temporary WAL directory."""
+        return tmp_path / 'wal'
+
+    @pytest.fixture
+    def wal_writer(self, wal_dir):
+        """Create a WalWriter instance."""
+        writer = WalWriter(wal_dir, max_events_per_file=5)
+        yield writer
+        # Cleanup - close if not already closed
+        asyncio.get_event_loop().run_until_complete(writer.close())
+
+    @pytest.mark.asyncio
+    async def test_creates_wal_directory(self, wal_dir):
+        """WalWriter creates WAL directory if it doesn't exist."""
+        assert not wal_dir.exists()
+        writer = WalWriter(wal_dir)
+        assert wal_dir.exists()
+        await writer.close()
+
+    @pytest.mark.asyncio
+    async def test_log_mutation_creates_file(self, wal_dir):
+        """First logged mutation creates a WAL file."""
+        writer = WalWriter(wal_dir)
+        await writer.log_mutation('CREATE (n:Test)', {}, 'test_db')
+        await writer.close()
+
+        files = list(wal_dir.glob('*.jsonl'))
+        assert len(files) == 1
+
+    @pytest.mark.asyncio
+    async def test_log_mutation_writes_jsonl_entry(self, wal_dir):
+        """Logged mutations are written as JSONL entries."""
+        writer = WalWriter(wal_dir)
+        await writer.log_mutation('CREATE (n:Test {name: $name})', {'name': 'test'}, 'test_db')
+        await writer.close()
+
+        files = list(wal_dir.glob('*.jsonl'))
+        with open(files[0]) as f:
+            entry = json.loads(f.readline())
+
+        assert entry['seq'] == 0
+        assert 'ts' in entry
+        assert entry['db'] == 'test_db'
+        assert entry['cypher'] == 'CREATE (n:Test {name: $name})'
+        assert entry['params'] == {'name': 'test'}
+
+    @pytest.mark.asyncio
+    async def test_sequence_numbers_increment(self, wal_dir):
+        """Sequence numbers increment with each logged mutation."""
+        writer = WalWriter(wal_dir)
+        await writer.log_mutation('CREATE (n:Test1)', {}, 'db')
+        await writer.log_mutation('CREATE (n:Test2)', {}, 'db')
+        await writer.log_mutation('CREATE (n:Test3)', {}, 'db')
+        await writer.close()
+
+        files = list(wal_dir.glob('*.jsonl'))
+        with open(files[0]) as f:
+            lines = f.readlines()
+
+        assert len(lines) == 3
+        assert json.loads(lines[0])['seq'] == 0
+        assert json.loads(lines[1])['seq'] == 1
+        assert json.loads(lines[2])['seq'] == 2
+
+    @pytest.mark.asyncio
+    async def test_file_rotation(self, wal_dir):
+        """Files rotate after max_events_per_file entries."""
+        writer = WalWriter(wal_dir, max_events_per_file=3)
+
+        # Write 5 mutations - should create 2 files (3 + 2)
+        for i in range(5):
+            await writer.log_mutation(f'CREATE (n:Test{i})', {}, 'db')
+
+        await writer.close()
+
+        files = sorted(wal_dir.glob('*.jsonl'))
+        assert len(files) == 2
+
+        # First file should have 3 entries
+        with open(files[0]) as f:
+            assert len(f.readlines()) == 3
+
+        # Second file should have 2 entries
+        with open(files[1]) as f:
+            assert len(f.readlines()) == 2
+
+    @pytest.mark.asyncio
+    async def test_sequence_continuity_across_files(self, wal_dir):
+        """Sequence numbers continue across file boundaries."""
+        writer = WalWriter(wal_dir, max_events_per_file=2)
+
+        for i in range(4):
+            await writer.log_mutation(f'CREATE (n:Test{i})', {}, 'db')
+
+        await writer.close()
+
+        # Read all entries from all files
+        all_seqs = []
+        for f in sorted(wal_dir.glob('*.jsonl')):
+            with open(f) as fp:
+                for line in fp:
+                    all_seqs.append(json.loads(line)['seq'])
+
+        assert all_seqs == [0, 1, 2, 3]
+
+    @pytest.mark.asyncio
+    async def test_sequence_continuity_on_restart(self, wal_dir):
+        """Sequence numbers continue from where previous session left off."""
+        # First session
+        writer1 = WalWriter(wal_dir)
+        await writer1.log_mutation('CREATE (n:Test1)', {}, 'db')
+        await writer1.log_mutation('CREATE (n:Test2)', {}, 'db')
+        await writer1.close()
+
+        # Second session - should continue sequence
+        writer2 = WalWriter(wal_dir)
+        assert writer2.current_sequence == 2  # Should resume from where first left off
+        await writer2.log_mutation('CREATE (n:Test3)', {}, 'db')
+        await writer2.close()
+
+        # Check sequences across all files (order doesn't matter, just that all seqs present)
+        all_seqs = []
+        for f in wal_dir.glob('*.jsonl'):
+            with open(f) as fp:
+                for line in fp:
+                    all_seqs.append(json.loads(line)['seq'])
+
+        assert sorted(all_seqs) == [0, 1, 2]
+
+    @pytest.mark.asyncio
+    async def test_filters_read_only_queries(self, wal_dir):
+        """Read-only queries are not logged."""
+        writer = WalWriter(wal_dir)
+        await writer.log_mutation('MATCH (n) RETURN n', {}, 'db')
+        await writer.log_mutation('MATCH (n:Person) WHERE n.age > 18 RETURN n', {}, 'db')
+        await writer.close()
+
+        files = list(wal_dir.glob('*.jsonl'))
+        assert len(files) == 0  # No file created since nothing was logged
+
+    @pytest.mark.asyncio
+    async def test_filters_index_ddl(self, wal_dir):
+        """Index DDL queries are not logged."""
+        writer = WalWriter(wal_dir)
+        await writer.log_mutation('CREATE INDEX FOR (n:Person) ON (n.name)', {}, 'db')
+        await writer.log_mutation('DROP INDEX idx_name', {}, 'db')
+        await writer.close()
+
+        files = list(wal_dir.glob('*.jsonl'))
+        assert len(files) == 0
+
+    @pytest.mark.asyncio
+    async def test_serializes_datetime_params(self, wal_dir):
+        """Datetime parameters are serialized to ISO format."""
+        writer = WalWriter(wal_dir)
+        dt = datetime(2024, 1, 15, 12, 30, 45, tzinfo=timezone.utc)
+        await writer.log_mutation('CREATE (n:Test {created: $ts})', {'ts': dt}, 'db')
+        await writer.close()
+
+        files = list(wal_dir.glob('*.jsonl'))
+        with open(files[0]) as f:
+            entry = json.loads(f.readline())
+
+        assert entry['params']['ts'] == '2024-01-15T12:30:45+00:00'
+
+    @pytest.mark.asyncio
+    async def test_serializes_nested_datetime_params(self, wal_dir):
+        """Nested datetime parameters are serialized correctly."""
+        writer = WalWriter(wal_dir)
+        dt = datetime(2024, 1, 15, tzinfo=timezone.utc)
+        params = {
+            'data': {'created': dt, 'items': [dt, dt]},
+            'tuple_data': (dt, 'string'),
+        }
+        await writer.log_mutation('CREATE (n:Test $props)', params, 'db')
+        await writer.close()
+
+        files = list(wal_dir.glob('*.jsonl'))
+        with open(files[0]) as f:
+            entry = json.loads(f.readline())
+
+        assert entry['params']['data']['created'] == '2024-01-15T00:00:00+00:00'
+        assert entry['params']['data']['items'] == [
+            '2024-01-15T00:00:00+00:00',
+            '2024-01-15T00:00:00+00:00',
+        ]
+        # Tuples are converted to lists in JSON
+        assert entry['params']['tuple_data'] == ['2024-01-15T00:00:00+00:00', 'string']
+
+    @pytest.mark.asyncio
+    async def test_serializes_embedding_params(self, wal_dir):
+        """Embedding (list of floats) parameters are serialized correctly."""
+        writer = WalWriter(wal_dir)
+        embedding = [0.1, 0.2, 0.3, 0.4, 0.5]
+        await writer.log_mutation(
+            'CREATE (n:Test {embedding: $emb})', {'emb': embedding, 'name': 'test'}, 'db'
+        )
+        await writer.close()
+
+        files = list(wal_dir.glob('*.jsonl'))
+        with open(files[0]) as f:
+            entry = json.loads(f.readline())
+
+        assert entry['params']['emb'] == [0.1, 0.2, 0.3, 0.4, 0.5]
+        assert entry['params']['name'] == 'test'
+
+    @pytest.mark.asyncio
+    async def test_close_is_idempotent(self, wal_dir):
+        """Calling close() multiple times is safe."""
+        writer = WalWriter(wal_dir)
+        await writer.log_mutation('CREATE (n:Test)', {}, 'db')
+
+        # Multiple closes should not raise
+        await writer.close()
+        await writer.close()
+        await writer.close()
+
+        assert writer.is_closed is True
+
+    @pytest.mark.asyncio
+    async def test_log_after_close_is_ignored(self, wal_dir):
+        """Logging after close is ignored with a warning."""
+        writer = WalWriter(wal_dir)
+        await writer.log_mutation('CREATE (n:Test1)', {}, 'db')
+        await writer.close()
+
+        # This should be silently ignored
+        await writer.log_mutation('CREATE (n:Test2)', {}, 'db')
+
+        files = list(wal_dir.glob('*.jsonl'))
+        with open(files[0]) as f:
+            lines = f.readlines()
+
+        assert len(lines) == 1
+
+    @pytest.mark.asyncio
+    async def test_current_sequence_property(self, wal_dir):
+        """current_sequence property returns next sequence to be written."""
+        writer = WalWriter(wal_dir)
+        assert writer.current_sequence == 0
+
+        await writer.log_mutation('CREATE (n:Test1)', {}, 'db')
+        assert writer.current_sequence == 1
+
+        await writer.log_mutation('CREATE (n:Test2)', {}, 'db')
+        assert writer.current_sequence == 2
+
+        await writer.close()
+
+
+class TestWalWriterConcurrency:
+    """Test concurrent write handling."""
+
+    @pytest.fixture
+    def wal_dir(self, tmp_path):
+        """Create a temporary WAL directory."""
+        return tmp_path / 'wal'
+
+    @pytest.mark.asyncio
+    async def test_concurrent_writes_dont_interleave(self, wal_dir):
+        """Concurrent writes produce valid JSONL (no interleaved lines)."""
+        writer = WalWriter(wal_dir, max_events_per_file=100)
+
+        async def write_batch(start: int, count: int):
+            for i in range(count):
+                await writer.log_mutation(
+                    f'CREATE (n:Test {{id: {start + i}}})', {'idx': start + i}, 'db'
+                )
+
+        # Launch concurrent writers
+        await asyncio.gather(
+            write_batch(0, 10),
+            write_batch(100, 10),
+            write_batch(200, 10),
+        )
+
+        await writer.close()
+
+        # Verify all entries are valid JSON
+        entries = []
+        for f in wal_dir.glob('*.jsonl'):
+            with open(f) as fp:
+                for line in fp:
+                    entry = json.loads(line)  # Should not raise
+                    entries.append(entry)
+
+        # Verify all 30 entries were written
+        assert len(entries) == 30
+
+        # Verify sequence numbers are unique and monotonic
+        seqs = [e['seq'] for e in entries]
+        assert sorted(seqs) == list(range(30))
+
+    @pytest.mark.asyncio
+    async def test_concurrent_writes_with_rotation(self, wal_dir):
+        """Concurrent writes with file rotation maintain sequence integrity."""
+        writer = WalWriter(wal_dir, max_events_per_file=5)
+
+        async def write_batch(start: int, count: int):
+            for i in range(count):
+                await writer.log_mutation(
+                    f'CREATE (n:Test {{id: {start + i}}})', {'idx': start + i}, 'db'
+                )
+
+        await asyncio.gather(
+            write_batch(0, 8),
+            write_batch(100, 8),
+        )
+
+        await writer.close()
+
+        # Read all entries
+        entries = []
+        for f in sorted(wal_dir.glob('*.jsonl')):
+            with open(f) as fp:
+                for line in fp:
+                    entries.append(json.loads(line))
+
+        # Verify all 16 entries
+        assert len(entries) == 16
+
+        # Verify sequences are unique and ordered
+        seqs = [e['seq'] for e in entries]
+        assert sorted(seqs) == list(range(16))

--- a/tests/driver/test_wal.py
+++ b/tests/driver/test_wal.py
@@ -404,6 +404,7 @@ class TestWalWriter:
         await writer.close()
 
 
+
 class TestWalWriterConcurrency:
     """Test concurrent write handling."""
 

--- a/tests/driver/test_wal.py
+++ b/tests/driver/test_wal.py
@@ -478,3 +478,90 @@ class TestWalWriterConcurrency:
         # Verify sequences are unique and ordered
         seqs = [e['seq'] for e in entries]
         assert sorted(seqs) == list(range(16))
+
+
+class TestWalWriterRefCounting:
+    """Test reference counting for shared WAL instances."""
+
+    @pytest.fixture
+    def wal_dir(self, tmp_path):
+        """Create a temporary WAL directory."""
+        return tmp_path / 'wal'
+
+    @pytest.mark.asyncio
+    async def test_close_clone_does_not_close_shared_wal(self, wal_dir):
+        """Closing a clone's reference should not close the shared WAL."""
+        writer = WalWriter(wal_dir)
+        writer.acquire()  # Simulate clone taking a reference
+
+        # Clone closes its reference
+        await writer.close()
+        assert writer.is_closed is False
+
+        # Original can still log
+        await writer.log_mutation('CREATE (n:Test)', {}, 'db')
+        assert writer.current_sequence == 1
+
+        # Original closes — now it's truly closed
+        await writer.close()
+        assert writer.is_closed is True
+
+    @pytest.mark.asyncio
+    async def test_multiple_acquires_require_matching_closes(self, wal_dir):
+        """Each acquire() requires a matching close() before the WAL shuts down."""
+        writer = WalWriter(wal_dir)
+        writer.acquire()
+        writer.acquire()
+
+        await writer.close()
+        assert writer.is_closed is False
+
+        await writer.close()
+        assert writer.is_closed is False
+
+        await writer.close()
+        assert writer.is_closed is True
+
+    @pytest.mark.asyncio
+    async def test_acquire_after_close_raises(self, wal_dir):
+        """Cannot acquire a reference on an already-closed WAL."""
+        writer = WalWriter(wal_dir)
+        await writer.close()
+
+        with pytest.raises(RuntimeError, match='Cannot acquire a closed WAL writer'):
+            writer.acquire()
+
+    @pytest.mark.asyncio
+    async def test_extra_close_after_shutdown_is_noop(self, wal_dir):
+        """Extra close() calls after the WAL is shut down are safe no-ops."""
+        writer = WalWriter(wal_dir)
+        await writer.close()
+        assert writer.is_closed is True
+
+        # Should not raise
+        await writer.close()
+        await writer.close()
+        assert writer.is_closed is True
+
+    @pytest.mark.asyncio
+    async def test_mutations_work_until_last_close(self, wal_dir):
+        """Mutations can be logged as long as at least one reference remains."""
+        writer = WalWriter(wal_dir)
+        writer.acquire()  # ref_count = 2
+
+        await writer.log_mutation('CREATE (n:A)', {}, 'db')
+        await writer.close()  # ref_count = 1, still open
+
+        await writer.log_mutation('CREATE (n:B)', {}, 'db')
+        await writer.close()  # ref_count = 0, closed
+
+        # After final close, mutation is dropped
+        await writer.log_mutation('CREATE (n:C)', {}, 'db')
+
+        files = list(wal_dir.glob('*.jsonl'))
+        with open(files[0]) as f:
+            lines = f.readlines()
+
+        assert len(lines) == 2
+        assert json.loads(lines[0])['cypher'] == 'CREATE (n:A)'
+        assert json.loads(lines[1])['cypher'] == 'CREATE (n:B)'

--- a/tests/driver/test_wal_dump.py
+++ b/tests/driver/test_wal_dump.py
@@ -1,0 +1,423 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import json
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+try:
+    from graphiti_core.driver.falkordb_driver import FalkorDriver
+
+    HAS_FALKORDB = True
+except ImportError:
+    FalkorDriver = None
+    HAS_FALKORDB = False
+
+
+class TestDumpNodes:
+    """Test node dumping to WAL."""
+
+    @pytest.mark.asyncio
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    async def test_dumps_entity_nodes(self, tmp_path):
+        from graphiti_core.driver.wal import WalWriter
+        from graphiti_core.driver.wal_dump import _dump_nodes
+
+        mock_driver = MagicMock()
+        mock_driver.execute_query = AsyncMock(
+            return_value=(
+                [
+                    {
+                        '_id': 1,
+                        '_labels': ['Entity', 'Person'],
+                        '_props': {
+                            'uuid': 'e1',
+                            'name': 'Alice',
+                            'group_id': 'test',
+                            'created_at': '2026-01-01T00:00:00Z',
+                            'summary': 'A person',
+                            'name_embedding': [0.1, 0.2, 0.3],
+                        },
+                    },
+                ],
+                ['_id', '_labels', '_props'],
+                None,
+            )
+        )
+
+        wal_dir = tmp_path / 'wal'
+        wal = WalWriter(wal_dir)
+
+        count = await _dump_nodes(mock_driver, wal, 'test_db')
+        await wal.close()
+
+        assert count == 1
+
+        wal_files = list(wal_dir.glob('*.jsonl'))
+        assert len(wal_files) == 1
+
+        with open(wal_files[0]) as f:
+            entry = json.loads(f.readline())
+
+        assert 'Entity:Person' in entry['cypher']
+        assert 'MERGE' in entry['cypher']
+        assert 'vecf32($name_embedding)' in entry['cypher']
+        assert entry['params']['uuid'] == 'e1'
+        assert entry['params']['name_embedding'] == [0.1, 0.2, 0.3]
+        # name_embedding should NOT be in scalar props
+        assert 'name_embedding' not in entry['params']['props']
+
+    @pytest.mark.asyncio
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    async def test_dumps_episodic_nodes(self, tmp_path):
+        from graphiti_core.driver.wal import WalWriter
+        from graphiti_core.driver.wal_dump import _dump_nodes
+
+        mock_driver = MagicMock()
+        mock_driver.execute_query = AsyncMock(
+            return_value=(
+                [
+                    {
+                        '_id': 2,
+                        '_labels': ['Episodic'],
+                        '_props': {
+                            'uuid': 'ep1',
+                            'name': 'Episode 1',
+                            'group_id': 'test',
+                            'source': 'text',
+                            'content': 'Hello world',
+                            'created_at': '2026-01-01T00:00:00Z',
+                            'valid_at': '2026-01-01T00:00:00Z',
+                        },
+                    },
+                ],
+                ['_id', '_labels', '_props'],
+                None,
+            )
+        )
+
+        wal_dir = tmp_path / 'wal'
+        wal = WalWriter(wal_dir)
+
+        count = await _dump_nodes(mock_driver, wal, 'test_db')
+        await wal.close()
+
+        assert count == 1
+
+        with open(list(wal_dir.glob('*.jsonl'))[0]) as f:
+            entry = json.loads(f.readline())
+
+        assert 'Episodic' in entry['cypher']
+        assert 'vecf32' not in entry['cypher']  # No embeddings on episodes
+
+    @pytest.mark.asyncio
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    async def test_skips_nodes_without_uuid(self, tmp_path):
+        from graphiti_core.driver.wal import WalWriter
+        from graphiti_core.driver.wal_dump import _dump_nodes
+
+        mock_driver = MagicMock()
+        mock_driver.execute_query = AsyncMock(
+            return_value=(
+                [{'_id': 1, '_labels': ['Orphan'], '_props': {'name': 'no uuid'}}],
+                ['_id', '_labels', '_props'],
+                None,
+            )
+        )
+
+        wal_dir = tmp_path / 'wal'
+        wal = WalWriter(wal_dir)
+
+        count = await _dump_nodes(mock_driver, wal, 'db')
+        await wal.close()
+
+        assert count == 0
+
+    @pytest.mark.asyncio
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    async def test_empty_database(self, tmp_path):
+        from graphiti_core.driver.wal import WalWriter
+        from graphiti_core.driver.wal_dump import _dump_nodes
+
+        mock_driver = MagicMock()
+        mock_driver.execute_query = AsyncMock(return_value=None)
+
+        wal_dir = tmp_path / 'wal'
+        wal = WalWriter(wal_dir)
+
+        count = await _dump_nodes(mock_driver, wal, 'db')
+        await wal.close()
+
+        assert count == 0
+
+
+class TestDumpRelationships:
+    """Test relationship dumping to WAL."""
+
+    @pytest.mark.asyncio
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    async def test_dumps_relates_to_edges(self, tmp_path):
+        from graphiti_core.driver.wal import WalWriter
+        from graphiti_core.driver.wal_dump import _dump_relationships
+
+        mock_driver = MagicMock()
+        mock_driver.execute_query = AsyncMock(
+            return_value=(
+                [
+                    {
+                        '_type': 'RELATES_TO',
+                        '_src_uuid': 'e1',
+                        '_dst_uuid': 'e2',
+                        '_props': {
+                            'uuid': 'r1',
+                            'name': 'knows',
+                            'fact': 'Alice knows Bob',
+                            'group_id': 'test',
+                            'created_at': '2026-01-01T00:00:00Z',
+                            'fact_embedding': [0.4, 0.5, 0.6],
+                        },
+                        '_src_labels': ['Entity'],
+                        '_dst_labels': ['Entity'],
+                    },
+                ],
+                ['_type', '_src_uuid', '_dst_uuid', '_props', '_src_labels', '_dst_labels'],
+                None,
+            )
+        )
+
+        wal_dir = tmp_path / 'wal'
+        wal = WalWriter(wal_dir)
+
+        count = await _dump_relationships(mock_driver, wal, 'test_db')
+        await wal.close()
+
+        assert count == 1
+
+        with open(list(wal_dir.glob('*.jsonl'))[0]) as f:
+            entry = json.loads(f.readline())
+
+        assert 'RELATES_TO' in entry['cypher']
+        assert 'vecf32($fact_embedding)' in entry['cypher']
+        assert entry['params']['src_uuid'] == 'e1'
+        assert entry['params']['dst_uuid'] == 'e2'
+        assert entry['params']['fact_embedding'] == [0.4, 0.5, 0.6]
+        # fact_embedding should NOT be in scalar props
+        assert 'fact_embedding' not in entry['params']['props']
+
+    @pytest.mark.asyncio
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    async def test_dumps_mentions_edges(self, tmp_path):
+        from graphiti_core.driver.wal import WalWriter
+        from graphiti_core.driver.wal_dump import _dump_relationships
+
+        mock_driver = MagicMock()
+        mock_driver.execute_query = AsyncMock(
+            return_value=(
+                [
+                    {
+                        '_type': 'MENTIONS',
+                        '_src_uuid': 'ep1',
+                        '_dst_uuid': 'e1',
+                        '_props': {
+                            'uuid': 'm1',
+                            'group_id': 'test',
+                            'created_at': '2026-01-01T00:00:00Z',
+                        },
+                        '_src_labels': ['Episodic'],
+                        '_dst_labels': ['Entity'],
+                    },
+                ],
+                ['_type', '_src_uuid', '_dst_uuid', '_props', '_src_labels', '_dst_labels'],
+                None,
+            )
+        )
+
+        wal_dir = tmp_path / 'wal'
+        wal = WalWriter(wal_dir)
+
+        count = await _dump_relationships(mock_driver, wal, 'test_db')
+        await wal.close()
+
+        assert count == 1
+
+        with open(list(wal_dir.glob('*.jsonl'))[0]) as f:
+            entry = json.loads(f.readline())
+
+        assert 'MENTIONS' in entry['cypher']
+        assert 'vecf32' not in entry['cypher']  # No embeddings on MENTIONS
+
+    @pytest.mark.asyncio
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    async def test_skips_relationships_without_endpoint_uuids(self, tmp_path):
+        from graphiti_core.driver.wal import WalWriter
+        from graphiti_core.driver.wal_dump import _dump_relationships
+
+        mock_driver = MagicMock()
+        mock_driver.execute_query = AsyncMock(
+            return_value=(
+                [
+                    {
+                        '_type': 'RELATES_TO',
+                        '_src_uuid': None,
+                        '_dst_uuid': 'e2',
+                        '_props': {'uuid': 'r1'},
+                        '_src_labels': ['Entity'],
+                        '_dst_labels': ['Entity'],
+                    },
+                ],
+                ['_type', '_src_uuid', '_dst_uuid', '_props', '_src_labels', '_dst_labels'],
+                None,
+            )
+        )
+
+        wal_dir = tmp_path / 'wal'
+        wal = WalWriter(wal_dir)
+
+        count = await _dump_relationships(mock_driver, wal, 'db')
+        await wal.close()
+
+        assert count == 0
+
+
+class TestDumpEndToEnd:
+    """Test full dump → replay cycle."""
+
+    @pytest.mark.asyncio
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    async def test_dump_then_dry_run_replay(self, tmp_path):
+        """Dump mock data, then verify replay can read it."""
+        from graphiti_core.driver.wal import WalWriter
+        from graphiti_core.driver.wal_dump import _dump_nodes, _dump_relationships
+        from graphiti_core.driver.wal_replay import replay_wal
+
+        mock_driver = MagicMock()
+
+        # First call returns nodes, second returns relationships
+        mock_driver.execute_query = AsyncMock(
+            side_effect=[
+                (
+                    [
+                        {
+                            '_id': 1,
+                            '_labels': ['Entity'],
+                            '_props': {
+                                'uuid': 'e1',
+                                'name': 'Alice',
+                                'group_id': 'g1',
+                                'created_at': '2026-01-01T00:00:00Z',
+                            },
+                        },
+                        {
+                            '_id': 2,
+                            '_labels': ['Entity'],
+                            '_props': {
+                                'uuid': 'e2',
+                                'name': 'Bob',
+                                'group_id': 'g1',
+                                'created_at': '2026-01-01T00:00:00Z',
+                            },
+                        },
+                    ],
+                    ['_id', '_labels', '_props'],
+                    None,
+                ),
+                (
+                    [
+                        {
+                            '_type': 'RELATES_TO',
+                            '_src_uuid': 'e1',
+                            '_dst_uuid': 'e2',
+                            '_props': {
+                                'uuid': 'r1',
+                                'name': 'knows',
+                                'fact': 'Alice knows Bob',
+                                'group_id': 'g1',
+                                'created_at': '2026-01-01T00:00:00Z',
+                            },
+                            '_src_labels': ['Entity'],
+                            '_dst_labels': ['Entity'],
+                        },
+                    ],
+                    ['_type', '_src_uuid', '_dst_uuid', '_props', '_src_labels', '_dst_labels'],
+                    None,
+                ),
+            ]
+        )
+
+        wal_dir = tmp_path / 'wal'
+        wal = WalWriter(wal_dir)
+
+        await _dump_nodes(mock_driver, wal, 'db')
+        await _dump_relationships(mock_driver, wal, 'db')
+        await wal.close()
+
+        # Verify replay reads the dumped data
+        count = await replay_wal(wal_dir, dry_run=True)
+        assert count == 3  # 2 nodes + 1 relationship
+
+    @pytest.mark.asyncio
+    @unittest.skipIf(not HAS_FALKORDB, 'FalkorDB is not installed')
+    async def test_dump_preserves_node_order_before_edges(self, tmp_path):
+        """Verify nodes come before edges in WAL output."""
+        from graphiti_core.driver.wal import WalWriter
+        from graphiti_core.driver.wal_dump import _dump_nodes, _dump_relationships
+
+        mock_driver = MagicMock()
+        mock_driver.execute_query = AsyncMock(
+            side_effect=[
+                (
+                    [
+                        {
+                            '_id': 1,
+                            '_labels': ['Entity'],
+                            '_props': {'uuid': 'e1', 'name': 'A'},
+                        },
+                    ],
+                    ['_id', '_labels', '_props'],
+                    None,
+                ),
+                (
+                    [
+                        {
+                            '_type': 'RELATES_TO',
+                            '_src_uuid': 'e1',
+                            '_dst_uuid': 'e1',
+                            '_props': {'uuid': 'r1'},
+                            '_src_labels': ['Entity'],
+                            '_dst_labels': ['Entity'],
+                        },
+                    ],
+                    ['_type', '_src_uuid', '_dst_uuid', '_props', '_src_labels', '_dst_labels'],
+                    None,
+                ),
+            ]
+        )
+
+        wal_dir = tmp_path / 'wal'
+        wal = WalWriter(wal_dir)
+
+        await _dump_nodes(mock_driver, wal, 'db')
+        await _dump_relationships(mock_driver, wal, 'db')
+        await wal.close()
+
+        with open(list(wal_dir.glob('*.jsonl'))[0]) as f:
+            entries = [json.loads(line) for line in f]
+
+        assert len(entries) == 2
+        assert 'MERGE (n:' in entries[0]['cypher']  # Node first
+        assert 'MERGE (src)-[r:' in entries[1]['cypher']  # Edge second

--- a/tests/driver/test_wal_replay.py
+++ b/tests/driver/test_wal_replay.py
@@ -1,0 +1,294 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import json
+
+import pytest
+
+from graphiti_core.driver.wal_replay import replay_wal
+
+
+def _write_wal_file(wal_dir, filename, entries):
+    """Helper to write a JSONL WAL file."""
+    path = wal_dir / filename
+    with open(path, 'w', encoding='utf-8') as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + '\n')
+    return path
+
+
+class TestReplayWalDryRun:
+    """Test WAL replay in dry-run mode (no FalkorDB dependency)."""
+
+    @pytest.mark.asyncio
+    async def test_dry_run_counts_mutations(self, tmp_path):
+        wal_dir = tmp_path / 'wal'
+        wal_dir.mkdir()
+
+        _write_wal_file(
+            wal_dir,
+            '20260324_000000_abc123_0000.jsonl',
+            [
+                {
+                    'seq': 0,
+                    'ts': '2026-03-24T00:00:00Z',
+                    'db': 'test_db',
+                    'cypher': 'CREATE (n:Test)',
+                    'params': {},
+                },
+                {
+                    'seq': 1,
+                    'ts': '2026-03-24T00:00:01Z',
+                    'db': 'test_db',
+                    'cypher': 'MERGE (n:Entity {uuid: $uuid})',
+                    'params': {'uuid': 'abc'},
+                },
+            ],
+        )
+
+        count = await replay_wal(wal_dir, dry_run=True)
+        assert count == 2
+
+    @pytest.mark.asyncio
+    async def test_dry_run_respects_from_seq(self, tmp_path):
+        wal_dir = tmp_path / 'wal'
+        wal_dir.mkdir()
+
+        _write_wal_file(
+            wal_dir,
+            '20260324_000000_abc123_0000.jsonl',
+            [
+                {
+                    'seq': 0,
+                    'ts': '2026-03-24T00:00:00Z',
+                    'db': 'db',
+                    'cypher': 'CREATE (n:First)',
+                    'params': {},
+                },
+                {
+                    'seq': 1,
+                    'ts': '2026-03-24T00:00:01Z',
+                    'db': 'db',
+                    'cypher': 'CREATE (n:Second)',
+                    'params': {},
+                },
+                {
+                    'seq': 2,
+                    'ts': '2026-03-24T00:00:02Z',
+                    'db': 'db',
+                    'cypher': 'CREATE (n:Third)',
+                    'params': {},
+                },
+            ],
+        )
+
+        count = await replay_wal(wal_dir, from_seq=2, dry_run=True)
+        assert count == 1
+
+    @pytest.mark.asyncio
+    async def test_dry_run_empty_directory(self, tmp_path):
+        wal_dir = tmp_path / 'wal'
+        wal_dir.mkdir()
+
+        count = await replay_wal(wal_dir, dry_run=True)
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_missing_directory_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            await replay_wal(tmp_path / 'nonexistent', dry_run=True)
+
+    @pytest.mark.asyncio
+    async def test_dry_run_multiple_files_in_order(self, tmp_path):
+        wal_dir = tmp_path / 'wal'
+        wal_dir.mkdir()
+
+        _write_wal_file(
+            wal_dir,
+            '20260324_000000_abc123_0000.jsonl',
+            [
+                {
+                    'seq': 0,
+                    'ts': '2026-03-24T00:00:00Z',
+                    'db': 'db',
+                    'cypher': 'CREATE (n:File1)',
+                    'params': {},
+                },
+            ],
+        )
+        _write_wal_file(
+            wal_dir,
+            '20260324_000100_abc123_0001.jsonl',
+            [
+                {
+                    'seq': 1,
+                    'ts': '2026-03-24T00:01:00Z',
+                    'db': 'db',
+                    'cypher': 'CREATE (n:File2)',
+                    'params': {},
+                },
+                {
+                    'seq': 2,
+                    'ts': '2026-03-24T00:01:01Z',
+                    'db': 'db',
+                    'cypher': 'CREATE (n:File2b)',
+                    'params': {},
+                },
+            ],
+        )
+
+        count = await replay_wal(wal_dir, dry_run=True)
+        assert count == 3
+
+    @pytest.mark.asyncio
+    async def test_dry_run_skips_blank_lines(self, tmp_path):
+        wal_dir = tmp_path / 'wal'
+        wal_dir.mkdir()
+
+        path = wal_dir / '20260324_000000_abc123_0000.jsonl'
+        with open(path, 'w') as f:
+            f.write(
+                json.dumps(
+                    {
+                        'seq': 0,
+                        'ts': '2026-03-24T00:00:00Z',
+                        'db': 'db',
+                        'cypher': 'CREATE (n:Test)',
+                        'params': {},
+                    }
+                )
+                + '\n'
+            )
+            f.write('\n')  # blank line
+            f.write('\n')  # another blank line
+            f.write(
+                json.dumps(
+                    {
+                        'seq': 1,
+                        'ts': '2026-03-24T00:00:01Z',
+                        'db': 'db',
+                        'cypher': 'CREATE (n:Test2)',
+                        'params': {},
+                    }
+                )
+                + '\n'
+            )
+
+        count = await replay_wal(wal_dir, dry_run=True)
+        assert count == 2
+
+    @pytest.mark.asyncio
+    async def test_dry_run_handles_malformed_json(self, tmp_path):
+        wal_dir = tmp_path / 'wal'
+        wal_dir.mkdir()
+
+        path = wal_dir / '20260324_000000_abc123_0000.jsonl'
+        with open(path, 'w') as f:
+            f.write(
+                json.dumps(
+                    {
+                        'seq': 0,
+                        'ts': '2026-03-24T00:00:00Z',
+                        'db': 'db',
+                        'cypher': 'CREATE (n:Good)',
+                        'params': {},
+                    }
+                )
+                + '\n'
+            )
+            f.write('{bad json\n')  # malformed
+            f.write(
+                json.dumps(
+                    {
+                        'seq': 2,
+                        'ts': '2026-03-24T00:00:02Z',
+                        'db': 'db',
+                        'cypher': 'CREATE (n:AlsoGood)',
+                        'params': {},
+                    }
+                )
+                + '\n'
+            )
+
+        # Should replay the valid entries and skip the bad one
+        count = await replay_wal(wal_dir, dry_run=True)
+        assert count == 2
+
+
+class TestReplayWalEndToEnd:
+    """Test full WAL write → replay cycle using WalWriter + dry-run replay."""
+
+    @pytest.mark.asyncio
+    async def test_write_then_replay_dry_run(self, tmp_path):
+        """Write mutations via WalWriter, then verify replay reads them correctly."""
+        from graphiti_core.driver.wal import WalWriter
+
+        wal_dir = tmp_path / 'wal'
+        writer = WalWriter(wal_dir)
+
+        await writer.log_mutation(
+            'MERGE (n:Entity {uuid: $uuid}) SET n.name = $name',
+            {'uuid': 'e1', 'name': 'Alice'},
+            database='mydb',
+        )
+        await writer.log_mutation(
+            'MERGE (n:Entity {uuid: $uuid}) SET n.name = $name',
+            {'uuid': 'e2', 'name': 'Bob'},
+            database='mydb',
+        )
+        # This should NOT appear in WAL (read-only)
+        await writer.log_mutation('MATCH (n) RETURN n', {}, database='mydb')
+        await writer.close()
+
+        count = await replay_wal(wal_dir, dry_run=True)
+        assert count == 2
+
+    @pytest.mark.asyncio
+    async def test_write_rotate_then_replay(self, tmp_path):
+        """Write enough to trigger rotation, then replay all files."""
+        from graphiti_core.driver.wal import WalWriter
+
+        wal_dir = tmp_path / 'wal'
+        writer = WalWriter(wal_dir, max_events_per_file=3)
+
+        for i in range(7):
+            await writer.log_mutation(
+                f'CREATE (n:Node{i})', {}, database='db'
+            )
+        await writer.close()
+
+        # Should have 3 files: 3 + 3 + 1
+        wal_files = sorted(wal_dir.glob('*.jsonl'))
+        assert len(wal_files) == 3
+
+        count = await replay_wal(wal_dir, dry_run=True)
+        assert count == 7
+
+    @pytest.mark.asyncio
+    async def test_partial_replay_with_from_seq(self, tmp_path):
+        """Write mutations, then replay only from a specific sequence."""
+        from graphiti_core.driver.wal import WalWriter
+
+        wal_dir = tmp_path / 'wal'
+        writer = WalWriter(wal_dir)
+
+        for i in range(5):
+            await writer.log_mutation(f'CREATE (n:Node{i})', {}, database='db')
+        await writer.close()
+
+        # Replay only seq >= 3
+        count = await replay_wal(wal_dir, from_seq=3, dry_run=True)
+        assert count == 2


### PR DESCRIPTION
Closes #9

# Write-Ahead Log (WAL) for FalkorDB Implementation Plan

## Overview

Implement a write-ahead log (WAL) system that captures all FalkorDB mutations as replayable JSONL files. This enables git-friendly backup of the knowledge graph without storing the 149MB binary database file.

## Current State Analysis

### Key Discoveries:
- **Two mutation paths confirmed**: `FalkorDriver.execute_query()` at line 222-253 and `FalkorDriverSession.run()` at lines 95-106 in `falkordb_driver.py`
- **Datetime serialization handled**: `convert_datetimes_to_strings()` in `utils/datetime_utils.py:45-55` already converts datetimes to ISO 8601
- **`clone()` creates new instance**: Must explicitly pass `wal_writer` parameter (unlike `with_database()` which uses shallow copy)
- **Two driver usage patterns**: Instance replacement (`graphiti.py:886-890`) and temporary concurrent clones (`decorators.py:47-68`)
- **Test patterns established**: `tests/driver/test_falkordb_driver.py` uses `@pytest.mark.asyncio`, `AsyncMock`, `MagicMock`

## Desired End State

After implementation:
1. FalkorDriver accepts optional `wal_dir` parameter to enable WAL logging
2. All mutations (CREATE, MERGE, SET, DELETE, DETACH, DROP, REMOVE) are captured to JSONL files
3. Index DDL operations are excluded (handled separately by `build_indices_and_constraints()`)
4. WAL files can be replayed to reconstruct the database from scratch
5. `.graphiti/db` can be gitignored; `.graphiti/wal/` becomes the git-tracked source of truth

**Verification**: Run `make test` — all existing tests pass. New WAL tests verify mutation detection, file rotation, and replay functionality.

## What We're NOT Doing

- **No compression** — git's delta compression is sufficient
- **No encryption** — WAL files contain the same data as the database
- **No Neo4j driver changes** — WAL is FalkorDB-specific for now
- **No automatic WAL cleanup/compaction** — files are immutable once written
- **No liminis-framework changes in this PR** — that's a separate downstream task (documented in Step 7)

## Implementation Approach

The WAL is implemented as an optional feature enabled by passing `wal_dir` to `FalkorDriver.__init__()`. The `WalWriter` class handles all file I/O with async locking for concurrency safety. Mutations are logged after successful execution to ensure only committed operations are recorded.

---

### TASK 1: Create WalWriter Class [HIGH PRIORITY]
**Status:** COMPLETE
**Milestone:** WalWriter class exists with mutation detection, JSONL writing, and file rotation

- [x] Create `graphiti_core/driver/wal.py` module
- [x] Implement `WalWriter.__init__(wal_dir, max_events_per_file=10_000)`
- [x] Implement `is_mutation(cypher)` static method — detect CREATE/MERGE/SET/DELETE/DETACH/DROP/REMOVE
- [x] Implement `is_index_ddl(cypher)` static method — detect CREATE INDEX, CREATE FULLTEXT INDEX, DROP INDEX, CALL db.idx.fulltext
- [x] Implement `log_mutation(cypher, params, database)` async method with filtering
- [x] Implement file rotation when `max_events_per_file` reached
- [x] Implement sequence number continuity — scan existing files on startup
- [x] Implement `close()` async method — flush and close current file (idempotent)
- [x] Add `asyncio.Lock` for thread-safe concurrent writes

**Validation:** Unit tests in `tests/driver/test_wal.py` pass for `is_mutation()`, `is_index_ddl()`, file rotation, and sequence continuity

**Requirements from spec:**
- File naming: `{timestamp}_{session_uuid_short}_{file_seq:04d}.jsonl`
- JSONL format: `{"seq": N, "ts": "ISO8601", "db": "database_name", "cypher": "...", "params": {...}}`
- Mutation keywords: CREATE, MERGE, SET, DELETE, DETACH, DROP, REMOVE (case-insensitive)
- Index exclusion patterns: `CREATE INDEX`, `CREATE FULLTEXT INDEX`, `DROP INDEX`, `DROP FULLTEXT INDEX`, `CALL db.idx.fulltext.createNodeIndex`

**Files to Create:**
- `graphiti_core/driver/wal.py` — WalWriter class with all mutation detection and file I/O logic

**Implementation Details:**
```python
class WalWriter:
    def __init__(self, wal_dir: str | Path, max_events_per_file: int = 10_000):
        self._wal_dir = Path(wal_dir)
        self._max_events = max_events_per_file
        self._lock = asyncio.Lock()
        self._file: aiofiles.threadpool.AsyncTextIOWrapper | None = None
        self._current_seq = 0
        self._events_in_file = 0
        self._session_id = uuid.uuid4().hex[:6]
        self._file_seq = 0
        self._closed = False
        # Scan for existing seq on init
        
    @staticmethod
    def is_mutation(cypher: str) -> bool:
        # Strip string literals, check for keywords case-insensitively
        
    @staticmethod
    def is_index_ddl(cypher: str) -> bool:
        # Check for index-related patterns
        
    async def log_mutation(self, cypher: str, params: dict, database: str) -> None:
        if not self.is_mutation(cypher) or self.is_index_ddl(cypher):
            return
        # Write JSONL line with seq, ts, db, cypher, params
        
    async def close(self) -> None:
        # Idempotent close — flush and set _closed flag
```

---

### TASK 2: Integrate WAL into FalkorDriver [HIGH PRIORITY]
**Status:** COMPLETE
**Milestone:** FalkorDriver accepts `wal_dir`/`wal_writer` params and logs mutations from `execute_query()`

- [x] Add `wal_dir: str | Path | None = None` parameter to `FalkorDriver.__init__()`
- [x] Add `wal_writer: WalWriter | None = None` parameter to `FalkorDriver.__init__()`
- [x] Initialize `self._wal` based on parameters (create new or reuse)
- [x] Import `WalWriter` conditionally to avoid circular imports
- [x] Instrument `execute_query()` — call `log_mutation()` after successful `graph.query()`
- [x] Update `close()` — call `await self._wal.close()` if WAL enabled

**Validation:** Existing `test_falkordb_driver.py` tests still pass; manual test shows WAL files created when `wal_dir` provided

**Requirements from spec:**
- `wal_dir` provided → create new `WalWriter(wal_dir)`
- `wal_writer` provided → reuse it (for clones)
- Neither → WAL disabled (`self._wal = None`)
- Log after successful execution only

**Files to Modify:**
- `graphiti_core/driver/falkordb_driver.py` — lines 115-168 (`__init__`), lines 222-236 (`execute_query`), lines 258-265 (`close`)

**Implementation Details:**
```python
# In __init__:
self._wal: WalWriter | None = None
if wal_writer is not None:
    self._wal = wal_writer
elif wal_dir is not None:
    from graphiti_core.driver.wal import WalWriter
    self._wal = WalWriter(wal_dir)

# In execute_query, after line 229:
if self._wal is not None:
    await self._wal.log_mutation(cypher_query_, params, database=self._database)

# In close:
if self._wal is not None:
    await self._wal.close()
```

---

### TASK 3: Integrate WAL into FalkorDriverSession [HIGH PRIORITY]
**Status:** COMPLETE
**Milestone:** Session-based mutations are logged to WAL

- [x] Add `wal: WalWriter | None = None` parameter to `FalkorDriverSession.__init__()`
- [x] Add `database: str | None = None` parameter to `FalkorDriverSession.__init__()`
- [x] Store as `self._wal` and `self._database` instance variables
- [x] Update `FalkorDriver.session()` to pass `wal=self._wal, database=database or self._database`
- [x] Instrument `run()` — call `log_mutation()` after each successful `graph.query()` in both branches

**Validation:** Session-based operations (list queries) are logged to WAL

**Requirements from spec:**
- Session must receive WAL and database from parent driver
- Both single-query and list-query branches in `run()` must log mutations

**Files to Modify:**
- `graphiti_core/driver/falkordb_driver.py` — lines 74-77 (`FalkorDriverSession.__init__`), lines 95-106 (`run`), lines 255-256 (`session`)

**Implementation Details:**
```python
# FalkorDriverSession.__init__:
def __init__(self, graph: FalkorGraph, wal: WalWriter | None = None, database: str | None = None):
    self.graph = graph
    self._wal = wal
    self._database = database

# FalkorDriverSession.run, after each graph.query():
if self._wal is not None:
    await self._wal.log_mutation(str(cypher), params, database=self._database or '')

# FalkorDriver.session:
def session(self, database: str | None = None) -> GraphDriverSession:
    return FalkorDriverSession(
        self._get_graph(database),
        wal=self._wal,
        database=database or self._database
    )
```

---

### TASK 4: Update clone() to Share WAL [HIGH PRIORITY]
**Status:** COMPLETE
**Milestone:** Cloned drivers share the same WAL instance

- [x] Update `clone()` method to pass `wal_writer=self._wal` when creating new FalkorDriver instances
- [x] Handle all three branches: same database, default_group_id, and custom database

**Validation:** Cloned driver mutations appear in the same WAL files as parent driver

**Requirements from spec:**
- All cloned drivers write to the same WAL with their respective `database` field
- `with_database()` already works via shallow copy — no changes needed

**Files to Modify:**
- `graphiti_core/driver/falkordb_driver.py` — lines 306-319 (`clone`)

**Implementation Details:**
```python
def clone(self, database: str) -> 'GraphDriver':
    if database == self._database:
        cloned = self
    elif database == self.default_group_id:
        cloned = FalkorDriver(falkor_db=self.client, wal_writer=self._wal)
    else:
        cloned = FalkorDriver(falkor_db=self.client, database=database, wal_writer=self._wal)
    return cloned
```

---

### TASK 5: Create WAL Replay Script [MEDIUM PRIORITY]
**Status:** COMPLETE
**Milestone:** CLI script can replay WAL files to reconstruct database

- [ ] Create `graphiti_core/driver/wal_replay.py` module
- [ ] Implement `replay_wal(wal_dir, host, port, database, from_seq, dry_run)` async function
- [ ] Read all `.jsonl` files sorted by filename
- [ ] Parse each line and execute cypher against appropriate database
- [ ] Support `from_seq` for partial replay / resume
- [ ] Support `dry_run` mode that prints queries without executing
- [ ] Support optional `database_mapping` for remapping database names
- [ ] Call `build_indices_and_constraints()` before replay
- [ ] Add CLI entry point with argparse

**Validation:** Replay empty DB with WAL files → query results match original DB

**Requirements from spec:**
- Connect to fresh FalkorDB with WAL disabled
- Build indices first
- Execute events in sequence order
- Skip events with `seq < from_seq`

**Files to Create:**
- `graphiti_core/driver/wal_replay.py` — replay function + CLI

**Implementation Details:**
```python
async def replay_wal(
    wal_dir: str | Path,
    host: str = 'localhost',
    port: int = 6379,
    database: str | None = None,
    database_mapping: dict[str, str] | None = None,
    from_seq: int = 0,
    dry_run: bool = False,
) -> int:
    """Replay WAL files to reconstruct database. Returns count of events replayed."""
    
if __name__ == '__main__':
    import argparse
    parser = argparse.ArgumentParser(description='Replay WAL files to FalkorDB')
    parser.add_argument('wal_dir', help='Directory containing WAL files')
    parser.add_argument('--host', default='localhost')
    parser.add_argument('--port', type=int, default=6379)
    parser.add_argument('--database', help='Target database (default: use db from events)')
    parser.add_argument('--from-seq', type=int, default=0, help='Start from sequence number')
    parser.add_argument('--dry-run', action='store_true', help='Print queries without executing')
    # ...
```

---

### TASK 6: Write Unit Tests [MEDIUM PRIORITY]
**Status:** COMPLETE
**Milestone:** Comprehensive test coverage for WAL functionality

- [ ] Create `tests/driver/test_wal.py`
- [ ] Test `is_mutation()` with various query types (MATCH, CREATE, MERGE, SET, DELETE, etc.)
- [ ] Test `is_index_ddl()` with all index patterns from `graph_queries.py`
- [ ] Test file rotation after `max_events_per_file`
- [ ] Test sequence continuity across file boundaries
- [ ] Test sequence continuity on restart (scan existing files)
- [ ] Test concurrent writes don't interleave
- [ ] Test `close()` idempotency
- [ ] Test WAL integration in FalkorDriver (mock-based)
- [ ] Test WAL integration in FalkorDriverSession (mock-based)
- [ ] Test clone() shares WAL instance

**Validation:** `make test` passes, new tests provide >90% coverage of WAL code

**Requirements from spec:**
- Follow existing patterns from `test_falkordb_driver.py`
- Use `@pytest.mark.asyncio`, `AsyncMock`, `MagicMock`
- Use temp directories for file-based tests

**Files to Create:**
- `tests/driver/test_wal.py` — comprehensive unit tests

**Implementation Details:**
Test categories:
1. `TestIsMutation` — query classification
2. `TestIsIndexDDL` — index DDL detection
3. `TestWalWriter` — file operations, rotation, sequence
4. `TestWalDriverIntegration` — mock-based driver integration
5. `TestWalReplay` — replay functionality

---

### TASK 7: Integration Testing [LOW PRIORITY]
**Status:** COMPLETE
**Milestone:** End-to-end WAL capture and replay verified

- [ ] Create integration test that requires FalkorDB connection
- [ ] Start driver with WAL enabled
- [ ] Execute various mutations (create entities, edges, delete)
- [ ] Verify WAL files contain expected mutations
- [ ] Replay to fresh database
- [ ] Compare query results between original and replayed DB

**Validation:** Integration test passes with real FalkorDB instance

**Requirements from spec:**
- Mark with `@unittest.skipIf(not HAS_FALKORDB, ...)`
- Use `pytest.importorskip('falkordb')`
- Use temp directory for WAL files

**Files to Modify:**
- `tests/driver/test_wal.py` — add integration test class

---

## Testing Strategy

### Unit Tests:
- `is_mutation()` correctly classifies: MATCH (false), CREATE (true), MERGE (true), SET (true), DELETE (true), DETACH DELETE (true), DROP (true), REMOVE (true)
- `is_index_ddl()` detects: CREATE INDEX FOR, CREATE FULLTEXT INDEX, DROP INDEX ON, DROP FULLTEXT INDEX, CALL db.idx.fulltext.createNodeIndex
- File rotation creates new file after `max_events_per_file`
- Sequence numbers are monotonic across files
- Sequence numbers survive restart by scanning existing files
- `close()` is idempotent — multiple calls don't error

### Integration Tests:
- WAL files created when `wal_dir` passed to FalkorDriver
- Mutations logged, reads not logged
- Index DDL not logged
- Replay reconstructs semantically equivalent database

### Manual Testing Steps:
1. Start FalkorDB locally: `docker run -p 6379:6379 falkordb/falkordb`
2. Create driver with `wal_dir='/tmp/test_wal'`
3. Execute `driver.execute_query("CREATE (n:Test {name: 'test'})")`
4. Verify `/tmp/test_wal/*.jsonl` contains the mutation
5. Drop database, replay WAL
6. Query for test node — should exist

## Performance Considerations

- **Write overhead**: Minimal — async file writes with buffering
- **WAL file size**: ~15-20KB per entity mutation (with 1024-dim embeddings), ~0.5-1KB for other mutations
- **Concurrency**: `asyncio.Lock` prevents interleaved writes but serializes logging (acceptable given I/O bottleneck)
- **Git efficiency**: Small, append-only files delta-compress well in packfiles

## Migration Notes

- No migration needed — WAL is opt-in via `wal_dir` parameter
- Existing deployments without WAL continue to work unchanged
- To enable: pass `wal_dir` when constructing `FalkorDriver`
- Downstream task (liminis-framework): Update `graphiti_service.py` line ~462 to pass `wal_dir`

---

*This PR uses iterative implementation. Tasks are completed one at a time.*


