### PR TITLE
fix: yield event loop after each WAL batch commit for live progress streaming

### DIFF
--- a/graphiti_core/driver/ladybug_driver.py
+++ b/graphiti_core/driver/ladybug_driver.py
@@ -7,6 +7,7 @@ the community fork of KuzuDB.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from contextlib import nullcontext
@@ -611,12 +612,19 @@ async def replay_wal_ladybug(
                             'Committed batch: %d total replayed (%d errors)',
                             replayed, errors,
                         )
+                        # Yield so other coroutines (e.g. progress-drain loops
+                        # listening on logging handlers) can run.  Without
+                        # this yield, replay_wal_ladybug pegs the event loop
+                        # and any concurrent `await` (in the calling service)
+                        # is starved until the replay completes.
+                        await asyncio.sleep(0)
 
         # Flush remaining batch
         if not dry_run and conn is not None and batch:
             batch_r, batch_e = _replay_batch(conn, batch)
             replayed += batch_r
             errors += batch_e
+            await asyncio.sleep(0)
 
     finally:
         if conn is not None:

--- a/graphiti_core/driver/ladybug_driver.py
+++ b/graphiti_core/driver/ladybug_driver.py
@@ -596,6 +596,11 @@ async def replay_wal_ladybug(
                     if dry_run:
                         logger.debug('DRY RUN seq=%d: %s', seq, cypher[:80])
                         replayed += 1
+                        # Yield periodically during dry_run too — the JSON
+                        # parse + regex work can still block the event loop
+                        # on large WALs (e.g. 900k mutations).
+                        if replayed % batch_size == 0:
+                            await asyncio.sleep(0)
                         continue
 
                     if conn is None:


### PR DESCRIPTION
## Summary

\`replay_wal_ladybug()\` is \`async def\` but its inner loop makes synchronous \`real_ladybug.Connection.execute()\` calls (\`BEGIN TRANSACTION\`, N × \`CREATE\`, \`COMMIT\`) that never yield to the event loop. The only \`await\` points were \`driver.build_indices_and_constraints()\` at the very end.

## Problem

Concurrent coroutines waiting on the event loop (e.g. the graphiti service's progress-drain loop that reads from a logging handler queue and forwards events over the IPC socket) are starved for the entire replay duration. Progress events pile up in the queue until the replay completes, then flush in a final burst. The MCP streaming path never delivers live progress to the app.

## Fix

Add \`await asyncio.sleep(0)\` after each committed batch. This yields control to the event loop long enough for other coroutines (like the progress-drain loop) to run, without meaningfully affecting replay throughput (one yield per ~30s of sync work).

## Evidence

Production trace: 41k WAL files, 900k mutations, 0 \`notifications/progress\` events reached the Liminis app during a 20+ minute replay. All the plumbing for streaming progress (verveguy/liminis-framework#142, #148) was working — but the replay blocked the event loop so nothing could drain.

## Test plan

- [x] \`asyncio\` import added
- [x] Yields placed after every batch commit and after the trailing batch
- [ ] Manual: trigger UI rebuild on Liminis app, confirm progress events stream during replay (not just at the end)