### PR TITLE
Batch edge dedup into single LLM call instead of N sequential calls

### DIFF
--- a/graphiti_core/prompts/dedupe_edges.py
+++ b/graphiti_core/prompts/dedupe_edges.py
@@ -32,12 +32,32 @@ class EdgeDuplicate(BaseModel):
     )
 
 
+class EdgeResolution(BaseModel):
+    edge_idx: int = Field(
+        ...,
+        description='Index of the new edge in the batch (0-based, matches the edge_idx provided in the prompt).',
+    )
+    duplicate_of: int | None = Field(
+        ...,
+        description='candidate_idx of the existing edge this new edge is a duplicate of, or null if not a duplicate.',
+    )
+
+
+class EdgeBatchResolutions(BaseModel):
+    edge_resolutions: list[EdgeResolution] = Field(
+        ...,
+        description='List of per-edge dedup decisions. Must include one entry per edge in the batch.',
+    )
+
+
 class Prompt(Protocol):
     resolve_edge: PromptVersion
+    resolve_edges_batch: PromptVersion
 
 
 class Versions(TypedDict):
     resolve_edge: PromptFunction
+    resolve_edges_batch: PromptFunction
 
 
 def resolve_edge(context: dict[str, Any]) -> list[Message]:
@@ -100,4 +120,77 @@ Result: duplicate_facts=[], contradicted_facts=[] (different events on different
     ]
 
 
-versions: Versions = {'resolve_edge': resolve_edge}
+def _format_batch_edges_for_prompt(edges: list[dict[str, Any]]) -> str:
+    parts = []
+    for edge in edges:
+        parts.append(f'<EDGE edge_idx="{edge["edge_idx"]}">')
+        parts.append(f'  NEW FACT: {edge["fact"]}')
+        if edge['candidates']:
+            parts.append('  EXISTING CANDIDATES:')
+            for candidate in edge['candidates']:
+                parts.append(
+                    f'    candidate_idx={candidate["candidate_idx"]}: {candidate["fact"]}'
+                )
+        else:
+            parts.append('  EXISTING CANDIDATES: (none)')
+        parts.append('</EDGE>')
+    return '\n'.join(parts)
+
+
+def resolve_edges_batch(context: dict[str, Any]) -> list[Message]:
+    edges: list[dict[str, Any]] = context['edges']
+    edge_indices = ', '.join(str(e['edge_idx']) for e in edges)
+    return [
+        Message(
+            role='system',
+            content='You are a fact deduplication assistant. '
+            'NEVER mark facts with key differences as duplicates.',
+        ),
+        Message(
+            role='user',
+            content=f"""
+NEVER mark facts as duplicates if they have key differences, particularly around numeric values, dates, or key qualifiers.
+
+For each NEW FACT below, determine if it is a duplicate of any EXISTING CANDIDATE listed under that fact.
+Each new fact has its own candidate list — do NOT compare candidates across different new facts.
+
+{_format_batch_edges_for_prompt(edges)}
+
+For each new fact (identified by edge_idx), return:
+- edge_idx: the index of the new fact (as provided above)
+- duplicate_of: the candidate_idx of the matching existing fact, or null if not a duplicate
+
+Your response MUST include exactly {len(edges)} resolutions with edge_idx values {edge_indices}.
+Do not skip any edge_idx.
+
+A fact is a duplicate only if it represents IDENTICAL factual information.
+Do NOT mark a fact as a duplicate if it has different numeric values, different dates, or different qualifiers.
+
+<EXAMPLE>
+<EDGE edge_idx="0">
+  NEW FACT: "Alice joined Acme Corp in 2020"
+  EXISTING CANDIDATES:
+    candidate_idx=0: "Alice joined Acme Corp in 2020"
+    candidate_idx=1: "Alice works at Acme Corp"
+</EDGE>
+<EDGE edge_idx="1">
+  NEW FACT: "Bob ran 5 miles on Tuesday"
+  EXISTING CANDIDATES:
+    candidate_idx=0: "Bob ran 3 miles on Wednesday"
+</EDGE>
+<EDGE edge_idx="2">
+  NEW FACT: "Alice is a software engineer at Acme"
+  EXISTING CANDIDATES: (none)
+</EDGE>
+
+Result:
+- edge_idx=0, duplicate_of=0  (identical fact)
+- edge_idx=1, duplicate_of=null  (different event)
+- edge_idx=2, duplicate_of=null  (no candidates)
+</EXAMPLE>
+""",
+        ),
+    ]
+
+
+versions: Versions = {'resolve_edge': resolve_edge, 'resolve_edges_batch': resolve_edges_batch}

--- a/graphiti_core/utils/maintenance/edge_operations.py
+++ b/graphiti_core/utils/maintenance/edge_operations.py
@@ -655,19 +655,23 @@ async def resolve_extracted_edges(
     ]
 
     if stage1_duplicate_indices:
-        await semaphore_gather(*[
-            _extract_edge_attributes(
-                llm_client,
-                related_edges_lists[i][stage1_duplicate_of[i]],  # type: ignore[index]
-                episode,
-                edge_types_lst[i],
-            )
-            for i in stage1_duplicate_indices
-        ])
+        # Deduplicate by resolved edge UUID: multiple extracted edges can map to the
+        # same existing edge, and calling _extract_edge_attributes on the same object
+        # in parallel is both redundant and races on edge.attributes.
+        seen_uuids: set[str] = set()
+        unique_attr_tasks = []
+        for i in stage1_duplicate_indices:
+            resolved_for_attr = related_edges_lists[i][stage1_duplicate_of[i]]  # type: ignore[index]
+            if resolved_for_attr.uuid not in seen_uuids:
+                seen_uuids.add(resolved_for_attr.uuid)
+                unique_attr_tasks.append(
+                    _extract_edge_attributes(llm_client, resolved_for_attr, episode, edge_types_lst[i])
+                )
+        await semaphore_gather(*unique_attr_tasks)
     for i in stage1_duplicate_indices:
         dup_idx = stage1_duplicate_of[i]
         resolved = related_edges_lists[i][dup_idx]  # type: ignore[index]
-        if episode is not None:
+        if episode is not None and episode.uuid not in resolved.episodes:
             resolved.episodes.append(episode.uuid)
         final_results[i] = (resolved, [], [resolved])
         logger.debug(
@@ -921,7 +925,7 @@ async def resolve_extracted_edge(
 
             if duplicate_fact_ids:
                 resolved_edge = related_edges[duplicate_fact_ids[0]]
-                if episode is not None:
+                if episode is not None and episode.uuid not in resolved_edge.episodes:
                     resolved_edge.episodes.append(episode.uuid)
                 duplicate_edges = [related_edges[idx] for idx in duplicate_fact_ids]
 

--- a/graphiti_core/utils/maintenance/edge_operations.py
+++ b/graphiti_core/utils/maintenance/edge_operations.py
@@ -34,7 +34,7 @@ from graphiti_core.llm_client import LLMClient
 from graphiti_core.llm_client.config import ModelSize
 from graphiti_core.nodes import CommunityNode, EntityNode, EpisodicNode
 from graphiti_core.prompts import prompt_library
-from graphiti_core.prompts.dedupe_edges import EdgeDuplicate
+from graphiti_core.prompts.dedupe_edges import EdgeBatchResolutions, EdgeDuplicate
 from graphiti_core.prompts.extract_edges import Edge as ExtractedEdge
 from graphiti_core.prompts.extract_edges import ExtractedEdges
 from graphiti_core.search.search import search
@@ -49,6 +49,11 @@ logger = logging.getLogger(__name__)
 INVALIDATION_SIM_THRESHOLD = 0.3  # cosine similarity floor for invalidation candidates (stage 2)
 DEDUP_SIM_THRESHOLD = 0.5  # cosine similarity floor for dedup candidates (stage 1)
 
+# Maximum number of edges to include in a single batched Stage 1 LLM call.
+# At typical fact lengths (~50 tokens each) and 10 candidates per edge, 20 edges
+# keeps the prompt well within context limits (~10k tokens).
+EDGE_DEDUP_BATCH_SIZE = 20
+
 
 def _cosine_sim(a: list[float] | None, b: list[float] | None) -> float:
     if a is None or b is None or len(a) == 0 or len(b) == 0:
@@ -59,6 +64,31 @@ def _cosine_sim(a: list[float] | None, b: list[float] | None) -> float:
     if norm_a == 0 or norm_b == 0:
         return 0.0
     return dot / (norm_a * norm_b)
+
+
+async def _extract_edge_attributes(
+    llm_client: LLMClient,
+    edge: EntityEdge,
+    episode: EpisodicNode | None,
+    edge_type_candidates: dict[str, type[BaseModel]] | None,
+) -> None:
+    """Extract and set custom attributes on an edge using the appropriate edge type model."""
+    edge_model = edge_type_candidates.get(edge.name) if edge_type_candidates else None
+    if edge_model is not None and len(edge_model.model_fields) != 0:
+        edge_attributes_context = {
+            'fact': edge.fact,
+            'reference_time': episode.valid_at if episode is not None else None,
+            'existing_attributes': edge.attributes,
+        }
+        edge_attributes_response = await llm_client.generate_response(
+            prompt_library.extract_edges.extract_attributes(edge_attributes_context),
+            response_model=edge_model,  # type: ignore
+            model_size=ModelSize.small,
+            prompt_name='extract_edges.extract_attributes',
+        )
+        edge.attributes = edge_attributes_response
+    else:
+        edge.attributes = {}
 
 
 def build_episodic_edges(
@@ -481,55 +511,216 @@ async def resolve_extracted_edges(
 
         edge_types_lst.append(extracted_edge_types)
 
-    # resolve edges with related edges in the graph and find invalidation candidates
+    # =========================================================================
+    # FAST-PATH CLASSIFICATION + BATCHED STAGE 1 DEDUP
+    # =========================================================================
     t_llm_resolve = time()
-    results: list[tuple[EntityEdge, list[EntityEdge], list[EntityEdge]]] = list(
+
+    final_results: dict[int, tuple[EntityEdge, list[EntityEdge], list[EntityEdge]]] = {}
+    no_candidates_indices: list[int] = []   # both related and invalidation candidates empty
+    direct_stage2_indices: list[int] = []   # no dedup candidates but has invalidation candidates
+    batch_indices: list[int] = []           # need batched Stage 1
+    fast_path_exact_count = 0
+
+    for i, (extracted_edge, related_edges, inv_candidates) in enumerate(zip(
+        extracted_edges, related_edges_lists, edge_invalidation_candidates, strict=True
+    )):
+        # Fast path 1: no candidates at all — skip all LLM calls
+        if len(related_edges) == 0 and len(inv_candidates) == 0:
+            no_candidates_indices.append(i)
+            continue
+
+        # No dedup candidates but has invalidation candidates — skip Stage 1, go to Stage 2
+        if len(related_edges) == 0:
+            direct_stage2_indices.append(i)
+            continue
+
+        # Fast path 2: exact text match among related_edges — skip all LLM calls
+        normalized_fact = _normalize_string_exact(extracted_edge.fact)
+        matched: EntityEdge | None = None
+        for edge in related_edges:
+            if (
+                edge.source_node_uuid == extracted_edge.source_node_uuid
+                and edge.target_node_uuid == extracted_edge.target_node_uuid
+                and _normalize_string_exact(edge.fact) == normalized_fact
+            ):
+                matched = edge
+                break
+
+        if matched is not None:
+            if episode is not None and episode.uuid not in matched.episodes:
+                matched.episodes.append(episode.uuid)
+            final_results[i] = (matched, [], [])
+            fast_path_exact_count += 1
+            logger.debug(
+                'EDGE_RESOLVE_STAGE: edge %s — exact text match fast path', extracted_edge.uuid,
+            )
+            continue
+
+        batch_indices.append(i)
+
+    # Extract attributes for no-candidates edges (they are new, genuine edges)
+    if no_candidates_indices:
+        await semaphore_gather(*[
+            _extract_edge_attributes(llm_client, extracted_edges[i], episode, edge_types_lst[i])
+            for i in no_candidates_indices
+        ])
+    for i in no_candidates_indices:
+        final_results[i] = (extracted_edges[i], [], [])
+        logger.debug(
+            'EDGE_RESOLVE_STAGE: edge %s — no candidates fast path', extracted_edges[i].uuid,
+        )
+
+    logger.debug(
+        'EDGE_RESOLVE_STAGE: %d edges total — %d no-candidates, %d exact-match, '
+        '%d direct-stage2, %d queued for Stage 1 batch',
+        len(extracted_edges), len(no_candidates_indices), fast_path_exact_count,
+        len(direct_stage2_indices), len(batch_indices),
+    )
+
+    # =========================================================================
+    # BATCHED STAGE 1: Single LLM call per sub-batch to identify duplicates
+    # =========================================================================
+    stage1_duplicate_of: dict[int, int | None] = {i: None for i in batch_indices}
+
+    if batch_indices:
+        t_stage1 = time()
+        for batch_start in range(0, len(batch_indices), EDGE_DEDUP_BATCH_SIZE):
+            sub_batch_indices = batch_indices[batch_start: batch_start + EDGE_DEDUP_BATCH_SIZE]
+            batch_payload = [
+                {
+                    'edge_idx': batch_pos,
+                    'fact': extracted_edges[i].fact,
+                    'candidates': [
+                        {'candidate_idx': j, 'fact': e.fact}
+                        for j, e in enumerate(related_edges_lists[i])
+                    ],
+                }
+                for batch_pos, i in enumerate(sub_batch_indices)
+            ]
+            t_sub = time()
+            llm_response = await llm_client.generate_response(
+                prompt_library.dedupe_edges.resolve_edges_batch({'edges': batch_payload}),
+                response_model=EdgeBatchResolutions,
+                model_size=ModelSize.small,
+                prompt_name='dedupe_edges.resolve_edges_batch',
+            )
+            batch_response = EdgeBatchResolutions(**llm_response)
+            logger.debug(
+                'EDGE_RESOLVE_TIMING: Stage 1 sub-batch %d–%d (%d edges) in %.0f ms',
+                batch_start, batch_start + len(sub_batch_indices) - 1,
+                len(sub_batch_indices), (time() - t_sub) * 1000,
+            )
+
+            response_by_batch_pos: dict[int, int | None] = {}
+            for resolution in batch_response.edge_resolutions:
+                if 0 <= resolution.edge_idx < len(sub_batch_indices):
+                    dup_of = resolution.duplicate_of
+                    candidates_len = len(related_edges_lists[sub_batch_indices[resolution.edge_idx]])
+                    if dup_of is not None and not (0 <= dup_of < candidates_len):
+                        logger.warning(
+                            'EDGE_RESOLVE_STAGE1_BATCH: edge_idx=%d duplicate_of=%d out of range '
+                            '(candidates=%d), treating as non-duplicate',
+                            resolution.edge_idx, dup_of, candidates_len,
+                        )
+                        dup_of = None
+                    response_by_batch_pos[resolution.edge_idx] = dup_of
+                else:
+                    logger.warning(
+                        'EDGE_RESOLVE_STAGE1_BATCH: out-of-range edge_idx=%d in response '
+                        '(batch size=%d)',
+                        resolution.edge_idx, len(sub_batch_indices),
+                    )
+
+            for batch_pos, i in enumerate(sub_batch_indices):
+                if batch_pos not in response_by_batch_pos:
+                    logger.warning(
+                        'EDGE_RESOLVE_STAGE1_BATCH: missing edge_idx=%d in response '
+                        '(edge "%s"), treating as non-duplicate',
+                        batch_pos, extracted_edges[i].fact[:60],
+                    )
+                stage1_duplicate_of[i] = response_by_batch_pos.get(batch_pos)
+
+        logger.debug(
+            'EDGE_RESOLVE_TIMING: Stage 1 batched LLM (%d edges, %d sub-batches) in %.0f ms',
+            len(batch_indices),
+            (len(batch_indices) + EDGE_DEDUP_BATCH_SIZE - 1) // EDGE_DEDUP_BATCH_SIZE,
+            (time() - t_stage1) * 1000,
+        )
+
+    # Extract attributes for batch-identified duplicates and record their results
+    stage1_duplicate_indices = [i for i in batch_indices if stage1_duplicate_of[i] is not None]
+    stage2_indices = direct_stage2_indices + [
+        i for i in batch_indices if stage1_duplicate_of[i] is None
+    ]
+
+    if stage1_duplicate_indices:
+        await semaphore_gather(*[
+            _extract_edge_attributes(
+                llm_client,
+                related_edges_lists[i][stage1_duplicate_of[i]],  # type: ignore[index]
+                episode,
+                edge_types_lst[i],
+            )
+            for i in stage1_duplicate_indices
+        ])
+    for i in stage1_duplicate_indices:
+        dup_idx = stage1_duplicate_of[i]
+        resolved = related_edges_lists[i][dup_idx]  # type: ignore[index]
+        if episode is not None:
+            resolved.episodes.append(episode.uuid)
+        final_results[i] = (resolved, [], [resolved])
+        logger.debug(
+            'EDGE_RESOLVE_STAGE: edge %s — Stage 1 batch duplicate -> %s',
+            extracted_edges[i].uuid, resolved.uuid,
+        )
+
+    # =========================================================================
+    # STAGE 2: Run invalidation check in parallel for all non-duplicate edges
+    # =========================================================================
+    stage2_results_list: list[tuple[EntityEdge, list[EntityEdge], list[EntityEdge]]] = list(
         await semaphore_gather(
             *[
                 resolve_extracted_edge(
                     llm_client,
-                    extracted_edge,
-                    related_edges,
-                    existing_edges,
+                    extracted_edges[i],
+                    related_edges_lists[i],
+                    edge_invalidation_candidates[i],
                     episode,
-                    extracted_edge_types,
+                    edge_types_lst[i],
+                    _bypass_stage1=True,
                 )
-                for extracted_edge, related_edges, existing_edges, extracted_edge_types in zip(
-                    extracted_edges,
-                    related_edges_lists,
-                    edge_invalidation_candidates,
-                    edge_types_lst,
-                    strict=True,
-                )
+                for i in stage2_indices
             ]
         )
     )
+    for i, result in zip(stage2_indices, stage2_results_list, strict=True):
+        final_results[i] = result
 
-    logger.debug(
-        'EDGE_RESOLVE_TIMING: LLM resolve for %d edges in %.0f ms (%.0f ms/edge)',
-        len(extracted_edges),
-        (time() - t_llm_resolve) * 1000,
-        (time() - t_llm_resolve) * 1000 / max(len(extracted_edges), 1),
-    )
+    # Collect results in original order
+    results: list[tuple[EntityEdge, list[EntityEdge], list[EntityEdge]]] = [
+        final_results[i] for i in range(len(extracted_edges))
+    ]
 
-    # Count resolution outcomes
-    exact_match_count = sum(
-        1
-        for edge, result in zip(extracted_edges, results, strict=True)
-        if result[0].uuid != edge.uuid  # resolved to existing edge
-    )
-    no_op_invalidation_count = sum(
-        1
-        for result in results
-        if len(result[1]) == 0  # no invalidations
+    stage1_dedup_count = len(stage1_duplicate_indices)
+    fast_path_total = len(no_candidates_indices) + fast_path_exact_count
+    matched_existing_count = sum(
+        1 for edge, result in zip(extracted_edges, results, strict=True)
+        if result[0].uuid != edge.uuid
     )
     logger.debug(
-        'EDGE_RESOLVE_OUTCOMES: %d edges resolved: %d matched existing, %d new, %d with invalidations, %d no-op invalidation checks',
-        len(extracted_edges),
-        exact_match_count,
-        len(extracted_edges) - exact_match_count,
+        'EDGE_RESOLVE_TIMING: total LLM resolve for %d edges in %.0f ms '
+        '(%d fast-path, %d Stage 1 batch duplicates, %d Stage 2)',
+        len(extracted_edges), (time() - t_llm_resolve) * 1000,
+        fast_path_total, stage1_dedup_count, len(stage2_indices),
+    )
+    logger.debug(
+        'EDGE_RESOLVE_OUTCOMES: %d edges resolved: %d matched existing (%d batch-dedup, %d exact-match), '
+        '%d new, %d with invalidations',
+        len(extracted_edges), matched_existing_count,
+        stage1_dedup_count, fast_path_exact_count,
+        len(extracted_edges) - matched_existing_count,
         sum(1 for r in results if len(r[1]) > 0),
-        no_op_invalidation_count,
     )
 
     resolved_edges: list[EntityEdge] = []
@@ -604,6 +795,8 @@ async def resolve_extracted_edge(
     existing_edges: list[EntityEdge],
     episode: EpisodicNode,
     edge_type_candidates: dict[str, type[BaseModel]] | None = None,
+    *,
+    _bypass_stage1: bool = False,
 ) -> tuple[EntityEdge, list[EntityEdge], list[EntityEdge]]:
     """Resolve an extracted edge against existing graph context.
 
@@ -630,6 +823,10 @@ async def resolve_extracted_edge(
         Episode providing content context when extracting edge attributes.
     edge_type_candidates : dict[str, type[BaseModel]] | None
         Custom edge types permitted for the current source/target signature.
+    _bypass_stage1 : bool
+        Internal flag. When True, skip fast paths and Stage 1 (already handled
+        by the batched dedup in resolve_extracted_edges). Used only by
+        resolve_extracted_edges; external callers should not set this.
 
     Returns
     -------
@@ -638,130 +835,111 @@ async def resolve_extracted_edge(
     """
     start = time()
 
-    # --- Extract custom attributes helper ---
-    async def _extract_attributes(edge: EntityEdge) -> None:
-        edge_model = edge_type_candidates.get(edge.name) if edge_type_candidates else None
-        if edge_model is not None and len(edge_model.model_fields) != 0:
-            edge_attributes_context = {
-                'fact': edge.fact,
-                'reference_time': episode.valid_at if episode is not None else None,
-                'existing_attributes': edge.attributes,
-            }
-            edge_attributes_response = await llm_client.generate_response(
-                prompt_library.extract_edges.extract_attributes(edge_attributes_context),
-                response_model=edge_model,  # type: ignore
-                model_size=ModelSize.small,
-                prompt_name='extract_edges.extract_attributes',
+    if not _bypass_stage1:
+        # --- Fast path: no candidates at all ---
+        if len(related_edges) == 0 and len(existing_edges) == 0:
+            await _extract_edge_attributes(llm_client, extracted_edge, episode, edge_type_candidates)
+            logger.debug(
+                'EDGE_RESOLVE_STAGE: edge %s — no candidates, skipped both LLM calls (%.0f ms)',
+                extracted_edge.uuid, (time() - start) * 1000,
             )
-            edge.attributes = edge_attributes_response
+            return extracted_edge, [], []
+
+        # --- Fast path: exact text match ---
+        normalized_fact = _normalize_string_exact(extracted_edge.fact)
+        for edge in related_edges:
+            if (
+                edge.source_node_uuid == extracted_edge.source_node_uuid
+                and edge.target_node_uuid == extracted_edge.target_node_uuid
+                and _normalize_string_exact(edge.fact) == normalized_fact
+            ):
+                resolved = edge
+                if episode is not None and episode.uuid not in resolved.episodes:
+                    resolved.episodes.append(episode.uuid)
+                logger.debug(
+                    'EDGE_RESOLVE_STAGE: edge %s — exact text match, skipped both LLM calls (%.0f ms)',
+                    extracted_edge.uuid, (time() - start) * 1000,
+                )
+                return resolved, [], []
+
+        # --- Stage 1 pre-filter: drop low-similarity dedup candidates ---
+        # Candidates with None embeddings score 0.0 via _cosine_sim and are dropped — consistent
+        # with stage 2 behavior. The None-embedding fallback below only applies to the extracted edge.
+        if extracted_edge.fact_embedding is None:
+            logger.warning(
+                'EDGE_RESOLVE_STAGE1_DEDUP: edge %s — fact_embedding is None, skipping similarity pre-filter',
+                extracted_edge.uuid,
+            )
         else:
-            edge.attributes = {}
+            filtered = [
+                c
+                for c in related_edges
+                if _cosine_sim(extracted_edge.fact_embedding, c.fact_embedding) >= DEDUP_SIM_THRESHOLD
+            ]
+            if len(filtered) < len(related_edges):
+                logger.debug(
+                    'EDGE_RESOLVE_STAGE1_DEDUP: edge %s — dropped %d of %d candidates below DEDUP_SIM_THRESHOLD=%.2f',
+                    extracted_edge.uuid,
+                    len(related_edges) - len(filtered),
+                    len(related_edges),
+                    DEDUP_SIM_THRESHOLD,
+                )
+            related_edges = filtered
 
-    # --- Fast path: no candidates at all ---
-    if len(related_edges) == 0 and len(existing_edges) == 0:
-        await _extract_attributes(extracted_edge)
-        logger.debug(
-            'EDGE_RESOLVE_STAGE: edge %s — no candidates, skipped both LLM calls (%.0f ms)',
-            extracted_edge.uuid,
-            (time() - start) * 1000,
-        )
-        return extracted_edge, [], []
+        # =====================================================================
+        # STAGE 1: Dedup — is this fact already known between these endpoints?
+        # =====================================================================
+        resolved_edge = extracted_edge
+        duplicate_edges: list[EntityEdge] = []
 
-    # --- Fast path: exact text match ---
-    normalized_fact = _normalize_string_exact(extracted_edge.fact)
-    for edge in related_edges:
-        if (
-            edge.source_node_uuid == extracted_edge.source_node_uuid
-            and edge.target_node_uuid == extracted_edge.target_node_uuid
-            and _normalize_string_exact(edge.fact) == normalized_fact
-        ):
-            resolved = edge
-            if episode is not None and episode.uuid not in resolved.episodes:
-                resolved.episodes.append(episode.uuid)
+        if related_edges:
+            t_dedup = time()
+            dedup_context = {
+                'existing_edges': [
+                    {'idx': i, 'fact': edge.fact} for i, edge in enumerate(related_edges)
+                ],
+                'new_edge': extracted_edge.fact,
+                'edge_invalidation_candidates': [],  # empty — dedup only
+            }
+
             logger.debug(
-                'EDGE_RESOLVE_STAGE: edge %s — exact text match, skipped both LLM calls (%.0f ms)',
-                extracted_edge.uuid,
-                (time() - start) * 1000,
+                'EDGE_RESOLVE_STAGE1_DEDUP: edge "%s" — checking %d related edges',
+                extracted_edge.fact[:60], len(related_edges),
             )
-            return resolved, [], []
 
-    # --- Stage 1 pre-filter: drop low-similarity dedup candidates ---
-    # Candidates with None embeddings score 0.0 via _cosine_sim and are dropped — consistent
-    # with stage 2 behavior. The None-embedding fallback below only applies to the extracted edge.
-    if extracted_edge.fact_embedding is None:
-        logger.warning(
-            'EDGE_RESOLVE_STAGE1_DEDUP: edge %s — fact_embedding is None, skipping similarity pre-filter',
-            extracted_edge.uuid,
-        )
+            llm_response = await llm_client.generate_response(
+                prompt_library.dedupe_edges.resolve_edge(dedup_context),
+                response_model=EdgeDuplicate,
+                model_size=ModelSize.small,
+                prompt_name='dedupe_edges.resolve_edge',
+            )
+            response_object = EdgeDuplicate(**llm_response)
+
+            duplicate_fact_ids: list[int] = [
+                i for i in response_object.duplicate_facts if 0 <= i < len(related_edges)
+            ]
+
+            if duplicate_fact_ids:
+                resolved_edge = related_edges[duplicate_fact_ids[0]]
+                if episode is not None:
+                    resolved_edge.episodes.append(episode.uuid)
+                duplicate_edges = [related_edges[idx] for idx in duplicate_fact_ids]
+
+                await _extract_edge_attributes(llm_client, resolved_edge, episode, edge_type_candidates)
+
+                logger.debug(
+                    'EDGE_RESOLVE_STAGE: edge %s — duplicate found, skipped invalidation LLM call (%.0f ms)',
+                    extracted_edge.uuid, (time() - start) * 1000,
+                )
+                return resolved_edge, [], duplicate_edges
+
+            logger.debug(
+                'EDGE_RESOLVE_STAGE1_DEDUP: no duplicate found (%.0f ms)',
+                (time() - t_dedup) * 1000,
+            )
     else:
-        filtered = [
-            c
-            for c in related_edges
-            if _cosine_sim(extracted_edge.fact_embedding, c.fact_embedding) >= DEDUP_SIM_THRESHOLD
-        ]
-        if len(filtered) < len(related_edges):
-            logger.debug(
-                'EDGE_RESOLVE_STAGE1_DEDUP: edge %s — dropped %d of %d candidates below DEDUP_SIM_THRESHOLD=%.2f',
-                extracted_edge.uuid,
-                len(related_edges) - len(filtered),
-                len(related_edges),
-                DEDUP_SIM_THRESHOLD,
-            )
-        related_edges = filtered
-
-    # =========================================================================
-    # STAGE 1: Dedup — is this fact already known between these endpoints?
-    # =========================================================================
-    resolved_edge = extracted_edge
-    duplicate_edges: list[EntityEdge] = []
-
-    if related_edges:
-        t_dedup = time()
-        dedup_context = {
-            'existing_edges': [
-                {'idx': i, 'fact': edge.fact} for i, edge in enumerate(related_edges)
-            ],
-            'new_edge': extracted_edge.fact,
-            'edge_invalidation_candidates': [],  # empty — dedup only
-        }
-
-        logger.debug(
-            'EDGE_RESOLVE_STAGE1_DEDUP: edge "%s" — checking %d related edges',
-            extracted_edge.fact[:60],
-            len(related_edges),
-        )
-
-        llm_response = await llm_client.generate_response(
-            prompt_library.dedupe_edges.resolve_edge(dedup_context),
-            response_model=EdgeDuplicate,
-            model_size=ModelSize.small,
-            prompt_name='dedupe_edges.resolve_edge',
-        )
-        response_object = EdgeDuplicate(**llm_response)
-
-        duplicate_fact_ids: list[int] = [
-            i for i in response_object.duplicate_facts if 0 <= i < len(related_edges)
-        ]
-
-        if duplicate_fact_ids:
-            resolved_edge = related_edges[duplicate_fact_ids[0]]
-            if episode is not None:
-                resolved_edge.episodes.append(episode.uuid)
-            duplicate_edges = [related_edges[idx] for idx in duplicate_fact_ids]
-
-            await _extract_attributes(resolved_edge)
-
-            logger.debug(
-                'EDGE_RESOLVE_STAGE: edge %s — duplicate found, skipped invalidation LLM call (%.0f ms)',
-                extracted_edge.uuid,
-                (time() - start) * 1000,
-            )
-            return resolved_edge, [], duplicate_edges
-
-        logger.debug(
-            'EDGE_RESOLVE_STAGE1_DEDUP: no duplicate found (%.0f ms)',
-            (time() - t_dedup) * 1000,
-        )
+        resolved_edge = extracted_edge
+        duplicate_edges = []
 
     # =========================================================================
     # STAGE 2: Invalidation — does this NEW fact contradict existing facts?
@@ -831,7 +1009,7 @@ async def resolve_extracted_edge(
         if resolved_edge.invalid_at and not resolved_edge.expired_at:
             resolved_edge.expired_at = now
 
-    await _extract_attributes(resolved_edge)
+    await _extract_edge_attributes(llm_client, resolved_edge, episode, edge_type_candidates)
 
     logger.debug(
         'EDGE_RESOLVE_STAGE: edge %s -> %s, %d invalidations, total %.0f ms',

--- a/tests/utils/maintenance/test_edge_operations.py
+++ b/tests/utils/maintenance/test_edge_operations.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 
 from graphiti_core.edges import EntityEdge
 from graphiti_core.nodes import EntityNode, EpisodicNode
+from graphiti_core.prompts.dedupe_edges import EdgeBatchResolutions, EdgeResolution
 from graphiti_core.search.search_config import SearchResults
 from graphiti_core.utils.maintenance.edge_operations import (
     extract_edges,
@@ -351,6 +352,8 @@ async def test_resolve_extracted_edges_fast_path_deduplication(monkeypatch):
         existing_edges,
         episode,
         edge_type_candidates=None,
+        *,
+        _bypass_stage1=False,
     ):
         nonlocal resolve_call_count
         resolve_call_count += 1
@@ -444,9 +447,11 @@ async def test_resolve_extracted_edges_fast_path_deduplication(monkeypatch):
         {},
     )
 
-    # Fast path should have deduplicated the 3 identical edges to 1
-    # So resolve_extracted_edge should only be called once
-    assert resolve_call_count == 1
+    # Fast path should have deduplicated the 3 identical edges to 1 (intra-batch dedup).
+    # The surviving edge has no graph candidates (get_between_nodes and get_by_node_uuid
+    # return []), so it hits the no-candidates fast path and resolve_extracted_edge is
+    # never called.
+    assert resolve_call_count == 0
     assert len(resolved_edges) == 1
     assert invalidated_edges == []
     assert new_edges == resolved_edges  # All edges are new (no graph duplicates)
@@ -852,3 +857,284 @@ async def test_dedup_prefilter_none_embedding_warns_and_passes_all(mock_llm_clie
     mock_llm_client.generate_response.assert_called_once()
     assert resolved is extracted
     assert duplicates == []
+
+
+# ---------------------------------------------------------------------------
+# Task 9: resolve_edges_batch prompt construction
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_edges_batch_prompt_structure():
+    """resolve_edges_batch renders edge_idx and candidate_idx correctly."""
+    from graphiti_core.prompts.dedupe_edges import resolve_edges_batch
+
+    context = {
+        'edges': [
+            {
+                'edge_idx': 0,
+                'fact': 'Alice works at Acme Corp',
+                'candidates': [
+                    {'candidate_idx': 0, 'fact': 'Alice is employed at Acme'},
+                    {'candidate_idx': 1, 'fact': 'Alice lives in Paris'},
+                ],
+            },
+            {
+                'edge_idx': 1,
+                'fact': 'Bob runs every morning',
+                'candidates': [],
+            },
+        ]
+    }
+
+    messages = resolve_edges_batch(context)
+
+    assert len(messages) == 2
+    assert messages[0].role == 'system'
+    assert messages[1].role == 'user'
+
+    content = messages[1].content
+
+    # Both edges must appear with correct edge_idx tags
+    assert 'edge_idx="0"' in content
+    assert 'edge_idx="1"' in content
+
+    # Edge 0's fact and candidates must appear
+    assert 'Alice works at Acme Corp' in content
+    assert 'candidate_idx=0' in content
+    assert 'Alice is employed at Acme' in content
+    assert 'candidate_idx=1' in content
+    assert 'Alice lives in Paris' in content
+
+    # Edge 1 has no candidates
+    assert 'Bob runs every morning' in content
+    assert '(none)' in content
+
+    # Response requirement must reference both edge_idx values
+    assert '0, 1' in content
+    assert 'exactly 2 resolutions' in content
+
+
+# ---------------------------------------------------------------------------
+# Task 10: batched Stage 1 dedup path in resolve_extracted_edges
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_extracted_edges_batch_stage1_dedup(monkeypatch):
+    """Batched Stage 1 resolves one edge as a duplicate and passes the other to Stage 2."""
+    from graphiti_core.utils.maintenance import edge_operations as edge_ops
+
+    monkeypatch.setattr(edge_ops, 'create_entity_edge_embeddings', AsyncMock(return_value=None))
+
+    # A similar (but not exact-match) existing edge — forces batch Stage 1 LLM call
+    related_edge = EntityEdge(
+        source_node_uuid='source_uuid',
+        target_node_uuid='target_uuid',
+        name='test_edge',
+        group_id='group_1',
+        fact='Alice is employed at Acme Corp',
+        episodes=['episode_1'],
+        created_at=datetime.now(timezone.utc) - timedelta(days=1),
+        valid_at=None,
+        invalid_at=None,
+    )
+
+    monkeypatch.setattr(EntityEdge, 'get_between_nodes', AsyncMock(return_value=[related_edge]))
+    monkeypatch.setattr(EntityEdge, 'get_by_node_uuid', AsyncMock(return_value=[]))
+    monkeypatch.setattr(
+        edge_ops, 'search', AsyncMock(return_value=SearchResults(edges=[related_edge]))
+    )
+
+    async def immediate_gather(*aws, max_coroutines=None):
+        return [await aw for aw in aws]
+
+    monkeypatch.setattr(edge_ops, 'semaphore_gather', immediate_gather)
+
+    # Batch response: edge_idx=0 is a duplicate of candidate_idx=0; edge_idx=1 is new
+    batch_response = EdgeBatchResolutions(
+        edge_resolutions=[
+            EdgeResolution(edge_idx=0, duplicate_of=0),
+            EdgeResolution(edge_idx=1, duplicate_of=None),
+        ]
+    )
+
+    # Stage 2 for the non-duplicate edge returns no contradictions
+    stage2_response = {'duplicate_facts': [], 'contradicted_facts': []}
+
+    async def mock_generate_response(messages, response_model=None, **kwargs):
+        if response_model is EdgeBatchResolutions:
+            return batch_response.model_dump()
+        return stage2_response
+
+    llm_client = MagicMock()
+    llm_client.generate_response = AsyncMock(side_effect=mock_generate_response)
+
+    clients = SimpleNamespace(
+        driver=MagicMock(),
+        llm_client=llm_client,
+        embedder=MagicMock(),
+        cross_encoder=MagicMock(),
+    )
+
+    source_node = EntityNode(
+        uuid='source_uuid', name='Source', group_id='group_1', labels=['Entity']
+    )
+    target_node = EntityNode(
+        uuid='target_uuid', name='Target', group_id='group_1', labels=['Entity']
+    )
+
+    episode = EpisodicNode(
+        uuid='episode_uuid',
+        name='Episode',
+        group_id='group_1',
+        source='message',
+        source_description='desc',
+        content='content',
+        valid_at=datetime.now(timezone.utc),
+    )
+
+    # edge1: different wording → no exact-match fast path → goes to batch Stage 1
+    edge1 = EntityEdge(
+        source_node_uuid='source_uuid',
+        target_node_uuid='target_uuid',
+        name='test_edge',
+        group_id='group_1',
+        fact='Alice works at Acme Corp',
+        episodes=[],
+        created_at=datetime.now(timezone.utc),
+        valid_at=None,
+        invalid_at=None,
+    )
+
+    # edge2: genuinely new fact
+    edge2 = EntityEdge(
+        source_node_uuid='source_uuid',
+        target_node_uuid='target_uuid',
+        name='test_edge',
+        group_id='group_1',
+        fact='Alice is the VP of Engineering',
+        episodes=[],
+        created_at=datetime.now(timezone.utc),
+        valid_at=None,
+        invalid_at=None,
+    )
+
+    resolved_edges, invalidated_edges, new_edges = await resolve_extracted_edges(
+        clients,
+        [edge1, edge2],
+        episode,
+        [source_node, target_node],
+        {},
+        {},
+    )
+
+    # edge1 resolved to related_edge (duplicate identified by batch Stage 1)
+    assert resolved_edges[0].uuid == related_edge.uuid
+    # edge2 remains as the new edge
+    assert resolved_edges[1].uuid == edge2.uuid
+
+    assert len(new_edges) == 1
+    assert new_edges[0].uuid == edge2.uuid
+    assert invalidated_edges == []
+
+    # The batch LLM call must have been made with EdgeBatchResolutions
+    batch_call = next(
+        c for c in llm_client.generate_response.call_args_list
+        if c.kwargs.get('response_model') is EdgeBatchResolutions
+    )
+    assert batch_call is not None
+
+
+@pytest.mark.asyncio
+async def test_batch_stage1_missing_edge_idx_fallback(monkeypatch):
+    """Edges with missing edge_idx in the batch response default to non-duplicate."""
+    from graphiti_core.utils.maintenance import edge_operations as edge_ops
+
+    monkeypatch.setattr(edge_ops, 'create_entity_edge_embeddings', AsyncMock(return_value=None))
+
+    related_edge = EntityEdge(
+        source_node_uuid='source_uuid',
+        target_node_uuid='target_uuid',
+        name='test_edge',
+        group_id='group_1',
+        fact='Alice is employed at Acme Corp',
+        episodes=['episode_1'],
+        created_at=datetime.now(timezone.utc) - timedelta(days=1),
+        valid_at=None,
+        invalid_at=None,
+    )
+
+    monkeypatch.setattr(EntityEdge, 'get_between_nodes', AsyncMock(return_value=[related_edge]))
+    monkeypatch.setattr(EntityEdge, 'get_by_node_uuid', AsyncMock(return_value=[]))
+    monkeypatch.setattr(
+        edge_ops, 'search', AsyncMock(return_value=SearchResults(edges=[related_edge]))
+    )
+
+    async def immediate_gather(*aws, max_coroutines=None):
+        return [await aw for aw in aws]
+
+    monkeypatch.setattr(edge_ops, 'semaphore_gather', immediate_gather)
+
+    # LLM returns an empty response — no edge_idx entries at all
+    empty_batch_response = EdgeBatchResolutions(edge_resolutions=[])
+    stage2_response = {'duplicate_facts': [], 'contradicted_facts': []}
+
+    async def mock_generate_response(messages, response_model=None, **kwargs):
+        if response_model is EdgeBatchResolutions:
+            return empty_batch_response.model_dump()
+        return stage2_response
+
+    llm_client = MagicMock()
+    llm_client.generate_response = AsyncMock(side_effect=mock_generate_response)
+
+    clients = SimpleNamespace(
+        driver=MagicMock(),
+        llm_client=llm_client,
+        embedder=MagicMock(),
+        cross_encoder=MagicMock(),
+    )
+
+    source_node = EntityNode(
+        uuid='source_uuid', name='Source', group_id='group_1', labels=['Entity']
+    )
+    target_node = EntityNode(
+        uuid='target_uuid', name='Target', group_id='group_1', labels=['Entity']
+    )
+
+    episode = EpisodicNode(
+        uuid='episode_uuid',
+        name='Episode',
+        group_id='group_1',
+        source='message',
+        source_description='desc',
+        content='content',
+        valid_at=datetime.now(timezone.utc),
+    )
+
+    extracted_edge = EntityEdge(
+        source_node_uuid='source_uuid',
+        target_node_uuid='target_uuid',
+        name='test_edge',
+        group_id='group_1',
+        fact='Alice works at Acme Corp',
+        episodes=[],
+        created_at=datetime.now(timezone.utc),
+        valid_at=None,
+        invalid_at=None,
+    )
+
+    resolved_edges, invalidated_edges, new_edges = await resolve_extracted_edges(
+        clients,
+        [extracted_edge],
+        episode,
+        [source_node, target_node],
+        {},
+        {},
+    )
+
+    # Missing edge_idx → treated as non-duplicate → extracted_edge is the resolved edge
+    assert len(resolved_edges) == 1
+    assert resolved_edges[0].uuid == extracted_edge.uuid
+    assert len(new_edges) == 1
+    assert new_edges[0].uuid == extracted_edge.uuid
+    assert invalidated_edges == []


### PR DESCRIPTION
## Summary

Replace the per-edge Stage 1 (dedup) LLM calls in `resolve_extracted_edges` with a single batched LLM call that resolves all extracted edges against their respective candidate sets simultaneously, using indexed edge identifiers so the model can't conflate candidates across edges. Stage 2 (invalidation) remains per-edge in parallel, unchanged. This brings edge dedup to parity with entity dedup and reduces wall-clock time from ~30s to ~3–5s per chunk.

## Problem

Edge resolution currently makes one LLM call per edge for dedup (Stage 1) and optionally one more per edge for invalidation (Stage 2). For a chunk with 20 edges, that's 20+ sequential LLM calls at ~1.5s each — approximately 30 seconds on edge dedup alone.

This is inconsistent with entity dedup (`resolve_extracted_nodes` in `node_operations.py`), which batches all unresolved entities into a single LLM call via the `nodes` prompt. The asymmetry creates a significant performance bottleneck on dense chunks.

From production `EDGE_RESOLVE_STAGE` logs:
- Each edge: 1 LLM call for dedup, optionally 1 more for invalidation
- 20 edges in a chunk → 20+ sequential LLM calls
- Total time: ~30s per chunk on edge dedup alone

## Approach

### Approach

**Strategy**: Lift Stage 1 dedup out of the per-edge `semaphore_gather` in `resolve_extracted_edges` and replace it with a single batched LLM call. Stage 2 (invalidation) and attribute extraction remain per-edge, routed through the existing `resolve_extracted_edge` function (whose signature stays stable for external callers).

**Key design decisions** resolved below:

**1. How to bypass Stage 1 in `resolve_extracted_edge` for the batch path**

Add a private keyword-only parameter `_bypass_stage1: bool = False` to `resolve_extracted_edge`. When `True`, the function skips the fast paths and Stage 1 LLM block and proceeds directly to Stage 2 + `_extract_attributes`. External callers (`graphiti.py:1676`, `bulk_utils.py:471`) don't pass it, so they see no change. Duplicate edges identified by the batch Stage 1 are handled directly in `resolve_extracted_edges` without calling `resolve_extracted_edge` at all (they get `_extract_edge_attributes` called and are returned immediately).

Rejected alternative: adding a `pre_resolved_duplicate: EntityEdge | None` parameter with a sentinel. This would require threading the sentinel type through the type annotation, is trickier for callers to reason about, and conflates "fast-path exact match" with "batch dedup found a duplicate." A simple boolean flag is clearer.

**2. `_extract_attributes` refactoring**

Extract the nested `_extract_attributes` closure from `resolve_extracted_edge` to a module-level async function `_extract_edge_attributes(llm_client, edge, episode, edge_type_candidates)`. This is required because `resolve_extracted_edges` must call it directly for duplicate edges that skip Stage 2, and closures can't be shared across function boundaries.

**3. Candidate index scope**

Edge-local indices (restart at 0 per edge in the batch prompt). Each edge carries its own candidate list; the model returns a `candidate_idx` local to that edge's list, plus the global `edge_idx` to identify which edge it's resolving. Global indexing across all candidates of all edges increases the LLM's index-space and risk of confusion.

**4. Batch size constant**

`EDGE_DEDUP_BATCH_SIZE = 20` defined in `edge_operations.py` (the usage site) with a comment. The prompt file (`dedupe_edges.py`) is about prompt construction, not orchestration.

**5. ADR**

No ADR warranted. Batching the Stage 1 LLM call follows the established pattern in node dedup (`_resolve_with_llm`) and introduces no new architectural primitives.

---

### New/Modified Files

| File | Change |
|------|--------|
| `graphiti_core/prompts/dedupe_edges.py` | Add `EdgeResolution`, `EdgeBatchResolutions` Pydantic models; add `resolve_edges_batch` prompt function; update `Prompt` Protocol and `Versions` TypedDict |
| `graphiti_core/utils/maintenance/edge_operations.py` | Extract `_extract_attributes` to top-level `_extract_edge_attributes`; add `_bypass_stage1` param to `resolve_extracted_edge`; replace `semaphore_gather→resolve_extracted_edge` in `resolve_extracted_edges` with fast-path classification + batch Stage 1 + `semaphore_gather→resolve_extracted_edge(bypass)` for Stage 2; add `EDGE_DEDUP_BATCH_SIZE` constant; update log lines |
| `tests/utils/maintenance/test_edge_operations.py` | Update monkeypatched tests that relied on `resolve_extracted_edge` being called from `resolve_extracted_edges`; add tests for the new batch prompt, response parsing, and fallback behavior |

No user-facing documentation changes needed (internal optimization, no API surface change).

---

### Key Decisions

- **Stage 1 bypass via `_bypass_stage1` keyword arg**: Keeps `resolve_extracted_edge` stable for external callers while allowing the batch orchestrator to skip Stage 1 without duplicating Stage 2 logic. The underscore prefix signals it is an internal hook.
- **`_extract_edge_attributes` as module-level function**: Necessary to share attribute extraction between the duplicate-found path (called directly in `resolve_extracted_edges`) and the Stage 2 path (called inside `resolve_extracted_edge`). Eliminates the closure duplication risk.
- **Edge-local candidate indices in batch prompt**: Simpler for the LLM — each edge entry in the prompt is self-contained, and the model only needs to return an index into that edge's own candidate list.
- **`EDGE_DEDUP_BATCH_SIZE = 20` constant in `edge_operations.py`**: Bounds the prompt length for pathological inputs; configurable without touching the prompt file.

---

### Task Checklist

- [ ] **Task 1**: In `graphiti_core/prompts/dedupe_edges.py`, add `EdgeResolution(edge_idx: int, duplicate_of: int | None)` and `EdgeBatchResolutions(edge_resolutions: list[EdgeResolution])` Pydantic models
- [ ] **Task 2**: In `graphiti_core/prompts/dedupe_edges.py`, add `resolve_edges_batch` prompt function that accepts `context['edges']` (list of `{edge_idx, fact, candidates: [{candidate_idx, fact}]}`); update `Prompt` Protocol and `Versions` TypedDict to include it; add to `versions` registry
- [ ] **Task 3**: In `graphiti_core/utils/maintenance/edge_operations.py`, extract the `_extract_attributes` nested closure from `resolve_extracted_edge` into a top-level module-level async function `_extract_edge_attributes(llm_client, edge, episode, edge_type_candidates)`; update all call sites inside `resolve_extracted_edge` to call the top-level function
- [ ] **Task 4**: Add `_bypass_stage1: bool = False` keyword-only parameter to `resolve_extracted_edge`; gate the fast-path checks and Stage 1 LLM block behind `if not _bypass_stage1:`; document the parameter as internal
- [ ] **Task 5**: In `resolve_extracted_edges`, before the LLM resolve block, add fast-path classification loop: for each edge, check `(len(related_edges)==0 and len(existing_edges)==0)` (total skip) and exact-text-match in `related_edges`; record these as pre-resolved with their result, removing them from the batch payload
- [ ] **Task 6**: Add `EDGE_DEDUP_BATCH_SIZE = 20` constant (with comment) to `edge_operations.py`; implement the batched Stage 1 loop: chunk remaining edges into sub-batches of `EDGE_DEDUP_BATCH_SIZE`, call `prompt_library.dedupe_edges.resolve_edges_batch` with `EdgeBatchResolutions` response model, parse responses and record per-edge duplicate results; fall back to "no duplicate" for any `edge_idx` missing from the response (log a warning)
- [ ] **Task 7**: Replace the `semaphore_gather → resolve_extracted_edge` call in `resolve_extracted_edges` with two steps: (a) for edges the batch identified as duplicates, call `_extract_edge_attributes` and build the result tuple directly; (b) for non-duplicate edges, call `semaphore_gather → resolve_extracted_edge(..., _bypass_stage1=True)` in parallel
- [ ] **Task 8**: Update `EDGE_RESOLVE_STAGE`, `EDGE_RESOLVE_TIMING`, and `EDGE_RESOLVE_OUTCOMES` log lines in `resolve_extracted_edges` to report: number of edges sent to the batch call, number of fast-path-resolved edges, total Stage 1 LLM time, and per-batch timing
- [ ] **Task 9**: Write unit tests for `resolve_edges_batch` prompt construction: verify `edge_idx` and `candidate_idx` fields are correctly populated in the rendered prompt context
- [ ] **Task 10**: Write unit tests for the batched Stage 1 path in `resolve_extracted_edges`: mock `llm_client.generate_response` to return an `EdgeBatchResolutions` with a mix of duplicate and non-duplicate entries; assert the correct edges are resolved to existing edges vs. treated as new; assert that edges with missing `edge_idx` in the response default to non-duplicate
- [ ] **Task 11**: Update `test_resolve_extracted_edges_fast_path_deduplication` (line 336) and any other tests that monkeypatch `resolve_extracted_edge` within the context of `resolve_extracted_edges` — either remove the monkeypatch (since `resolve_extracted_edge` is now only called for Stage 2) or redirect to mock the new batch LLM call instead
- [ ] **Task 12**: Run `make lint` and `make test` to verify no regressions; fix any type errors from the new Pydantic models and the `_bypass_stage1` parameter

---

### Risks

- **External caller regression** (`graphiti.py:1676`, `bulk_utils.py:471`): Mitigated by keeping the `resolve_extracted_edge` signature additive (keyword-only default-`False` param). Add a regression test asserting `resolve_extracted_edge` called without `_bypass_stage1` still performs Stage 1.
- **Tests monkeypatching `resolve_extracted_edge` by name**: Once `resolve_extracted_edges` no longer calls `resolve_extracted_edge` for Stage 1, patches on that function won't intercept Stage 1. Task 11 directly addresses this — tests must be rewritten to mock the batch LLM call.
- **LLM index confusion with per-edge candidate pools**: Mitigated by the edge-local indexing scheme and clear XML-tagged sections per edge in the prompt (Task 2). Include an example in the prompt that shows multi-edge structure.
- **Sub-batch boundary edge cases**: If `EDGE_DEDUP_BATCH_SIZE = 20` splits an otherwise-correlating batch, duplicates across sub-batches are still detected correctly since each edge's candidates come from the graph, not from other edges in the batch.

---
Used 11/50 turns, 4k input / 8k output tokens.

## Verification

Replaced the per-edge sequential Stage 1 dedup LLM calls in `resolve_extracted_edges` with a single batched call per sub-batch of up to 20 edges, using a new indexed `resolve_edges_batch` prompt and `EdgeBatchResolutions` response model in `dedupe_edges.py`. The `_extract_attributes` closure was extracted to a module-level `_extract_edge_attributes` function, and a `_bypass_stage1` keyword parameter was added to `resolve_extracted_edge` so external callers (`graphiti.py`, `bulk_utils.py`) remain unaffected. Stage 2 invalidation still runs per-edge in parallel via `semaphore_gather`. All 11 edge-operations unit tests pass, including 3 new tests covering batch prompt structure, duplicate/non-duplicate routing, and missing-`edge_idx` fallback behavior.

---

Closes #40