### PR TITLE
fix: yield per WAL file for smoother UI progress streaming

### DIFF
--- a/graphiti_core/driver/ladybug_driver.py
+++ b/graphiti_core/driver/ladybug_driver.py
@@ -570,6 +570,13 @@ async def replay_wal_ladybug(
         for wal_file in wal_files:
             logger.info('Replaying %s...', wal_file.name)
 
+            # Yield between files so UI progress updates smoothly. The
+            # between-batch yield (after COMMIT) is only every ~10s of
+            # wall time in fat files, which causes UI updates to arrive
+            # in 10-second bursts. Yielding per file keeps file-progress
+            # events draining at ~100ms intervals.
+            await asyncio.sleep(0)
+
             with open(wal_file, encoding='utf-8') as f:
                 for line_num, line in enumerate(f, 1):
                     line = line.strip()


### PR DESCRIPTION
## Summary

Follow-up to #49. The post-batch yield (every 10K mutations) runs only every ~10 seconds of wall time in fat files. Between commits, per-file progress events pile up and flush in bursts.

## Symptom

Liminis UI shows file-count progress jumping: \`109 / 41,632 files\`, then sits for 10s, then jumps forward. Not smooth.

## Fix

Add \`await asyncio.sleep(0)\` at the start of each file iteration. Yields ~100ms intervals (100 files/sec in fat files), letting the graphiti service's progress-drain loop send each file-progress event as it arrives.

## Test plan

- [x] Minimal change, single yield point added
- [ ] Manual: rebuild from UI, confirm file count updates smoothly rather than in bursts