### PR TITLE
test: fix resolve_extracted_edges tests broken by endpoint-scoped invalidation

### DIFF
--- a/tests/utils/maintenance/test_edge_operations.py
+++ b/tests/utils/maintenance/test_edge_operations.py
@@ -162,6 +162,7 @@ async def test_resolve_extracted_edges_keeps_unknown_names(monkeypatch):
 
     monkeypatch.setattr(edge_ops, 'create_entity_edge_embeddings', AsyncMock(return_value=None))
     monkeypatch.setattr(EntityEdge, 'get_between_nodes', AsyncMock(return_value=[]))
+    monkeypatch.setattr(EntityEdge, 'get_by_node_uuid', AsyncMock(return_value=[]))
 
     async def immediate_gather(*aws, max_coroutines=None):
         return [await aw for aw in aws]
@@ -338,6 +339,7 @@ async def test_resolve_extracted_edges_fast_path_deduplication(monkeypatch):
 
     monkeypatch.setattr(edge_ops, 'create_entity_edge_embeddings', AsyncMock(return_value=None))
     monkeypatch.setattr(EntityEdge, 'get_between_nodes', AsyncMock(return_value=[]))
+    monkeypatch.setattr(EntityEdge, 'get_by_node_uuid', AsyncMock(return_value=[]))
 
     # Track how many times resolve_extracted_edge is called
     resolve_call_count = 0


### PR DESCRIPTION
## Summary

- Commit 8c646b6 added endpoint-scoped invalidation in `resolve_extracted_edges` that calls `await EntityEdge.get_by_node_uuid(driver, ...)` per endpoint node.
- Two unit tests (`test_resolve_extracted_edges_keeps_unknown_names`, `test_resolve_extracted_edges_fast_path_deduplication`) mock `driver` as a plain `MagicMock`, so the subsequent `await driver.graph_operations_interface.edge_get_by_node_uuid(...)` returns a non-awaitable `MagicMock` and raises `TypeError`.
- Patch `EntityEdge.get_by_node_uuid` with `AsyncMock(return_value=[])` in both tests, mirroring the existing `get_between_nodes` stub — fetch returns an empty list without touching the driver internals.

No production code changed. Unit suite: 442 passed, 0 failed in ~12s.

## Test plan

- [x] \`uv run pytest tests/utils/maintenance/test_edge_operations.py\` — 8 passed
- [x] \`uv run pytest tests/ -k "not _int"\` — 442 passed, 152 deselected
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)