### PR TITLE
Skip edge resolve LLM call when no candidates

### DIFF
--- a/graphiti_core/utils/maintenance/edge_operations.py
+++ b/graphiti_core/utils/maintenance/edge_operations.py
@@ -46,6 +46,20 @@ from graphiti_core.utils.maintenance.dedup_helpers import _normalize_string_exac
 
 logger = logging.getLogger(__name__)
 
+INVALIDATION_SIM_THRESHOLD = 0.3  # cosine similarity floor for invalidation candidates (stage 2)
+DEDUP_SIM_THRESHOLD = 0.5  # cosine similarity floor for dedup candidates (stage 1)
+
+
+def _cosine_sim(a: list[float] | None, b: list[float] | None) -> float:
+    if a is None or b is None or len(a) == 0 or len(b) == 0:
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b, strict=False))
+    norm_a = sum(x * x for x in a) ** 0.5
+    norm_b = sum(x * x for x in b) ** 0.5
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
 
 def build_episodic_edges(
     entity_nodes: list[EntityNode],
@@ -368,18 +382,7 @@ async def resolve_extracted_edges(
     # Build per-edge invalidation candidates from endpoint edges,
     # filtering by embedding similarity to avoid sending irrelevant edges to the LLM.
     # "Brett attended meeting X" should not be checked against "Brett manages Sanjeev".
-    INVALIDATION_SIM_THRESHOLD = 0.3  # cosine similarity floor for invalidation candidates
     MAX_INVALIDATION_CANDIDATES = 10  # cap per edge to bound LLM prompt size
-
-    def _cosine_sim(a: list[float] | None, b: list[float] | None) -> float:
-        if a is None or b is None or len(a) == 0 or len(b) == 0:
-            return 0.0
-        dot = sum(x * y for x, y in zip(a, b))
-        norm_a = sum(x * x for x in a) ** 0.5
-        norm_b = sum(x * x for x in b) ** 0.5
-        if norm_a == 0 or norm_b == 0:
-            return 0.0
-        return dot / (norm_a * norm_b)
 
     edge_invalidation_candidates: list[list[EntityEdge]] = []
     for extracted_edge, related_edges in zip(
@@ -669,6 +672,26 @@ async def resolve_extracted_edge(
                 extracted_edge.uuid, (time() - start) * 1000,
             )
             return resolved, [], []
+
+    # --- Stage 1 pre-filter: drop low-similarity dedup candidates ---
+    # Candidates with None embeddings score 0.0 via _cosine_sim and are dropped — consistent
+    # with stage 2 behavior. The None-embedding fallback below only applies to the extracted edge.
+    if extracted_edge.fact_embedding is None:
+        logger.warning(
+            'EDGE_RESOLVE_STAGE1_DEDUP: edge %s — fact_embedding is None, skipping similarity pre-filter',
+            extracted_edge.uuid,
+        )
+    else:
+        filtered = [
+            c for c in related_edges
+            if _cosine_sim(extracted_edge.fact_embedding, c.fact_embedding) >= DEDUP_SIM_THRESHOLD
+        ]
+        if len(filtered) < len(related_edges):
+            logger.debug(
+                'EDGE_RESOLVE_STAGE1_DEDUP: edge %s — dropped %d of %d candidates below DEDUP_SIM_THRESHOLD=%.2f',
+                extracted_edge.uuid, len(related_edges) - len(filtered), len(related_edges), DEDUP_SIM_THRESHOLD,
+            )
+        related_edges = filtered
 
     # =========================================================================
     # STAGE 1: Dedup — is this fact already known between these endpoints?

--- a/graphiti_core/utils/maintenance/edge_operations.py
+++ b/graphiti_core/utils/maintenance/edge_operations.py
@@ -308,7 +308,8 @@ async def resolve_extracted_edges(
     )
     logger.debug(
         'EDGE_RESOLVE_TIMING: get_between_nodes for %d edges in %.0f ms',
-        len(extracted_edges), (time() - t_between) * 1000,
+        len(extracted_edges),
+        (time() - t_between) * 1000,
     )
 
     # Merge override edges (e.g. from the recent Redis dedup cache) into
@@ -346,7 +347,8 @@ async def resolve_extracted_edges(
     )
     logger.debug(
         'EDGE_RESOLVE_TIMING: related_edges search for %d edges in %.0f ms',
-        len(extracted_edges), (time() - t_related) * 1000,
+        len(extracted_edges),
+        (time() - t_related) * 1000,
     )
 
     related_edges_lists: list[list[EntityEdge]] = [result.edges for result in related_edges_results]
@@ -376,7 +378,8 @@ async def resolve_extracted_edges(
 
     logger.debug(
         'EDGE_RESOLVE_TIMING: invalidation_candidate fetch for %d endpoints in %.0f ms',
-        len(endpoint_uuids), (time() - t_invalidation) * 1000,
+        len(endpoint_uuids),
+        (time() - t_invalidation) * 1000,
     )
 
     # Build per-edge invalidation candidates from endpoint edges,
@@ -385,9 +388,7 @@ async def resolve_extracted_edges(
     MAX_INVALIDATION_CANDIDATES = 10  # cap per edge to bound LLM prompt size
 
     edge_invalidation_candidates: list[list[EntityEdge]] = []
-    for extracted_edge, related_edges in zip(
-        extracted_edges, related_edges_lists, strict=True
-    ):
+    for extracted_edge, related_edges in zip(extracted_edges, related_edges_lists, strict=True):
         # Union edges from both endpoints
         source_edges = endpoint_edges_map.get(extracted_edge.source_node_uuid, [])
         target_edges = endpoint_edges_map.get(extracted_edge.target_node_uuid, [])
@@ -396,14 +397,14 @@ async def resolve_extracted_edges(
         # Remove the extracted edge itself and any already in related_edges
         related_uuids = {edge.uuid for edge in related_edges}
         candidates = [
-            e for e in all_endpoint_edges.values()
+            e
+            for e in all_endpoint_edges.values()
             if e.uuid not in related_uuids and e.uuid != extracted_edge.uuid
         ]
 
         # Filter by embedding similarity and take top N
         scored = [
-            (e, _cosine_sim(extracted_edge.fact_embedding, e.fact_embedding))
-            for e in candidates
+            (e, _cosine_sim(extracted_edge.fact_embedding, e.fact_embedding)) for e in candidates
         ]
         filtered = sorted(
             [(e, s) for e, s in scored if s >= INVALIDATION_SIM_THRESHOLD],
@@ -417,7 +418,10 @@ async def resolve_extracted_edges(
         if len(candidates) != len(result):
             logger.debug(
                 'EDGE_INVALIDATION_FILTER: edge "%s" — %d endpoint edges -> %d after sim filter (threshold=%.1f)',
-                extracted_edge.fact[:60], len(candidates), len(result), INVALIDATION_SIM_THRESHOLD,
+                extracted_edge.fact[:60],
+                len(candidates),
+                len(result),
+                INVALIDATION_SIM_THRESHOLD,
             )
 
     logger.debug(
@@ -503,23 +507,29 @@ async def resolve_extracted_edges(
 
     logger.debug(
         'EDGE_RESOLVE_TIMING: LLM resolve for %d edges in %.0f ms (%.0f ms/edge)',
-        len(extracted_edges), (time() - t_llm_resolve) * 1000,
+        len(extracted_edges),
+        (time() - t_llm_resolve) * 1000,
         (time() - t_llm_resolve) * 1000 / max(len(extracted_edges), 1),
     )
 
     # Count resolution outcomes
     exact_match_count = sum(
-        1 for edge, result in zip(extracted_edges, results, strict=True)
+        1
+        for edge, result in zip(extracted_edges, results, strict=True)
         if result[0].uuid != edge.uuid  # resolved to existing edge
     )
     no_op_invalidation_count = sum(
-        1 for result in results
+        1
+        for result in results
         if len(result[1]) == 0  # no invalidations
     )
     logger.debug(
         'EDGE_RESOLVE_OUTCOMES: %d edges resolved: %d matched existing, %d new, %d with invalidations, %d no-op invalidation checks',
-        len(extracted_edges), exact_match_count, len(extracted_edges) - exact_match_count,
-        sum(1 for r in results if len(r[1]) > 0), no_op_invalidation_count,
+        len(extracted_edges),
+        exact_match_count,
+        len(extracted_edges) - exact_match_count,
+        sum(1 for r in results if len(r[1]) > 0),
+        no_op_invalidation_count,
     )
 
     resolved_edges: list[EntityEdge] = []
@@ -652,7 +662,8 @@ async def resolve_extracted_edge(
         await _extract_attributes(extracted_edge)
         logger.debug(
             'EDGE_RESOLVE_STAGE: edge %s — no candidates, skipped both LLM calls (%.0f ms)',
-            extracted_edge.uuid, (time() - start) * 1000,
+            extracted_edge.uuid,
+            (time() - start) * 1000,
         )
         return extracted_edge, [], []
 
@@ -669,7 +680,8 @@ async def resolve_extracted_edge(
                 resolved.episodes.append(episode.uuid)
             logger.debug(
                 'EDGE_RESOLVE_STAGE: edge %s — exact text match, skipped both LLM calls (%.0f ms)',
-                extracted_edge.uuid, (time() - start) * 1000,
+                extracted_edge.uuid,
+                (time() - start) * 1000,
             )
             return resolved, [], []
 
@@ -683,13 +695,17 @@ async def resolve_extracted_edge(
         )
     else:
         filtered = [
-            c for c in related_edges
+            c
+            for c in related_edges
             if _cosine_sim(extracted_edge.fact_embedding, c.fact_embedding) >= DEDUP_SIM_THRESHOLD
         ]
         if len(filtered) < len(related_edges):
             logger.debug(
                 'EDGE_RESOLVE_STAGE1_DEDUP: edge %s — dropped %d of %d candidates below DEDUP_SIM_THRESHOLD=%.2f',
-                extracted_edge.uuid, len(related_edges) - len(filtered), len(related_edges), DEDUP_SIM_THRESHOLD,
+                extracted_edge.uuid,
+                len(related_edges) - len(filtered),
+                len(related_edges),
+                DEDUP_SIM_THRESHOLD,
             )
         related_edges = filtered
 
@@ -702,14 +718,17 @@ async def resolve_extracted_edge(
     if related_edges:
         t_dedup = time()
         dedup_context = {
-            'existing_edges': [{'idx': i, 'fact': edge.fact} for i, edge in enumerate(related_edges)],
+            'existing_edges': [
+                {'idx': i, 'fact': edge.fact} for i, edge in enumerate(related_edges)
+            ],
             'new_edge': extracted_edge.fact,
             'edge_invalidation_candidates': [],  # empty — dedup only
         }
 
         logger.debug(
             'EDGE_RESOLVE_STAGE1_DEDUP: edge "%s" — checking %d related edges',
-            extracted_edge.fact[:60], len(related_edges),
+            extracted_edge.fact[:60],
+            len(related_edges),
         )
 
         llm_response = await llm_client.generate_response(
@@ -734,7 +753,8 @@ async def resolve_extracted_edge(
 
             logger.debug(
                 'EDGE_RESOLVE_STAGE: edge %s — duplicate found, skipped invalidation LLM call (%.0f ms)',
-                extracted_edge.uuid, (time() - start) * 1000,
+                extracted_edge.uuid,
+                (time() - start) * 1000,
             )
             return resolved_edge, [], duplicate_edges
 
@@ -761,7 +781,8 @@ async def resolve_extracted_edge(
 
         logger.debug(
             'EDGE_RESOLVE_STAGE2_INVALIDATION: edge "%s" — checking %d endpoint edges',
-            extracted_edge.fact[:60], len(existing_edges),
+            extracted_edge.fact[:60],
+            len(existing_edges),
         )
 
         llm_response = await llm_client.generate_response(
@@ -780,7 +801,8 @@ async def resolve_extracted_edge(
 
         logger.debug(
             'EDGE_RESOLVE_STAGE2_INVALIDATION: %d contradictions found (%.0f ms)',
-            len(invalidation_candidates), (time() - t_invalidation) * 1000,
+            len(invalidation_candidates),
+            (time() - t_invalidation) * 1000,
         )
 
         # Apply temporal invalidation logic
@@ -790,9 +812,7 @@ async def resolve_extracted_edge(
             resolved_edge.expired_at = now
 
         if resolved_edge.expired_at is None:
-            invalidation_candidates.sort(
-                key=lambda c: (c.valid_at is None, ensure_utc(c.valid_at))
-            )
+            invalidation_candidates.sort(key=lambda c: (c.valid_at is None, ensure_utc(c.valid_at)))
             for candidate in invalidation_candidates:
                 candidate_valid_at_utc = ensure_utc(candidate.valid_at)
                 resolved_edge_valid_at_utc = ensure_utc(resolved_edge.valid_at)
@@ -815,7 +835,9 @@ async def resolve_extracted_edge(
 
     logger.debug(
         'EDGE_RESOLVE_STAGE: edge %s -> %s, %d invalidations, total %.0f ms',
-        extracted_edge.uuid, resolved_edge.uuid, len(invalidated_edges),
+        extracted_edge.uuid,
+        resolved_edge.uuid,
+        len(invalidated_edges),
         (time() - start) * 1000,
     )
 

--- a/tests/utils/maintenance/test_edge_operations.py
+++ b/tests/utils/maintenance/test_edge_operations.py
@@ -703,3 +703,148 @@ async def test_extract_edges_keeps_valid_edges_with_same_name_different_nodes(mo
     assert len(edges) == 1
     assert edges[0].source_node_uuid == 'alice_uuid'
     assert edges[0].target_node_uuid == 'paris_uuid'
+
+
+# ---------------------------------------------------------------------------
+# Stage 1 dedup similarity pre-filter tests
+# ---------------------------------------------------------------------------
+
+def _make_edge(fact: str, embedding: list[float] | None = None) -> EntityEdge:
+    return EntityEdge(
+        source_node_uuid='source_uuid',
+        target_node_uuid='target_uuid',
+        name='test_edge',
+        group_id='group_1',
+        fact=fact,
+        episodes=[],
+        created_at=datetime.now(timezone.utc),
+        valid_at=None,
+        invalid_at=None,
+        fact_embedding=embedding,
+    )
+
+
+def _make_episode() -> EpisodicNode:
+    return EpisodicNode(
+        uuid='ep_uuid',
+        name='Episode',
+        group_id='group_1',
+        source='message',
+        source_description='desc',
+        content='episode content',
+        valid_at=datetime.now(timezone.utc),
+    )
+
+
+@pytest.mark.asyncio
+async def test_dedup_prefilter_all_below_threshold_skips_llm(mock_llm_client):
+    """All related_edges below DEDUP_SIM_THRESHOLD → stage 1 LLM not called."""
+    extracted = _make_edge('User likes yoga', embedding=[1.0, 0.0])
+    # Orthogonal → cosine sim = 0.0, below 0.5
+    related = [_make_edge('Something unrelated', embedding=[0.0, 1.0])]
+
+    resolved, invalidated, duplicates = await resolve_extracted_edge(
+        mock_llm_client,
+        extracted,
+        related,
+        [],
+        _make_episode(),
+        edge_type_candidates=None,
+    )
+
+    mock_llm_client.generate_response.assert_not_called()
+    assert resolved is extracted
+    assert invalidated == []
+    assert duplicates == []
+
+
+@pytest.mark.asyncio
+async def test_dedup_prefilter_all_above_threshold_calls_llm(mock_llm_client):
+    """All related_edges above DEDUP_SIM_THRESHOLD → stage 1 LLM called."""
+    mock_llm_client.generate_response.return_value = {
+        'duplicate_facts': [],
+        'contradicted_facts': [],
+    }
+
+    extracted = _make_edge('User likes yoga', embedding=[1.0, 0.0])
+    # Parallel → cosine sim ≈ 1.0, above 0.5
+    related = [
+        _make_edge('User enjoys yoga', embedding=[0.9, 0.1]),
+        _make_edge('User practices yoga', embedding=[0.8, 0.1]),
+    ]
+
+    resolved, invalidated, duplicates = await resolve_extracted_edge(
+        mock_llm_client,
+        extracted,
+        related,
+        [],
+        _make_episode(),
+        edge_type_candidates=None,
+    )
+
+    mock_llm_client.generate_response.assert_called_once()
+    assert resolved is extracted
+    assert invalidated == []
+    assert duplicates == []
+
+
+@pytest.mark.asyncio
+async def test_dedup_prefilter_mixed_candidates_calls_llm_with_filtered_list(mock_llm_client):
+    """Mixed similarity → LLM called; low-sim candidate is not passed through."""
+    # Return duplicate_facts=[0] — resolves to index 0 of the filtered list
+    mock_llm_client.generate_response.return_value = {
+        'duplicate_facts': [0],
+        'contradicted_facts': [],
+    }
+
+    extracted = _make_edge('User likes yoga', embedding=[1.0, 0.0])
+    # low_sim is first in the list; high_sim is second
+    low_sim = _make_edge('Completely different', embedding=[0.0, 1.0])   # cosine = 0.0 → filtered out
+    high_sim = _make_edge('User enjoys yoga', embedding=[0.9, 0.1])       # cosine ≈ 0.994 → passes
+
+    resolved, invalidated, duplicates = await resolve_extracted_edge(
+        mock_llm_client,
+        extracted,
+        [low_sim, high_sim],
+        [],
+        _make_episode(),
+        edge_type_candidates=None,
+    )
+
+    mock_llm_client.generate_response.assert_called_once()
+    # duplicate_facts=[0] resolves to high_sim (index 0 after filter drops low_sim)
+    assert resolved.uuid == high_sim.uuid
+    assert len(duplicates) == 1
+    assert duplicates[0].uuid == high_sim.uuid
+
+
+@pytest.mark.asyncio
+async def test_dedup_prefilter_none_embedding_warns_and_passes_all(mock_llm_client, caplog):
+    """None fact_embedding on extracted edge → WARNING logged, all candidates passed to LLM."""
+    import logging
+    mock_llm_client.generate_response.return_value = {
+        'duplicate_facts': [],
+        'contradicted_facts': [],
+    }
+
+    extracted = _make_edge('User likes yoga', embedding=None)  # None embedding
+    related = [
+        _make_edge('User enjoys yoga', embedding=[1.0, 0.0]),
+        _make_edge('User practices yoga', embedding=[0.9, 0.1]),
+    ]
+
+    with caplog.at_level(logging.WARNING):
+        resolved, invalidated, duplicates = await resolve_extracted_edge(
+            mock_llm_client,
+            extracted,
+            related,
+            [],
+            _make_episode(),
+            edge_type_candidates=None,
+        )
+
+    assert any('fact_embedding is None' in r.message for r in caplog.records)
+    # LLM should be called with all 2 candidates (no filtering occurred)
+    mock_llm_client.generate_response.assert_called_once()
+    assert resolved is extracted
+    assert duplicates == []

--- a/tests/utils/maintenance/test_edge_operations.py
+++ b/tests/utils/maintenance/test_edge_operations.py
@@ -709,6 +709,7 @@ async def test_extract_edges_keeps_valid_edges_with_same_name_different_nodes(mo
 # Stage 1 dedup similarity pre-filter tests
 # ---------------------------------------------------------------------------
 
+
 def _make_edge(fact: str, embedding: list[float] | None = None) -> EntityEdge:
     return EntityEdge(
         source_node_uuid='source_uuid',
@@ -799,8 +800,10 @@ async def test_dedup_prefilter_mixed_candidates_calls_llm_with_filtered_list(moc
 
     extracted = _make_edge('User likes yoga', embedding=[1.0, 0.0])
     # low_sim is first in the list; high_sim is second
-    low_sim = _make_edge('Completely different', embedding=[0.0, 1.0])   # cosine = 0.0 → filtered out
-    high_sim = _make_edge('User enjoys yoga', embedding=[0.9, 0.1])       # cosine ≈ 0.994 → passes
+    low_sim = _make_edge(
+        'Completely different', embedding=[0.0, 1.0]
+    )  # cosine = 0.0 → filtered out
+    high_sim = _make_edge('User enjoys yoga', embedding=[0.9, 0.1])  # cosine ≈ 0.994 → passes
 
     resolved, invalidated, duplicates = await resolve_extracted_edge(
         mock_llm_client,
@@ -822,6 +825,7 @@ async def test_dedup_prefilter_mixed_candidates_calls_llm_with_filtered_list(moc
 async def test_dedup_prefilter_none_embedding_warns_and_passes_all(mock_llm_client, caplog):
     """None fact_embedding on extracted edge → WARNING logged, all candidates passed to LLM."""
     import logging
+
     mock_llm_client.generate_response.return_value = {
         'duplicate_facts': [],
         'contradicted_facts': [],


### PR DESCRIPTION
## Summary

Add a similarity-based pre-filter for stage 1 dedup: before calling the LLM, compute cosine similarity between the new edge's `fact_embedding` and each candidate in `related_edges`. Filter out candidates below `DEDUP_SIM_THRESHOLD = 0.5`. If the filtered list is empty, skip the LLM call and proceed directly to stage 2. If `fact_embedding` is missing, pass all candidates through (safe fallback) and log a warning. Stage 2 retains its existing `INVALIDATION_SIM_THRESHOLD = 0.3` unchanged.

## Problem

The `resolve_extracted_edge` function in `graphiti_core/utils/maintenance/edge_operations.py` has two fast paths (no-candidates, exact-text-match) but still invokes the LLM unnecessarily when candidates exist with weak semantic similarity.

**Stage 1 (dedup)**: `related_edges` (same-endpoint edges) triggers an LLM call for every non-empty list, even when the single candidate is semantically unrelated to the new edge. Production logs show many calls returning "no duplicate found" after ~1.5s when candidates had clearly different fact structure.

**Stage 2 (invalidation)**: `existing_edges` is already pre-filtered by `INVALIDATION_SIM_THRESHOLD = 0.3` (cosine) before reaching the LLM. This threshold is intentionally lower than stage 1 because invalidation requires only topical relevance, not near-identity.

For a 20-edge chunk where many edges have 0–1 weak candidates, unnecessary LLM calls add 10–15s of latency.

## Approach

### Approach

The change touches a single file: `graphiti_core/utils/maintenance/edge_operations.py`. The work falls into two logical units:

1. **Refactor** — promote `_cosine_sim()` and `INVALIDATION_SIM_THRESHOLD` from their current local scope inside `resolve_extracted_edges` to module scope, and add the new co-located constant `DEDUP_SIM_THRESHOLD = 0.5`.

2. **Feature** — insert the similarity pre-filter inside `resolve_extracted_edge` (inner function), after the two existing fast paths and before the `if related_edges:` block at line 679. The filter replaces `related_edges` with a filtered list; if the filtered list is empty the `if related_edges:` block naturally skips the LLM call.

This ordering is chosen because the refactor (task 1) is a prerequisite for the feature (task 2): `resolve_extracted_edge` cannot reference `_cosine_sim` until it is at module scope.

The pre-filter logic mirrors stage 2's existing similarity gate. The None-embedding check on the *extracted* edge is a special case: rather than filtering, it passes all candidates through and logs a WARNING. Candidates with None embeddings are handled implicitly by `_cosine_sim` returning 0.0, which puts them below the 0.5 threshold — they are filtered out, which is the correct conservative behavior per the spec.

### New/Modified Files

| File | Change |
|------|--------|
| `graphiti_core/utils/maintenance/edge_operations.py` | Promote `_cosine_sim`, `INVALIDATION_SIM_THRESHOLD` to module scope; add `DEDUP_SIM_THRESHOLD`; insert similarity pre-filter in `resolve_extracted_edge` |
| `tests/utils/maintenance/test_edge_operations.py` | Add unit tests for pre-filter behavior (filtered-all, partial-filter, None-embedding fallback) |

### Key Decisions

- **Promote `_cosine_sim` to module scope (not duplicate it)**: Duplication would create a maintenance hazard with two diverging implementations. Module-scope extraction has zero behavioral impact and makes the helper available to both functions.

- **`INVALIDATION_SIM_THRESHOLD` moves to module scope as a side effect**: Required by the spec constraint that both constants be co-located. The local assignment at line 371 becomes a reference to the module constant — same value, no behavior change.

- **Pre-filter replaces `related_edges` in-place (rebinding the local variable)**: This keeps the stage 1 block (`if related_edges:`) unchanged. The empty-list case automatically skips the LLM call via the existing guard. No restructuring of stage 1 code needed.

- **No ADR warranted**: The threshold values are stated in the spec, there is no `adrs/` directory in this repo, and the decision (pre-filter before LLM call) is explained fully in the spec comments. A future contributor reading the code will find the constants and their rationale in the surrounding context.

- **No documentation updates**: This is an internal performance optimization with no user-facing changes — no new config options, environment variables, CLI flags, or API surface.

### Task Checklist

- [ ] **Task 1**: Promote `_cosine_sim()` and `INVALIDATION_SIM_THRESHOLD` from inside `resolve_extracted_edges` to module scope (immediately after the `logger = …` line, before any function definitions). Add `DEDUP_SIM_THRESHOLD = 0.5` co-located with `INVALIDATION_SIM_THRESHOLD = 0.3`. Remove the local definitions of both from inside `resolve_extracted_edges` (lines 371–382). Verify the existing reference to `INVALIDATION_SIM_THRESHOLD` inside `resolve_extracted_edges` (line 406) now resolves to the module-level constant.

- [ ] **Task 2**: In `resolve_extracted_edge`, after the exact-text-match fast path block (after line 671) and before the stage 1 comment block, insert the similarity pre-filter:
  - If `extracted_edge.fact_embedding is None`: log a `WARNING` ("EDGE_RESOLVE_STAGE1_DEDUP: edge {uuid} — fact_embedding is None, skipping similarity pre-filter") and leave `related_edges` unchanged.
  - Otherwise: compute `_cosine_sim(extracted_edge.fact_embedding, c.fact_embedding)` for each candidate `c` in `related_edges`. Build `filtered = [c for c in related_edges if _cosine_sim(...) >= DEDUP_SIM_THRESHOLD]`. If `len(filtered) < len(related_edges)`, emit a `DEBUG` log ("EDGE_RESOLVE_STAGE1_DEDUP: edge {uuid} — dropped {n} of {total} candidates below DEDUP_SIM_THRESHOLD={threshold:.2f}"). Rebind `related_edges = filtered`.
  - The existing `if related_edges:` block at line 679 then naturally skips the LLM call if the filtered list is empty.

- [ ] **Task 3**: Add unit tests in `tests/utils/maintenance/test_edge_operations.py` for the new pre-filter. Tests must set explicit `fact_embedding` values (e.g., orthogonal unit vectors for low similarity, parallel vectors for high similarity) on both `extracted_edge` and candidate edges. Cover:
  - All candidates below threshold → stage 1 LLM mock is NOT called, function returns without dedup
  - All candidates above threshold → stage 1 LLM mock IS called with the full list
  - Mixed candidates → stage 1 LLM mock IS called with only above-threshold candidates
  - `extracted_edge.fact_embedding is None` → WARNING is logged, stage 1 LLM mock IS called with all candidates

### Risks

- **`INVALIDATION_SIM_THRESHOLD` usage at line 406**: After promoting to module scope, the local reference must be removed cleanly. A careful diff review after task 1 will confirm no local shadow remains.

- **Candidates with None embeddings are silently dropped**: An existing graph edge with no embedding scores 0.0 via `_cosine_sim` and is dropped below the 0.5 threshold. This is intentional and consistent with stage 2 behavior, but the WARNING log only fires when the *extracted* edge embedding is None. Implementer should note this behavior in a brief inline comment next to the filter to prevent future confusion.

- **Test fixture pattern**: Existing `EntityEdge` fixtures default `fact_embedding` to `None`. New tests must explicitly set embedding values — don't rely on default fixtures for the filter tests.

---
Used 8/50 turns, 4k input / 3k output tokens.

## Verification

Implemented the stage 1 dedup similarity pre-filter in `graphiti_core/utils/maintenance/edge_operations.py`. Promoted `_cosine_sim()` and `INVALIDATION_SIM_THRESHOLD` from local scope inside `resolve_extracted_edges` to module scope, added `DEDUP_SIM_THRESHOLD = 0.5` co-located with it, and inserted the pre-filter in `resolve_extracted_edge` before the stage 1 LLM call — dropping candidates below 0.5 cosine similarity, skipping the LLM entirely if all are dropped, and emitting a WARNING when `fact_embedding` is None. Added 4 unit tests covering all required scenarios (all-below, all-above, mixed, and None-embedding fallback); all 12 tests pass with ruff clean.

---

Closes #41