### PR TITLE
perf: reduce entity dedup candidates with hybrid BM25+HNSW and type filtering

### DIFF
--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -427,7 +427,7 @@ async def _semantic_candidate_search(
             ),
             node_fulltext_search(
                 clients.driver,
-                node.name,
+                node.name.replace('\n', ' '),
                 search_filter,
                 [node.group_id],
                 NODE_DEDUP_CANDIDATE_LIMIT,

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -21,7 +21,7 @@ from collections.abc import Awaitable, Callable
 from time import time
 from typing import Any, cast
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from graphiti_core.edges import EntityEdge
 from graphiti_core.errors import NodeLabelValidationError
@@ -387,8 +387,10 @@ def _build_dedup_search_filter(node: EntityNode) -> SearchFilters:
     if not specific_labels:
         return SearchFilters()
     try:
-        return SearchFilters(node_labels=specific_labels)
-    except NodeLabelValidationError:
+        # Use the first specific label only: multi-label filters have inconsistent semantics
+        # across backends (OR on Neo4j/FalkorDB vs AND on Ladybug).
+        return SearchFilters(node_labels=[specific_labels[0]])
+    except (NodeLabelValidationError, ValidationError):
         return SearchFilters()
 
 

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import asyncio
 import logging
 import re
 from collections.abc import Awaitable, Callable
@@ -23,6 +24,7 @@ from typing import Any, cast
 from pydantic import BaseModel
 
 from graphiti_core.edges import EntityEdge
+from graphiti_core.errors import NodeLabelValidationError
 from graphiti_core.graphiti_types import GraphitiClients
 from graphiti_core.helpers import semaphore_gather
 from graphiti_core.llm_client import LLMClient
@@ -44,7 +46,7 @@ from graphiti_core.prompts.extract_nodes import (
     SummarizedEntities,
 )
 from graphiti_core.search.search_filters import SearchFilters
-from graphiti_core.search.search_utils import node_similarity_search
+from graphiti_core.search.search_utils import node_fulltext_search, node_similarity_search
 from graphiti_core.utils.datetime_utils import utc_now
 from graphiti_core.utils.maintenance.dedup_helpers import (
     DedupCandidateIndexes,
@@ -60,8 +62,10 @@ logger = logging.getLogger(__name__)
 
 # Maximum number of nodes to summarize in a single LLM call
 MAX_NODES = 30
-NODE_DEDUP_CANDIDATE_LIMIT = 15
-NODE_DEDUP_COSINE_MIN_SCORE = 0.0  # lowered from 0.6; bge-base-en-v1.5 scores 0.5-0.65 for true dupes
+NODE_DEDUP_CANDIDATE_LIMIT = 10
+# 0.3 floor replaces the old 0.6 (too aggressive for short names on bge-base-en-v1.5).
+# BM25 provides the recall safety net for true duplicates that fall below 0.3.
+NODE_DEDUP_COSINE_MIN_SCORE = 0.3
 
 NodeSummaryFilter = Callable[[EntityNode], Awaitable[bool]]
 
@@ -116,15 +120,11 @@ async def extract_nodes(
             return False  # URL, not a file path
         return bool(_FILE_PATH_RE.search(name))
 
-    filtered_entities = [
-        e for e in raw_entities
-        if e.name.strip() and not _is_file_path(e.name)
-    ]
+    filtered_entities = [e for e in raw_entities if e.name.strip() and not _is_file_path(e.name)]
 
     end = time()
     logger.debug(
-        f'Extracted {len(filtered_entities)} entities{log_suffix} '
-        f'in {(end - start) * 1000:.0f} ms'
+        f'Extracted {len(filtered_entities)} entities{log_suffix} in {(end - start) * 1000:.0f} ms'
     )
 
     # Convert to EntityNode objects
@@ -378,11 +378,29 @@ async def _collect_candidate_nodes(
     return [_merge_candidate_nodes(result, existing_nodes_override) for result in search_results]
 
 
+def _build_dedup_search_filter(node: EntityNode) -> SearchFilters:
+    """Return a SearchFilters that restricts candidates to the node's specific type.
+
+    Untyped nodes (only the generic 'Entity' label) fall back to unfiltered search.
+    """
+    specific_labels = [label for label in node.labels if label != 'Entity']
+    if not specific_labels:
+        return SearchFilters()
+    try:
+        return SearchFilters(node_labels=specific_labels)
+    except NodeLabelValidationError:
+        return SearchFilters()
+
+
 async def _semantic_candidate_search(
     clients: GraphitiClients,
     extracted_nodes: list[EntityNode],
 ) -> list[list[EntityNode]]:
-    """Run direct cosine similarity search per extracted node without reranking."""
+    """Run hybrid HNSW+BM25 candidate search per extracted node with entity-type filtering.
+
+    For each node, HNSW and BM25 results are fetched concurrently, merged HNSW-first,
+    deduplicated by UUID, and capped at NODE_DEDUP_CANDIDATE_LIMIT.
+    """
     if not extracted_nodes:
         return []
 
@@ -396,17 +414,39 @@ async def _semantic_candidate_search(
             )
         )
 
+    async def _search_node(node: EntityNode, query_vector: list[float]) -> list[EntityNode]:
+        search_filter = _build_dedup_search_filter(node)
+        hnsw_results, bm25_results = await asyncio.gather(
+            node_similarity_search(
+                clients.driver,
+                query_vector,
+                search_filter,
+                [node.group_id],
+                NODE_DEDUP_CANDIDATE_LIMIT,
+                NODE_DEDUP_COSINE_MIN_SCORE,
+            ),
+            node_fulltext_search(
+                clients.driver,
+                node.name,
+                search_filter,
+                [node.group_id],
+                NODE_DEDUP_CANDIDATE_LIMIT,
+            ),
+        )
+        seen: set[str] = set()
+        merged: list[EntityNode] = []
+        for result in (*hnsw_results, *bm25_results):
+            if result.uuid not in seen:
+                seen.add(result.uuid)
+                merged.append(result)
+                if len(merged) == NODE_DEDUP_CANDIDATE_LIMIT:
+                    break
+        return merged
+
     return list(
         await semaphore_gather(
             *[
-                node_similarity_search(
-                    clients.driver,
-                    query_vector,
-                    SearchFilters(),
-                    [node.group_id],
-                    NODE_DEDUP_CANDIDATE_LIMIT,
-                    NODE_DEDUP_COSINE_MIN_SCORE,
-                )
+                _search_node(node, query_vector)
                 for node, query_vector in zip(extracted_nodes, query_vectors, strict=True)
             ]
         )
@@ -496,8 +536,7 @@ async def _resolve_with_llm(
     }
 
     logger.debug(
-        'DEDUP_LLM_CONTEXT: %d unresolved entities, %d existing candidates, '
-        'existing_names=%s',
+        'DEDUP_LLM_CONTEXT: %d unresolved entities, %d existing candidates, existing_names=%s',
         len(llm_extracted_nodes),
         len(indexes.existing_nodes),
         sorted(c.name for c in indexes.existing_nodes),
@@ -676,7 +715,8 @@ async def resolve_extracted_nodes(
 
     # Summary: how many were deduped vs kept as new
     deduped_count = sum(
-        1 for e, r in zip(extracted_nodes, state.resolved_nodes, strict=True)
+        1
+        for e, r in zip(extracted_nodes, state.resolved_nodes, strict=True)
         if r is not None and r.uuid != e.uuid
     )
     new_count = len(extracted_nodes) - deduped_count
@@ -983,9 +1023,7 @@ def _sanitize_label(label: str) -> str:
         return 'Entity'
 
     # Normalize to PascalCase
-    normalized = ''.join(
-        p[0].upper() + p[1:].lower() if len(p) > 1 else p.upper() for p in parts
-    )
+    normalized = ''.join(p[0].upper() + p[1:].lower() if len(p) > 1 else p.upper() for p in parts)
 
     # Ensure it starts with a letter (prepend 'Label' if it starts with a digit)
     if normalized and normalized[0].isdigit():

--- a/tests/utils/maintenance/test_node_operations.py
+++ b/tests/utils/maintenance/test_node_operations.py
@@ -6,6 +6,7 @@ import pytest
 
 from graphiti_core.graphiti_types import GraphitiClients
 from graphiti_core.nodes import EntityNode, EpisodeType, EpisodicNode
+from graphiti_core.search.search_filters import SearchFilters
 from graphiti_core.utils.datetime_utils import utc_now
 from graphiti_core.utils.maintenance.dedup_helpers import (
     DedupCandidateIndexes,
@@ -24,9 +25,12 @@ from graphiti_core.utils.maintenance.dedup_helpers import (
     _shingles,
 )
 from graphiti_core.utils.maintenance.node_operations import (
+    NODE_DEDUP_CANDIDATE_LIMIT,
+    _build_dedup_search_filter,
     _collect_candidate_nodes,
     _extract_entity_summaries_batch,
     _resolve_with_llm,
+    _semantic_candidate_search,
     extract_attributes_from_nodes,
     resolve_extracted_nodes,
 )
@@ -918,3 +922,192 @@ async def test_batch_summaries_calls_llm_for_long_summary():
     # LLM should have been called to condense the long summary
     llm_client.generate_response.assert_awaited_once()
     assert node.summary == 'Condensed summary'
+
+
+# ---------------------------------------------------------------------------
+# _build_dedup_search_filter tests (Task 5)
+# ---------------------------------------------------------------------------
+
+
+def test_build_dedup_search_filter_typed_node():
+    node = EntityNode(name='Alice', group_id='group', labels=['Entity', 'Person'])
+    result = _build_dedup_search_filter(node)
+    assert result.node_labels == ['Person']
+
+
+def test_build_dedup_search_filter_untyped_node():
+    node = EntityNode(name='Thing', group_id='group', labels=['Entity'])
+    result = _build_dedup_search_filter(node)
+    assert result.node_labels is None
+
+
+def test_build_dedup_search_filter_invalid_label_falls_back(monkeypatch):
+    from graphiti_core.errors import NodeLabelValidationError
+
+    original_init = SearchFilters.__init__
+
+    call_count = [0]
+
+    def raising_init(self, **kwargs):
+        call_count[0] += 1
+        if kwargs.get('node_labels'):
+            raise NodeLabelValidationError(kwargs['node_labels'])
+        original_init(self, **kwargs)
+
+    monkeypatch.setattr(SearchFilters, '__init__', raising_init)
+
+    node = EntityNode(name='Test', group_id='group', labels=['Entity', 'Person'])
+    result = _build_dedup_search_filter(node)
+    assert result.node_labels is None
+
+
+# ---------------------------------------------------------------------------
+# _semantic_candidate_search tests (Task 6)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_semantic_candidate_search_hnsw_results_before_bm25(monkeypatch):
+    """HNSW results appear before BM25-only results in merged output."""
+    hnsw_node = EntityNode(name='HNSW Node', group_id='group', labels=['Entity'])
+    bm25_node = EntityNode(name='BM25 Node', group_id='group', labels=['Entity'])
+
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations.node_similarity_search',
+        AsyncMock(return_value=[hnsw_node]),
+    )
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations.node_fulltext_search',
+        AsyncMock(return_value=[bm25_node]),
+    )
+
+    clients, _ = _make_clients()
+    clients.embedder.create_batch = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+
+    extracted = EntityNode(name='Test', group_id='group', labels=['Entity'])
+    results = await _semantic_candidate_search(clients, [extracted])
+
+    assert len(results) == 1
+    assert results[0][0].uuid == hnsw_node.uuid
+    assert results[0][1].uuid == bm25_node.uuid
+
+
+@pytest.mark.asyncio
+async def test_semantic_candidate_search_uuid_deduplication(monkeypatch):
+    """A node appearing in both HNSW and BM25 results is included only once."""
+    shared = EntityNode(name='Shared', group_id='group', labels=['Entity'])
+    bm25_only = EntityNode(name='BM25 Only', group_id='group', labels=['Entity'])
+
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations.node_similarity_search',
+        AsyncMock(return_value=[shared]),
+    )
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations.node_fulltext_search',
+        AsyncMock(return_value=[shared, bm25_only]),
+    )
+
+    clients, _ = _make_clients()
+    clients.embedder.create_batch = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+
+    extracted = EntityNode(name='Test', group_id='group', labels=['Entity'])
+    results = await _semantic_candidate_search(clients, [extracted])
+
+    uuids = [n.uuid for n in results[0]]
+    assert len(uuids) == 2
+    assert uuids[0] == shared.uuid
+    assert uuids[1] == bm25_only.uuid
+
+
+@pytest.mark.asyncio
+async def test_semantic_candidate_search_capped_at_limit(monkeypatch):
+    """Merged results are capped at NODE_DEDUP_CANDIDATE_LIMIT."""
+    hnsw_nodes = [
+        EntityNode(name=f'H{i}', group_id='group', labels=['Entity'])
+        for i in range(NODE_DEDUP_CANDIDATE_LIMIT)
+    ]
+    bm25_nodes = [
+        EntityNode(name=f'B{i}', group_id='group', labels=['Entity'])
+        for i in range(NODE_DEDUP_CANDIDATE_LIMIT)
+    ]
+
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations.node_similarity_search',
+        AsyncMock(return_value=hnsw_nodes),
+    )
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations.node_fulltext_search',
+        AsyncMock(return_value=bm25_nodes),
+    )
+
+    clients, _ = _make_clients()
+    clients.embedder.create_batch = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+
+    extracted = EntityNode(name='Test', group_id='group', labels=['Entity'])
+    results = await _semantic_candidate_search(clients, [extracted])
+
+    assert len(results[0]) == NODE_DEDUP_CANDIDATE_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_semantic_candidate_search_untyped_node_uses_unfiltered_search(monkeypatch):
+    """An untyped node (only 'Entity' label) passes SearchFilters() with no label filter."""
+    captured_filters: list[SearchFilters] = []
+
+    async def capturing_hnsw(driver, query_vector, search_filter, group_ids, limit, min_score):
+        captured_filters.append(search_filter)
+        return []
+
+    async def capturing_bm25(driver, query, search_filter, group_ids, limit):
+        captured_filters.append(search_filter)
+        return []
+
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations.node_similarity_search',
+        capturing_hnsw,
+    )
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations.node_fulltext_search',
+        capturing_bm25,
+    )
+
+    clients, _ = _make_clients()
+    clients.embedder.create_batch = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+
+    extracted = EntityNode(name='Test', group_id='group', labels=['Entity'])
+    await _semantic_candidate_search(clients, [extracted])
+
+    assert len(captured_filters) == 2
+    assert all(f.node_labels is None for f in captured_filters)
+
+
+@pytest.mark.asyncio
+async def test_semantic_candidate_search_typed_node_uses_label_filter(monkeypatch):
+    """A typed node passes SearchFilters(node_labels=['Person']) to both search paths."""
+    captured_filters: list[SearchFilters] = []
+
+    async def capturing_hnsw(driver, query_vector, search_filter, group_ids, limit, min_score):
+        captured_filters.append(search_filter)
+        return []
+
+    async def capturing_bm25(driver, query, search_filter, group_ids, limit):
+        captured_filters.append(search_filter)
+        return []
+
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations.node_similarity_search',
+        capturing_hnsw,
+    )
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations.node_fulltext_search',
+        capturing_bm25,
+    )
+
+    clients, _ = _make_clients()
+    clients.embedder.create_batch = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+
+    extracted = EntityNode(name='Alice', group_id='group', labels=['Entity', 'Person'])
+    await _semantic_candidate_search(clients, [extracted])
+
+    assert len(captured_filters) == 2
+    assert all(f.node_labels == ['Person'] for f in captured_filters)

--- a/tests/utils/maintenance/test_node_operations.py
+++ b/tests/utils/maintenance/test_node_operations.py
@@ -941,22 +941,15 @@ def test_build_dedup_search_filter_untyped_node():
     assert result.node_labels is None
 
 
-def test_build_dedup_search_filter_invalid_label_falls_back(monkeypatch):
-    from graphiti_core.errors import NodeLabelValidationError
-
-    original_init = SearchFilters.__init__
-
-    call_count = [0]
-
-    def raising_init(self, **kwargs):
-        call_count[0] += 1
-        if kwargs.get('node_labels'):
-            raise NodeLabelValidationError(kwargs['node_labels'])
-        original_init(self, **kwargs)
-
-    monkeypatch.setattr(SearchFilters, '__init__', raising_init)
-
-    node = EntityNode(name='Test', group_id='group', labels=['Entity', 'Person'])
+def test_build_dedup_search_filter_invalid_label_falls_back():
+    # model_construct bypasses EntityNode validation so we can inject an invalid label
+    # (contains a space — fails SAFE_CYPHER_IDENTIFIER_PATTERN). SearchFilters raises
+    # pydantic.ValidationError (wrapping NodeLabelValidationError) which must be caught.
+    node = EntityNode.model_construct(
+        name='Test',
+        group_id='group',
+        labels=['Entity', 'Invalid Label'],
+    )
     result = _build_dedup_search_filter(node)
     assert result.node_labels is None
 


### PR DESCRIPTION
## Summary

- **Entity-type filtering**: `_semantic_candidate_search` now builds a `SearchFilters(node_labels=[...])` per node so HNSW and BM25 only return same-type candidates (e.g. `Person` → `Person`). Untyped entities (`labels=['Entity']`) fall back to unfiltered search.
- **Hybrid BM25+HNSW**: Candidate search now runs both `node_similarity_search` and `node_fulltext_search` concurrently per node. Results are merged HNSW-first, deduplicated by UUID, and capped at `NODE_DEDUP_CANDIDATE_LIMIT`.
- **Reduced candidate cap**: `NODE_DEDUP_CANDIDATE_LIMIT` lowered from 15 → 10.
- **Restored cosine floor**: `NODE_DEDUP_COSINE_MIN_SCORE` raised from 0.0 back to 0.3 (the 0.0 workaround is now replaced by BM25 as the recall safety net for short entity names below threshold).

## Key Changes

| File | Change |
|------|--------|
| `graphiti_core/utils/maintenance/node_operations.py` | New constants, `_build_dedup_search_filter` helper, rewritten `_semantic_candidate_search` |
| `tests/utils/maintenance/test_node_operations.py` | 8 new unit tests for label filtering, hybrid merge, UUID dedup, and cap behavior |

## How to Test

1. Run unit tests: `make test` (or `DISABLE_FALKORDB=1 DISABLE_LADYBUG=1 DISABLE_NEPTUNE=1 uv run pytest tests/utils/ --timeout=60 -m "not integration"`)
2. All 223 unit tests pass with no regressions.
3. For integration validation: ingest a 10K-entity graph and observe chunk processing time return to ~25s (from ~150s+).

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)