### PR TITLE
Fix live writes when HNSW indexes are present (rebased onto liminis)

### DIFF
--- a/examples/gliner2/gliner2_neo4j.py
+++ b/examples/gliner2/gliner2_neo4j.py
@@ -210,8 +210,8 @@ async def main():
                 'content': (
                     'Kamala Harris a été procureure générale de Californie de 2011 à 2017. '
                     'Avant cela, elle a occupé le poste de procureure du district de '
-                    'San Francisco. Elle est diplômée de l\'Université Howard et a obtenu '
-                    'son diplôme de droit au Hastings College of the Law de l\'Université de '
+                    "San Francisco. Elle est diplômée de l'Université Howard et a obtenu "
+                    "son diplôme de droit au Hastings College of the Law de l'Université de "
                     'Californie. En tant que procureure générale, elle a négocié un accord '
                     'national de 25 milliards de dollars avec les grandes banques américaines.'
                 ),

--- a/graphiti_core/driver/kuzu/hnsw_safe_writes.py
+++ b/graphiti_core/driver/kuzu/hnsw_safe_writes.py
@@ -1,0 +1,375 @@
+"""HNSW-safe write helpers for KuzuDB/LadybugDB.
+
+KuzuDB does not allow SET on columns that have HNSW vector indexes.
+These helpers replace the MERGE+SET pattern with DELETE+INSERT,
+preserving relationships across the delete-create cycle.
+"""
+
+import logging
+from typing import Any
+
+from graphiti_core.driver.driver import GraphDriverSession
+from graphiti_core.driver.query_executor import QueryExecutor, Transaction
+
+TxLike = Transaction | GraphDriverSession | None
+
+logger = logging.getLogger(__name__)
+
+
+async def _query(
+    executor: QueryExecutor,
+    query: str,
+    **kwargs: Any,
+) -> list[dict[str, Any]]:
+    records, _, _ = await executor.execute_query(query, **kwargs)
+    return records  # type: ignore
+
+
+async def _write(
+    executor: QueryExecutor,
+    tx: TxLike,
+    query: str,
+    **kwargs: Any,
+) -> None:
+    if tx is not None:
+        await tx.run(query, **kwargs)  # type: ignore[union-attr]
+    else:
+        await executor.execute_query(query, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Entity Edge (RelatesToNode_)
+# ---------------------------------------------------------------------------
+# Simplest case: source_uuid and target_uuid are already in save params,
+# so no relationship backup is needed.
+
+
+async def hnsw_safe_save_entity_edge(
+    executor: QueryExecutor,
+    tx: TxLike,
+    params: dict[str, Any],
+) -> None:
+    uuid = params['uuid']
+
+    existing = await _query(
+        executor,
+        'MATCH (e:RelatesToNode_ {uuid: $uuid}) RETURN e.uuid AS uuid',
+        uuid=uuid,
+    )
+
+    if existing:
+        await _write(
+            executor,
+            tx,
+            'MATCH (e:RelatesToNode_ {uuid: $uuid}) DETACH DELETE e',
+            uuid=uuid,
+        )
+
+    await _write(
+        executor,
+        tx,
+        """
+        CREATE (e:RelatesToNode_ {
+            uuid: $uuid,
+            group_id: $group_id,
+            created_at: $created_at,
+            name: $name,
+            fact: $fact,
+            fact_embedding: $fact_embedding,
+            episodes: $episodes,
+            expired_at: $expired_at,
+            valid_at: $valid_at,
+            invalid_at: $invalid_at,
+            attributes: $attributes
+        })
+        """,
+        **params,
+    )
+
+    await _write(
+        executor,
+        tx,
+        """
+        MATCH (source:Entity {uuid: $source_uuid}), (e:RelatesToNode_ {uuid: $uuid})
+        CREATE (source)-[:RELATES_TO]->(e)
+        """,
+        source_uuid=params['source_uuid'],
+        uuid=uuid,
+    )
+
+    await _write(
+        executor,
+        tx,
+        """
+        MATCH (e:RelatesToNode_ {uuid: $uuid}), (target:Entity {uuid: $target_uuid})
+        CREATE (e)-[:RELATES_TO]->(target)
+        """,
+        uuid=uuid,
+        target_uuid=params['target_uuid'],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entity Node
+# ---------------------------------------------------------------------------
+
+
+async def hnsw_safe_save_entity_node(
+    executor: QueryExecutor,
+    tx: TxLike,
+    params: dict[str, Any],
+) -> None:
+    uuid = params['uuid']
+
+    existing = await _query(
+        executor,
+        'MATCH (n:Entity {uuid: $uuid}) RETURN n.uuid AS uuid',
+        uuid=uuid,
+    )
+
+    if existing:
+        mentions = await _query(
+            executor,
+            """
+            MATCH (ep:Episodic)-[m:MENTIONS]->(n:Entity {uuid: $uuid})
+            RETURN ep.uuid AS episode_uuid, m.uuid AS mention_uuid,
+                   m.group_id AS group_id, m.created_at AS created_at
+            """,
+            uuid=uuid,
+        )
+
+        relates_to_outgoing = await _query(
+            executor,
+            """
+            MATCH (n:Entity {uuid: $uuid})-[:RELATES_TO]->(r:RelatesToNode_)
+            RETURN r.uuid AS relates_to_node_uuid
+            """,
+            uuid=uuid,
+        )
+
+        relates_to_incoming = await _query(
+            executor,
+            """
+            MATCH (r:RelatesToNode_)-[:RELATES_TO]->(n:Entity {uuid: $uuid})
+            RETURN r.uuid AS relates_to_node_uuid
+            """,
+            uuid=uuid,
+        )
+
+        has_member = await _query(
+            executor,
+            """
+            MATCH (c:Community)-[h:HAS_MEMBER]->(n:Entity {uuid: $uuid})
+            RETURN c.uuid AS community_uuid, h.uuid AS member_uuid,
+                   h.group_id AS group_id, h.created_at AS created_at
+            """,
+            uuid=uuid,
+        )
+
+        await _write(
+            executor,
+            tx,
+            'MATCH (n:Entity {uuid: $uuid}) DETACH DELETE n',
+            uuid=uuid,
+        )
+    else:
+        mentions = []
+        relates_to_outgoing = []
+        relates_to_incoming = []
+        has_member = []
+
+    await _write(
+        executor,
+        tx,
+        """
+        CREATE (n:Entity {
+            uuid: $uuid,
+            name: $name,
+            group_id: $group_id,
+            labels: $labels,
+            created_at: $created_at,
+            name_embedding: $name_embedding,
+            summary: $summary,
+            attributes: $attributes
+        })
+        """,
+        **params,
+    )
+
+    for m in mentions:
+        await _write(
+            executor,
+            tx,
+            """
+            MATCH (ep:Episodic {uuid: $episode_uuid}), (n:Entity {uuid: $uuid})
+            CREATE (ep)-[:MENTIONS {uuid: $mention_uuid, group_id: $group_id, created_at: $created_at}]->(n)
+            """,
+            uuid=uuid,
+            episode_uuid=m['episode_uuid'],
+            mention_uuid=m['mention_uuid'],
+            group_id=m['group_id'],
+            created_at=m['created_at'],
+        )
+
+    for r in relates_to_outgoing:
+        await _write(
+            executor,
+            tx,
+            """
+            MATCH (n:Entity {uuid: $uuid}), (r:RelatesToNode_ {uuid: $relates_to_node_uuid})
+            CREATE (n)-[:RELATES_TO]->(r)
+            """,
+            uuid=uuid,
+            relates_to_node_uuid=r['relates_to_node_uuid'],
+        )
+
+    for r in relates_to_incoming:
+        await _write(
+            executor,
+            tx,
+            """
+            MATCH (r:RelatesToNode_ {uuid: $relates_to_node_uuid}), (n:Entity {uuid: $uuid})
+            CREATE (r)-[:RELATES_TO]->(n)
+            """,
+            uuid=uuid,
+            relates_to_node_uuid=r['relates_to_node_uuid'],
+        )
+
+    for h in has_member:
+        await _write(
+            executor,
+            tx,
+            """
+            MATCH (c:Community {uuid: $community_uuid}), (n:Entity {uuid: $uuid})
+            CREATE (c)-[:HAS_MEMBER {uuid: $member_uuid, group_id: $group_id, created_at: $created_at}]->(n)
+            """,
+            uuid=uuid,
+            community_uuid=h['community_uuid'],
+            member_uuid=h['member_uuid'],
+            group_id=h['group_id'],
+            created_at=h['created_at'],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Community Node
+# ---------------------------------------------------------------------------
+
+
+async def hnsw_safe_save_community_node(
+    executor: QueryExecutor,
+    tx: TxLike,
+    params: dict[str, Any],
+) -> None:
+    uuid = params['uuid']
+
+    existing = await _query(
+        executor,
+        'MATCH (c:Community {uuid: $uuid}) RETURN c.uuid AS uuid',
+        uuid=uuid,
+    )
+
+    if existing:
+        has_member_to_entity = await _query(
+            executor,
+            """
+            MATCH (c:Community {uuid: $uuid})-[h:HAS_MEMBER]->(n:Entity)
+            RETURN n.uuid AS entity_uuid, h.uuid AS member_uuid,
+                   h.group_id AS group_id, h.created_at AS created_at
+            """,
+            uuid=uuid,
+        )
+
+        has_member_to_community = await _query(
+            executor,
+            """
+            MATCH (c:Community {uuid: $uuid})-[h:HAS_MEMBER]->(child:Community)
+            WHERE child.uuid <> $uuid
+            RETURN child.uuid AS child_uuid, h.uuid AS member_uuid,
+                   h.group_id AS group_id, h.created_at AS created_at
+            """,
+            uuid=uuid,
+        )
+
+        has_member_from_community = await _query(
+            executor,
+            """
+            MATCH (parent:Community)-[h:HAS_MEMBER]->(c:Community {uuid: $uuid})
+            WHERE parent.uuid <> $uuid
+            RETURN parent.uuid AS parent_uuid, h.uuid AS member_uuid,
+                   h.group_id AS group_id, h.created_at AS created_at
+            """,
+            uuid=uuid,
+        )
+
+        await _write(
+            executor,
+            tx,
+            'MATCH (c:Community {uuid: $uuid}) DETACH DELETE c',
+            uuid=uuid,
+        )
+    else:
+        has_member_to_entity = []
+        has_member_to_community = []
+        has_member_from_community = []
+
+    await _write(
+        executor,
+        tx,
+        """
+        CREATE (c:Community {
+            uuid: $uuid,
+            name: $name,
+            group_id: $group_id,
+            created_at: $created_at,
+            name_embedding: $name_embedding,
+            summary: $summary
+        })
+        """,
+        **params,
+    )
+
+    for h in has_member_to_entity:
+        await _write(
+            executor,
+            tx,
+            """
+            MATCH (c:Community {uuid: $uuid}), (n:Entity {uuid: $entity_uuid})
+            CREATE (c)-[:HAS_MEMBER {uuid: $member_uuid, group_id: $group_id, created_at: $created_at}]->(n)
+            """,
+            uuid=uuid,
+            entity_uuid=h['entity_uuid'],
+            member_uuid=h['member_uuid'],
+            group_id=h['group_id'],
+            created_at=h['created_at'],
+        )
+
+    for h in has_member_to_community:
+        await _write(
+            executor,
+            tx,
+            """
+            MATCH (c:Community {uuid: $uuid}), (child:Community {uuid: $child_uuid})
+            CREATE (c)-[:HAS_MEMBER {uuid: $member_uuid, group_id: $group_id, created_at: $created_at}]->(child)
+            """,
+            uuid=uuid,
+            child_uuid=h['child_uuid'],
+            member_uuid=h['member_uuid'],
+            group_id=h['group_id'],
+            created_at=h['created_at'],
+        )
+
+    for h in has_member_from_community:
+        await _write(
+            executor,
+            tx,
+            """
+            MATCH (parent:Community {uuid: $parent_uuid}), (c:Community {uuid: $uuid})
+            CREATE (parent)-[:HAS_MEMBER {uuid: $member_uuid, group_id: $group_id, created_at: $created_at}]->(c)
+            """,
+            uuid=uuid,
+            parent_uuid=h['parent_uuid'],
+            member_uuid=h['member_uuid'],
+            group_id=h['group_id'],
+            created_at=h['created_at'],
+        )

--- a/graphiti_core/driver/kuzu/hnsw_safe_writes.py
+++ b/graphiti_core/driver/kuzu/hnsw_safe_writes.py
@@ -21,6 +21,7 @@ async def _query(
     query: str,
     **kwargs: Any,
 ) -> list[dict[str, Any]]:
+    # Always uses executor (not tx) because KuzuDB tx.run() doesn't return results.
     records, _, _ = await executor.execute_query(query, **kwargs)
     return records  # type: ignore
 
@@ -50,20 +51,15 @@ async def hnsw_safe_save_entity_edge(
     params: dict[str, Any],
 ) -> None:
     uuid = params['uuid']
+    source_uuid = params.get('source_uuid') or params['source_node_uuid']
+    target_uuid = params.get('target_uuid') or params['target_node_uuid']
 
-    existing = await _query(
+    await _write(
         executor,
-        'MATCH (e:RelatesToNode_ {uuid: $uuid}) RETURN e.uuid AS uuid',
+        tx,
+        'MATCH (e:RelatesToNode_ {uuid: $uuid}) DETACH DELETE e',
         uuid=uuid,
     )
-
-    if existing:
-        await _write(
-            executor,
-            tx,
-            'MATCH (e:RelatesToNode_ {uuid: $uuid}) DETACH DELETE e',
-            uuid=uuid,
-        )
 
     await _write(
         executor,
@@ -90,22 +86,13 @@ async def hnsw_safe_save_entity_edge(
         executor,
         tx,
         """
-        MATCH (source:Entity {uuid: $source_uuid}), (e:RelatesToNode_ {uuid: $uuid})
-        CREATE (source)-[:RELATES_TO]->(e)
+        MATCH (source:Entity {uuid: $source_uuid}), (e:RelatesToNode_ {uuid: $uuid}),
+              (target:Entity {uuid: $target_uuid})
+        CREATE (source)-[:RELATES_TO]->(e), (e)-[:RELATES_TO]->(target)
         """,
-        source_uuid=params['source_uuid'],
+        source_uuid=source_uuid,
         uuid=uuid,
-    )
-
-    await _write(
-        executor,
-        tx,
-        """
-        MATCH (e:RelatesToNode_ {uuid: $uuid}), (target:Entity {uuid: $target_uuid})
-        CREATE (e)-[:RELATES_TO]->(target)
-        """,
-        uuid=uuid,
-        target_uuid=params['target_uuid'],
+        target_uuid=target_uuid,
     )
 
 

--- a/graphiti_core/driver/kuzu/hnsw_safe_writes.py
+++ b/graphiti_core/driver/kuzu/hnsw_safe_writes.py
@@ -360,3 +360,159 @@ async def hnsw_safe_save_community_node(
             group_id=h['group_id'],
             created_at=h['created_at'],
         )
+
+
+# ---------------------------------------------------------------------------
+# Episodic Node
+# ---------------------------------------------------------------------------
+# Episodic.content_embedding is HNSW-indexed, so MERGE+SET fails on it.
+# Outgoing: MENTIONS->Entity, NEXT_EPISODE->Episodic
+# Incoming: NEXT_EPISODE from Episodic, HAS_EPISODE from Saga
+
+
+async def hnsw_safe_save_episode_node(
+    executor: QueryExecutor,
+    tx: TxLike,
+    params: dict[str, Any],
+) -> None:
+    uuid = params['uuid']
+
+    existing = await _query(
+        executor,
+        'MATCH (n:Episodic {uuid: $uuid}) RETURN n.uuid AS uuid',
+        uuid=uuid,
+    )
+
+    if existing:
+        mentions = await _query(
+            executor,
+            """
+            MATCH (ep:Episodic {uuid: $uuid})-[m:MENTIONS]->(n:Entity)
+            RETURN n.uuid AS entity_uuid, m.uuid AS mention_uuid,
+                   m.group_id AS group_id, m.created_at AS created_at
+            """,
+            uuid=uuid,
+        )
+
+        next_episode_outgoing = await _query(
+            executor,
+            """
+            MATCH (ep:Episodic {uuid: $uuid})-[e:NEXT_EPISODE]->(target:Episodic)
+            RETURN target.uuid AS target_uuid, e.uuid AS edge_uuid,
+                   e.group_id AS group_id, e.created_at AS created_at
+            """,
+            uuid=uuid,
+        )
+
+        next_episode_incoming = await _query(
+            executor,
+            """
+            MATCH (source:Episodic)-[e:NEXT_EPISODE]->(ep:Episodic {uuid: $uuid})
+            WHERE source.uuid <> $uuid
+            RETURN source.uuid AS source_uuid, e.uuid AS edge_uuid,
+                   e.group_id AS group_id, e.created_at AS created_at
+            """,
+            uuid=uuid,
+        )
+
+        has_episode = await _query(
+            executor,
+            """
+            MATCH (s:Saga)-[e:HAS_EPISODE]->(ep:Episodic {uuid: $uuid})
+            RETURN s.uuid AS saga_uuid, e.uuid AS edge_uuid,
+                   e.group_id AS group_id, e.created_at AS created_at
+            """,
+            uuid=uuid,
+        )
+
+        await _write(
+            executor,
+            tx,
+            'MATCH (n:Episodic {uuid: $uuid}) DETACH DELETE n',
+            uuid=uuid,
+        )
+    else:
+        mentions = []
+        next_episode_outgoing = []
+        next_episode_incoming = []
+        has_episode = []
+
+    await _write(
+        executor,
+        tx,
+        """
+        CREATE (n:Episodic {
+            uuid: $uuid,
+            name: $name,
+            group_id: $group_id,
+            created_at: $created_at,
+            source: $source,
+            source_description: $source_description,
+            content: $content,
+            content_embedding: $content_embedding,
+            valid_at: $valid_at,
+            entity_edges: $entity_edges
+        })
+        """,
+        **params,
+    )
+
+    for m in mentions:
+        await _write(
+            executor,
+            tx,
+            """
+            MATCH (ep:Episodic {uuid: $uuid}), (n:Entity {uuid: $entity_uuid})
+            CREATE (ep)-[:MENTIONS {uuid: $mention_uuid, group_id: $group_id, created_at: $created_at}]->(n)
+            """,
+            uuid=uuid,
+            entity_uuid=m['entity_uuid'],
+            mention_uuid=m['mention_uuid'],
+            group_id=m['group_id'],
+            created_at=m['created_at'],
+        )
+
+    for e in next_episode_outgoing:
+        await _write(
+            executor,
+            tx,
+            """
+            MATCH (ep:Episodic {uuid: $uuid}), (target:Episodic {uuid: $target_uuid})
+            CREATE (ep)-[:NEXT_EPISODE {uuid: $edge_uuid, group_id: $group_id, created_at: $created_at}]->(target)
+            """,
+            uuid=uuid,
+            target_uuid=e['target_uuid'],
+            edge_uuid=e['edge_uuid'],
+            group_id=e['group_id'],
+            created_at=e['created_at'],
+        )
+
+    for e in next_episode_incoming:
+        await _write(
+            executor,
+            tx,
+            """
+            MATCH (source:Episodic {uuid: $source_uuid}), (ep:Episodic {uuid: $uuid})
+            CREATE (source)-[:NEXT_EPISODE {uuid: $edge_uuid, group_id: $group_id, created_at: $created_at}]->(ep)
+            """,
+            uuid=uuid,
+            source_uuid=e['source_uuid'],
+            edge_uuid=e['edge_uuid'],
+            group_id=e['group_id'],
+            created_at=e['created_at'],
+        )
+
+    for e in has_episode:
+        await _write(
+            executor,
+            tx,
+            """
+            MATCH (s:Saga {uuid: $saga_uuid}), (ep:Episodic {uuid: $uuid})
+            CREATE (s)-[:HAS_EPISODE {uuid: $edge_uuid, group_id: $group_id, created_at: $created_at}]->(ep)
+            """,
+            uuid=uuid,
+            saga_uuid=e['saga_uuid'],
+            edge_uuid=e['edge_uuid'],
+            group_id=e['group_id'],
+            created_at=e['created_at'],
+        )

--- a/graphiti_core/driver/kuzu/operations/community_node_ops.py
+++ b/graphiti_core/driver/kuzu/operations/community_node_ops.py
@@ -17,14 +17,13 @@ limitations under the License.
 import logging
 from typing import Any
 
-from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.kuzu.hnsw_safe_writes import hnsw_safe_save_community_node
 from graphiti_core.driver.operations.community_node_ops import CommunityNodeOperations
 from graphiti_core.driver.query_executor import QueryExecutor, Transaction
 from graphiti_core.driver.record_parsers import community_node_from_record
 from graphiti_core.errors import NodeNotFoundError
 from graphiti_core.models.nodes.node_db_queries import (
     COMMUNITY_NODE_RETURN,
-    get_community_node_save_query,
 )
 from graphiti_core.nodes import CommunityNode
 
@@ -38,7 +37,6 @@ class KuzuCommunityNodeOperations(CommunityNodeOperations):
         node: CommunityNode,
         tx: Transaction | None = None,
     ) -> None:
-        query = get_community_node_save_query(GraphProvider.KUZU)
         params: dict[str, Any] = {
             'uuid': node.uuid,
             'name': node.name,
@@ -47,10 +45,7 @@ class KuzuCommunityNodeOperations(CommunityNodeOperations):
             'name_embedding': node.name_embedding,
             'created_at': node.created_at,
         }
-        if tx is not None:
-            await tx.run(query, **params)
-        else:
-            await executor.execute_query(query, **params)
+        await hnsw_safe_save_community_node(executor, tx, params)
 
         logger.debug(f'Saved Community Node to Graph: {node.uuid}')
 

--- a/graphiti_core/driver/kuzu/operations/entity_edge_ops.py
+++ b/graphiti_core/driver/kuzu/operations/entity_edge_ops.py
@@ -19,6 +19,7 @@ import logging
 from typing import Any
 
 from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.kuzu.hnsw_safe_writes import hnsw_safe_save_entity_edge
 from graphiti_core.driver.kuzu.operations.record_parsers import parse_kuzu_entity_edge
 from graphiti_core.driver.operations.entity_edge_ops import EntityEdgeOperations
 from graphiti_core.driver.query_executor import QueryExecutor, Transaction
@@ -26,7 +27,6 @@ from graphiti_core.edges import EntityEdge
 from graphiti_core.errors import EdgeNotFoundError
 from graphiti_core.models.edges.edge_db_queries import (
     get_entity_edge_return_query,
-    get_entity_edge_save_query,
 )
 
 logger = logging.getLogger(__name__)
@@ -55,11 +55,7 @@ class KuzuEntityEdgeOperations(EntityEdgeOperations):
             'attributes': json.dumps(edge.attributes or {}),
         }
 
-        query = get_entity_edge_save_query(GraphProvider.KUZU)
-        if tx is not None:
-            await tx.run(query, **params)
-        else:
-            await executor.execute_query(query, **params)
+        await hnsw_safe_save_entity_edge(executor, tx, params)
 
         logger.debug(f'Saved Edge to Graph: {edge.uuid}')
 

--- a/graphiti_core/driver/kuzu/operations/entity_node_ops.py
+++ b/graphiti_core/driver/kuzu/operations/entity_node_ops.py
@@ -19,13 +19,13 @@ import logging
 from typing import Any
 
 from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.kuzu.hnsw_safe_writes import hnsw_safe_save_entity_node
 from graphiti_core.driver.kuzu.operations.record_parsers import parse_kuzu_entity_node
 from graphiti_core.driver.operations.entity_node_ops import EntityNodeOperations
 from graphiti_core.driver.query_executor import QueryExecutor, Transaction
 from graphiti_core.errors import NodeNotFoundError
 from graphiti_core.models.nodes.node_db_queries import (
     get_entity_node_return_query,
-    get_entity_node_save_query,
 )
 from graphiti_core.nodes import EntityNode
 
@@ -52,12 +52,7 @@ class KuzuEntityNodeOperations(EntityNodeOperations):
             'attributes': attrs_json,
         }
 
-        query = get_entity_node_save_query(GraphProvider.KUZU, '')
-
-        if tx is not None:
-            await tx.run(query, **params)
-        else:
-            await executor.execute_query(query, **params)
+        await hnsw_safe_save_entity_node(executor, tx, params)
 
         logger.debug(f'Saved Node to Graph: {node.uuid}')
 

--- a/graphiti_core/driver/kuzu/operations/episode_node_ops.py
+++ b/graphiti_core/driver/kuzu/operations/episode_node_ops.py
@@ -18,15 +18,12 @@ import logging
 from datetime import datetime
 from typing import Any
 
-from graphiti_core.driver.driver import GraphProvider
+from graphiti_core.driver.kuzu.hnsw_safe_writes import hnsw_safe_save_episode_node
 from graphiti_core.driver.operations.episode_node_ops import EpisodeNodeOperations
 from graphiti_core.driver.query_executor import QueryExecutor, Transaction
 from graphiti_core.driver.record_parsers import episodic_node_from_record
 from graphiti_core.errors import NodeNotFoundError
-from graphiti_core.models.nodes.node_db_queries import (
-    EPISODIC_NODE_RETURN,
-    get_episode_node_save_query,
-)
+from graphiti_core.models.nodes.node_db_queries import EPISODIC_NODE_RETURN
 from graphiti_core.nodes import EpisodicNode
 
 logger = logging.getLogger(__name__)
@@ -39,22 +36,19 @@ class KuzuEpisodeNodeOperations(EpisodeNodeOperations):
         node: EpisodicNode,
         tx: Transaction | None = None,
     ) -> None:
-        query = get_episode_node_save_query(GraphProvider.KUZU)
         params: dict[str, Any] = {
             'uuid': node.uuid,
             'name': node.name,
             'group_id': node.group_id,
             'source_description': node.source_description,
             'content': node.content,
+            'content_embedding': node.content_embedding,
             'entity_edges': node.entity_edges,
             'created_at': node.created_at,
             'valid_at': node.valid_at,
             'source': node.source.value,
         }
-        if tx is not None:
-            await tx.run(query, **params)
-        else:
-            await executor.execute_query(query, **params)
+        await hnsw_safe_save_episode_node(executor, tx, params)
 
         logger.debug(f'Saved Episode to Graph: {node.uuid}')
 

--- a/graphiti_core/edges.py
+++ b/graphiti_core/edges.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel, Field
 from typing_extensions import LiteralString
 
 from graphiti_core.driver.driver import GraphDriver, GraphProvider
+from graphiti_core.driver.kuzu.hnsw_safe_writes import hnsw_safe_save_entity_edge
 from graphiti_core.embedder import EmbedderClient
 from graphiti_core.errors import EdgeNotFoundError, GroupsEdgesNotFoundError
 from graphiti_core.helpers import parse_db_date
@@ -288,7 +289,9 @@ class EntityEdge(Edge):
         self.fact_embedding = await embedder.create(input_data=[text])
 
         end = time()
-        logger.debug(f'embedded edge {self.uuid} fact ({len(text)} chars) in {(end - start) * 1000} ms')
+        logger.debug(
+            f'embedded edge {self.uuid} fact ({len(text)} chars) in {(end - start) * 1000} ms'
+        )
 
         return self.fact_embedding
 
@@ -351,10 +354,8 @@ class EntityEdge(Edge):
 
         if driver.provider == GraphProvider.KUZU:
             edge_data['attributes'] = json.dumps(self.attributes)
-            result = await driver.execute_query(
-                get_entity_edge_save_query(driver.provider),
-                **edge_data,
-            )
+            await hnsw_safe_save_entity_edge(driver, None, edge_data)
+            result = None
         else:
             edge_data.update(self.attributes or {})
             result = await driver.execute_query(

--- a/graphiti_core/llm_client/gliner2_client.py
+++ b/graphiti_core/llm_client/gliner2_client.py
@@ -148,9 +148,7 @@ class GLiNER2Client(LLMClient):
         """
         user_content = messages[-1].content if len(messages) > 1 else messages[0].content
 
-        match = re.search(
-            r'<ENTITY TYPES>\s*(.*?)\s*</ENTITY TYPES>', user_content, re.DOTALL
-        )
+        match = re.search(r'<ENTITY TYPES>\s*(.*?)\s*</ENTITY TYPES>', user_content, re.DOTALL)
         if match:
             try:
                 raw = match.group(1)
@@ -205,10 +203,12 @@ class GLiNER2Client(LLMClient):
                 name = item.get('text', '') if isinstance(item, dict) else str(item)
 
                 if name:
-                    extracted_entities.append({
-                        'name': name,
-                        'entity_type_id': entity_type_id,
-                    })
+                    extracted_entities.append(
+                        {
+                            'name': name,
+                            'entity_type_id': entity_type_id,
+                        }
+                    )
 
         return {'extracted_entities': extracted_entities}
 

--- a/graphiti_core/nodes.py
+++ b/graphiti_core/nodes.py
@@ -30,6 +30,10 @@ from graphiti_core.driver.driver import (
     GraphDriver,
     GraphProvider,
 )
+from graphiti_core.driver.kuzu.hnsw_safe_writes import (
+    hnsw_safe_save_community_node,
+    hnsw_safe_save_entity_node,
+)
 from graphiti_core.embedder import EmbedderClient
 from graphiti_core.errors import NodeNotFoundError
 from graphiti_core.helpers import parse_db_date
@@ -498,7 +502,9 @@ class EntityNode(Node):
         text = self.name.replace('\n', ' ')
         self.name_embedding = await embedder.create(input_data=[text])
         end = time()
-        logger.debug(f'embedded entity {self.uuid} name ({len(text)} chars) in {(end - start) * 1000} ms')
+        logger.debug(
+            f'embedded entity {self.uuid} name ({len(text)} chars) in {(end - start) * 1000} ms'
+        )
 
         return self.name_embedding
 
@@ -550,10 +556,8 @@ class EntityNode(Node):
         if driver.provider == GraphProvider.KUZU:
             entity_data['attributes'] = json.dumps(self.attributes)
             entity_data['labels'] = list(set(self.labels + ['Entity']))
-            result = await driver.execute_query(
-                get_entity_node_save_query(driver.provider, labels=''),
-                **entity_data,
-            )
+            await hnsw_safe_save_entity_node(driver, None, entity_data)
+            result = None
         else:
             entity_data.update(self.attributes or {})
             labels = ':'.join(self.labels + ['Entity'])
@@ -684,15 +688,27 @@ class CommunityNode(Node):
                 'communities',
                 [{'name': self.name, 'uuid': self.uuid, 'group_id': self.group_id}],
             )
-        result = await driver.execute_query(
-            get_community_node_save_query(driver.provider),  # type: ignore
-            uuid=self.uuid,
-            name=self.name,
-            group_id=self.group_id,
-            summary=self.summary,
-            name_embedding=self.name_embedding,
-            created_at=self.created_at,
-        )
+        if driver.provider == GraphProvider.KUZU:
+            params: dict[str, Any] = {
+                'uuid': self.uuid,
+                'name': self.name,
+                'group_id': self.group_id,
+                'summary': self.summary,
+                'name_embedding': self.name_embedding,
+                'created_at': self.created_at,
+            }
+            await hnsw_safe_save_community_node(driver, None, params)
+            result = None
+        else:
+            result = await driver.execute_query(
+                get_community_node_save_query(driver.provider),  # type: ignore
+                uuid=self.uuid,
+                name=self.name,
+                group_id=self.group_id,
+                summary=self.summary,
+                name_embedding=self.name_embedding,
+                created_at=self.created_at,
+            )
 
         logger.debug(f'Saved Node to Graph: {self.uuid}')
 
@@ -703,7 +719,9 @@ class CommunityNode(Node):
         text = self.name.replace('\n', ' ')
         self.name_embedding = await embedder.create(input_data=[text])
         end = time()
-        logger.debug(f'embedded entity {self.uuid} name ({len(text)} chars) in {(end - start) * 1000} ms')
+        logger.debug(
+            f'embedded entity {self.uuid} name ({len(text)} chars) in {(end - start) * 1000} ms'
+        )
 
         return self.name_embedding
 

--- a/graphiti_core/nodes.py
+++ b/graphiti_core/nodes.py
@@ -33,6 +33,7 @@ from graphiti_core.driver.driver import (
 from graphiti_core.driver.kuzu.hnsw_safe_writes import (
     hnsw_safe_save_community_node,
     hnsw_safe_save_entity_node,
+    hnsw_safe_save_episode_node,
 )
 from graphiti_core.embedder import EmbedderClient
 from graphiti_core.errors import NodeNotFoundError
@@ -344,9 +345,13 @@ class EpisodicNode(Node):
             'source': self.source.value,
         }
 
-        result = await driver.execute_query(
-            get_episode_node_save_query(driver.provider), **episode_args
-        )
+        if driver.provider == GraphProvider.KUZU:
+            await hnsw_safe_save_episode_node(driver, None, episode_args)
+            result = None
+        else:
+            result = await driver.execute_query(
+                get_episode_node_save_query(driver.provider), **episode_args
+            )
 
         logger.debug(f'Saved Node to Graph: {self.uuid}')
 

--- a/graphiti_core/utils/bulk_utils.py
+++ b/graphiti_core/utils/bulk_utils.py
@@ -28,6 +28,10 @@ from graphiti_core.driver.driver import (
     GraphDriverSession,
     GraphProvider,
 )
+from graphiti_core.driver.kuzu.hnsw_safe_writes import (
+    hnsw_safe_save_entity_edge,
+    hnsw_safe_save_entity_node,
+)
 from graphiti_core.edges import Edge, EntityEdge, EpisodicEdge, create_entity_edge_embeddings
 from graphiti_core.embedder import EmbedderClient
 from graphiti_core.graphiti_types import GraphitiClients
@@ -226,12 +230,10 @@ async def add_nodes_and_edges_bulk_tx(
         episode_query = get_episode_node_save_bulk_query(driver.provider)
         for episode in episodes:
             await tx.run(episode_query, **episode)
-        entity_node_query = get_entity_node_save_bulk_query(driver.provider, nodes)
         for node in nodes:
-            await tx.run(entity_node_query, **node)
-        entity_edge_query = get_entity_edge_save_bulk_query(driver.provider)
+            await hnsw_safe_save_entity_node(driver, tx, node)
         for edge in edges:
-            await tx.run(entity_edge_query, **edge)
+            await hnsw_safe_save_entity_edge(driver, tx, edge)
         episodic_edge_query = get_episodic_edge_save_bulk_query(driver.provider)
         for edge in episodic_edges:
             await tx.run(episodic_edge_query, **edge.model_dump())

--- a/graphiti_core/utils/bulk_utils.py
+++ b/graphiti_core/utils/bulk_utils.py
@@ -31,6 +31,7 @@ from graphiti_core.driver.driver import (
 from graphiti_core.driver.kuzu.hnsw_safe_writes import (
     hnsw_safe_save_entity_edge,
     hnsw_safe_save_entity_node,
+    hnsw_safe_save_episode_node,
 )
 from graphiti_core.edges import Edge, EntityEdge, EpisodicEdge, create_entity_edge_embeddings
 from graphiti_core.embedder import EmbedderClient
@@ -227,9 +228,8 @@ async def add_nodes_and_edges_bulk_tx(
 
     elif driver.provider == GraphProvider.KUZU:
         # FIXME: Kuzu's UNWIND does not currently support STRUCT[] type properly, so we insert the data one by one instead for now.
-        episode_query = get_episode_node_save_bulk_query(driver.provider)
         for episode in episodes:
-            await tx.run(episode_query, **episode)
+            await hnsw_safe_save_episode_node(driver, tx, episode)
         for node in nodes:
             await hnsw_safe_save_entity_node(driver, tx, node)
         for edge in edges:

--- a/graphiti_core/utils/maintenance/community_operations.py
+++ b/graphiti_core/utils/maintenance/community_operations.py
@@ -207,9 +207,7 @@ async def build_community(
     )
     community_edges = build_community_edges(community_cluster, community_node, now)
 
-    logger.debug(
-        f'Built community {community_node.uuid} with {len(community_edges)} edges'
-    )
+    logger.debug(f'Built community {community_node.uuid} with {len(community_edges)} edges')
 
     return community_node, community_edges
 


### PR DESCRIPTION
Closes #19. Supersedes #21.

## Summary

Fixes the `Runtime exception: Cannot set property vec in table embeddings because it is used in one or more indexes` error blocking all live writes when HNSW vector indexes are present.

## Why a new PR

PR #21 was based off `main` rather than `liminis`, which meant:

1. **The LadybugDriver (`ladybug_driver.py`) doesn't exist on `main`** — it's only on `liminis`. So the `main`-based fix could never actually run against LadybugDB.
2. **PR #21 missed the Episodic save path** because the `Episodic.content_embedding` schema change only exists on `liminis` (added in commit `e5f27ee` "TASK 7 — add episodic content_embedding for unified semantic search"). The fabrik plan explicitly (but wrongly) stated: *"Note: Episodic.content_embedding does not exist in the current schema on the liminis branch."*

This PR takes the good work from #21, rebases it onto `liminis`, and adds the missing Episodic coverage.

## Changes

Commits:

1. `0a6c8e8` — fabrik's original DELETE+INSERT fix for Entity, Community, EntityEdge (cherry-picked from #21)
2. `b9db3e6` — fabrik's follow-up fix for edge key mismatch (cherry-picked from #21)
3. `0875aaf` — **new**: extend the pattern to Episodic nodes + restore missing `content_embedding` param

Third commit details:
- `hnsw_safe_writes.py`: add `hnsw_safe_save_episode_node` with backup/restore for MENTIONS (→Entity), NEXT_EPISODE (both directions), HAS_EPISODE (←Saga)
- `kuzu/operations/episode_node_ops.py`: route save() through the helper; also pass `content_embedding` in params (was dropped by original ops class — Q4 in fabrik plan)
- `nodes.py`: `EpisodicNode.save()` KUZU path now uses the helper
- `bulk_utils.py`: KUZU branch uses helper for episode saves instead of `get_episode_node_save_bulk_query`

## Verification

Tested end-to-end against a real demo-notebook workspace:

- **Before:** every chunk save returned `success: false` with the HNSW error on the Episodic `MERGE+SET`
- **After:** chunks index successfully — `success: true`, 13 nodes + 9 edges extracted on a test document

No unit-test regressions expected (same 259 passed as fabrik reported). The demo-notebook integration test is the source of truth for this fix.

## Still open

- **Content embedding pipeline bug** — `content_embedding` was observed as `None` in save params during testing. Writes now succeed with None, but semantic search over episode content won't work until the embedder is invoked earlier in the pipeline. This is likely in liminis-framework territory, not graphiti, and is outside the scope of #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)