### PR TITLE
fix: deserialize WAL timestamp strings for LadybugDB replay

### DIFF
--- a/graphiti_core/driver/ladybug_driver.py
+++ b/graphiti_core/driver/ladybug_driver.py
@@ -361,6 +361,45 @@ class LadybugDriverSession(GraphDriverSession):
         return None
 
 
+import re
+
+# ISO-8601 pattern for detecting timestamp strings in WAL params
+_ISO_TS_RE = re.compile(
+    r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$'
+)
+
+# Known timestamp field names in the graphiti schema
+_TIMESTAMP_FIELDS = frozenset({
+    'created_at', 'valid_at', 'invalid_at', 'expired_at',
+})
+
+
+def _deserialize_wal_params(params: dict[str, Any]) -> dict[str, Any]:
+    """Convert WAL JSON params back to Python types for LadybugDB.
+
+    WAL serializes datetime objects as ISO-8601 strings. LadybugDB (Kuzu)
+    requires native datetime objects for TIMESTAMP columns. This function
+    detects timestamp fields and converts them back.
+    """
+    converted = {}
+    for key, value in params.items():
+        if (
+            isinstance(value, str)
+            and key in _TIMESTAMP_FIELDS
+            and _ISO_TS_RE.match(value)
+        ):
+            try:
+                dt = datetime.fromisoformat(value.replace('Z', '+00:00'))
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                converted[key] = dt
+                continue
+            except (ValueError, TypeError):
+                pass  # Fall through to keep as string
+        converted[key] = value
+    return converted
+
+
 async def replay_wal_ladybug(
     wal_dir: str | Path,
     db: str,
@@ -424,7 +463,7 @@ async def replay_wal_ladybug(
                         continue
 
                     cypher = entry['cypher']
-                    params = entry.get('params', {})
+                    params = _deserialize_wal_params(entry.get('params', {}))
 
                     if dry_run:
                         logger.debug('DRY RUN seq=%d: %s', seq, cypher[:80])


### PR DESCRIPTION
## Summary

- WAL entries serialize `datetime` objects as ISO-8601 strings in JSON
- LadybugDB (Kuzu) requires native Python `datetime` objects for TIMESTAMP columns
- `replay_wal_ladybug` now converts known timestamp fields (`created_at`, `valid_at`, `invalid_at`, `expired_at`) back to `datetime` before execution

Without this fix, `replay_wal_ladybug` fails on every entry containing timestamps:
```
Binder exception: Expression $created_at has data type STRING but expected TIMESTAMP.
Implicit cast is not supported.
```

## Test plan

- [x] Tested with real WAL file (22 mutations): `Restored 22 mutations` with 0 errors
- [ ] Run existing WAL tests: `pytest tests/driver/test_wal_replay.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)