### PR TITLE
fix: close QueryResults to prevent segfault on process teardown

### DIFF
--- a/graphiti_core/driver/ladybug_driver.py
+++ b/graphiti_core/driver/ladybug_driver.py
@@ -139,6 +139,24 @@ SCHEMA_QUERIES = f"""
 """
 
 
+def _close_query_result(qr: Any) -> None:
+    """Eagerly close a sync QueryResult (or list of them) returned by Connection.execute().
+
+    Without this, discarded QueryResults can be collected by cyclic GC long after
+    their parent Connection is closed; QueryResult.__del__ then calls into a freed
+    underlying C++ object and segfaults the process. AsyncConnection.execute() also
+    returns the same sync QueryResult type (it dispatches to Connection.execute via
+    run_in_executor), so the helper is used for both sync and awaited results.
+    """
+    if qr is None:
+        return
+    if isinstance(qr, list):
+        for r in qr:
+            r.close()
+    else:
+        qr.close()
+
+
 def _fix_record_timestamps(record: dict[str, Any]) -> dict[str, Any]:
     """Normalise naive datetime values to UTC.
 
@@ -275,12 +293,16 @@ class LadybugDriver(GraphDriver):
         if not results:
             return [], None, None
 
-        if isinstance(results, list):
-            dict_results = [
-                [_fix_record_timestamps(row) for row in result.rows_as_dict()] for result in results
-            ]
-        else:
-            dict_results = [_fix_record_timestamps(row) for row in results.rows_as_dict()]
+        try:
+            if isinstance(results, list):
+                dict_results = [
+                    [_fix_record_timestamps(row) for row in result.rows_as_dict()]
+                    for result in results
+                ]
+            else:
+                dict_results = [_fix_record_timestamps(row) for row in results.rows_as_dict()]
+        finally:
+            _close_query_result(results)
         return dict_results, None, None  # type: ignore
 
     def session(self, _database: str | None = None) -> GraphDriverSession:
@@ -327,14 +349,14 @@ class LadybugDriver(GraphDriver):
         # Load FTS extension on the async connection — setup_schema() loaded it
         # on the sync connection, but extensions are per-connection in LadybugDB.
         try:
-            await self.client.execute('LOAD EXTENSION FTS;')
+            _close_query_result(await self.client.execute('LOAD EXTENSION FTS;'))
             logger.info('FTS extension loaded on async connection')
         except Exception as e:
             logger.warning(f'Could not load FTS extension on async connection: {e}')
 
         # Load vector extension on async connection (same dual-load pattern as FTS).
         try:
-            await self.client.execute('LOAD EXTENSION vector;')
+            _close_query_result(await self.client.execute('LOAD EXTENSION vector;'))
             logger.info('vector extension loaded on async connection')
         except Exception as e:
             logger.warning(f'Could not load vector extension on async connection: {e}')
@@ -345,7 +367,7 @@ class LadybugDriver(GraphDriver):
 
         for query in get_fulltext_indices(GraphProvider.LADYBUG):
             try:
-                await self.client.execute(query)
+                _close_query_result(await self.client.execute(query))
                 logger.info(f'Created FTS index: {query[:80]}')
             except Exception as e:
                 if 'already exists' in str(e).lower():
@@ -356,7 +378,7 @@ class LadybugDriver(GraphDriver):
         # Create HNSW vector indexes for similarity search.
         for query in get_vector_indices(GraphProvider.LADYBUG):
             try:
-                await self.client.execute(query)
+                _close_query_result(await self.client.execute(query))
                 logger.info(f'Created vector index: {query[:80]}')
             except Exception as e:
                 if 'already exists' in str(e).lower():
@@ -369,30 +391,30 @@ class LadybugDriver(GraphDriver):
         # Load FTS extension before creating schema — required for
         # fulltext index creation in build_indices_and_constraints().
         try:
-            conn.execute('INSTALL FTS; LOAD EXTENSION FTS;')
+            _close_query_result(conn.execute('INSTALL FTS; LOAD EXTENSION FTS;'))
         except Exception as e:
             # FTS may already be installed/loaded
             logger.debug(f'FTS extension setup: {e}')
             try:
-                conn.execute('LOAD EXTENSION FTS;')
+                _close_query_result(conn.execute('LOAD EXTENSION FTS;'))
             except Exception as e_load:
                 logger.warning(
                     f'Could not load FTS extension — fulltext search will be unavailable: {e_load}'
                 )
         # Load vector extension for HNSW index support (same pattern as FTS above).
         try:
-            conn.execute('INSTALL vector; LOAD EXTENSION vector;')
+            _close_query_result(conn.execute('INSTALL vector; LOAD EXTENSION vector;'))
             logger.info('vector extension loaded on sync connection')
         except Exception as e:
             logger.debug(f'vector extension setup: {e}')
             try:
-                conn.execute('LOAD EXTENSION vector;')
+                _close_query_result(conn.execute('LOAD EXTENSION vector;'))
                 logger.info('vector extension loaded on sync connection')
             except Exception as e_load:
                 logger.warning(
                     f'Could not load vector extension — HNSW indexes will be unavailable: {e_load}'
                 )
-        conn.execute(SCHEMA_QUERIES)
+        _close_query_result(conn.execute(SCHEMA_QUERIES))
         conn.close()
 
 
@@ -537,14 +559,14 @@ async def replay_wal_ladybug(
         if not mutations:
             return 0, 0
         try:
-            conn.execute('BEGIN TRANSACTION')
+            _close_query_result(conn.execute('BEGIN TRANSACTION'))
             for _seq, cypher, params in mutations:
-                conn.execute(cypher, parameters=params)
-            conn.execute('COMMIT')
+                _close_query_result(conn.execute(cypher, parameters=params))
+            _close_query_result(conn.execute('COMMIT'))
             return len(mutations), 0
         except Exception as e:
             try:
-                conn.execute('ROLLBACK')
+                _close_query_result(conn.execute('ROLLBACK'))
             except Exception:
                 pass
             if len(mutations) == 1:

--- a/graphiti_core/driver/ladybug_driver.py
+++ b/graphiti_core/driver/ladybug_driver.py
@@ -139,7 +139,7 @@ SCHEMA_QUERIES = f"""
 """
 
 
-def _close_query_result(qr: Any) -> None:
+def _close_query_result(qr: kuzu.QueryResult | list[kuzu.QueryResult] | None) -> None:
     """Eagerly close a sync QueryResult (or list of them) returned by Connection.execute().
 
     Without this, discarded QueryResults can be collected by cyclic GC long after
@@ -290,10 +290,10 @@ class LadybugDriver(GraphDriver):
         if self._wal is not None:
             await self._wal.log_mutation(cypher_query_, cast(dict[str, Any], params), database='')
 
-        if not results:
-            return [], None, None
-
         try:
+            if not results:
+                return [], None, None
+
             if isinstance(results, list):
                 dict_results = [
                     [_fix_record_timestamps(row) for row in result.rows_as_dict()]

--- a/tests/driver/test_close_query_result.py
+++ b/tests/driver/test_close_query_result.py
@@ -1,0 +1,100 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from graphiti_core.driver.ladybug_driver import LadybugDriver, _close_query_result
+
+
+class _FakeQR:
+    """Minimal stand-in for real_ladybug.QueryResult that records close() calls."""
+
+    def __init__(self) -> None:
+        self.close_calls = 0
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+class TestCloseQueryResult:
+    def test_closes_single_query_result(self) -> None:
+        qr = _FakeQR()
+        _close_query_result(qr)
+        assert qr.close_calls == 1
+
+    def test_closes_every_item_in_list(self) -> None:
+        qrs = [_FakeQR(), _FakeQR(), _FakeQR()]
+        _close_query_result(qrs)
+        assert [qr.close_calls for qr in qrs] == [1, 1, 1]
+
+    def test_noop_on_none(self) -> None:
+        # None is returned when Connection.execute is short-circuited
+        # (e.g. by the early-return branch in LadybugDriver.execute_query).
+        _close_query_result(None)
+
+    def test_noop_on_empty_list(self) -> None:
+        _close_query_result([])
+
+
+class TestExecuteQueryClosesResult:
+    """Regression: LadybugDriver.execute_query must close the QueryResult
+    on every path — including the empty-results early-return — to prevent
+    the late-GC segfault in QueryResult.__del__ (see fix/replay-query-result-leak).
+    """
+
+    @pytest.mark.asyncio
+    async def test_closes_single_query_result(self) -> None:
+        driver = LadybugDriver(db=':memory:')
+        try:
+            fake_qr = _FakeQR()
+            fake_qr.rows_as_dict = MagicMock(return_value=[])  # type: ignore[attr-defined]
+            with patch.object(driver.client, 'execute', return_value=fake_qr) as mock_exec:
+                await driver.execute_query('MATCH (n) RETURN n')
+                mock_exec.assert_awaited_once()
+            assert fake_qr.close_calls == 1
+        finally:
+            await driver.close()
+
+    @pytest.mark.asyncio
+    async def test_closes_list_of_query_results(self) -> None:
+        driver = LadybugDriver(db=':memory:')
+        try:
+            fake_qrs = [_FakeQR(), _FakeQR()]
+            for qr in fake_qrs:
+                qr.rows_as_dict = MagicMock(return_value=[])  # type: ignore[attr-defined]
+            with patch.object(driver.client, 'execute', return_value=fake_qrs):
+                await driver.execute_query('RETURN 1; RETURN 2;')
+            assert [qr.close_calls for qr in fake_qrs] == [1, 1]
+        finally:
+            await driver.close()
+
+    @pytest.mark.asyncio
+    async def test_closes_on_empty_list_early_return(self) -> None:
+        """An empty list still needs to be recognised as 'nothing to process'
+        while not skipping the close step — the finally block handles it."""
+        driver = LadybugDriver(db=':memory:')
+        try:
+            # Empty list is falsy → hits `if not results: return [], None, None`,
+            # but must still flow through finally. _close_query_result([]) is a no-op,
+            # so there's nothing to assert on fakes here; the test exists to lock in
+            # that the early return stays inside try/finally and doesn't regress.
+            with patch.object(driver.client, 'execute', return_value=[]):
+                rows, _, _ = await driver.execute_query('RETURN 1')
+            assert rows == []
+        finally:
+            await driver.close()


### PR DESCRIPTION
## Summary

- WAL reload (`knowledge_rebuild_from_wal`) was killing the graphiti service mid-stream with no traceback. Renderer saw "Connection error: Service closed the connection mid-stream."
- Root cause: PR #50 opened a raw `ladybug.Connection` for batched WAL transactions and discarded the `QueryResult` from every `conn.execute(...)` call (BEGIN, each mutation, COMMIT). Those QRs are GC'd long after the parent connection is closed; `QueryResult.__del__` → `close()` then segfaults on freed C++ state.
- The same leak existed pre-PR-#50 in `setup_schema`, `build_indices_and_constraints`, and `execute_query` — PR #50 just added enough new per-mutation leaks per replay to reliably trigger GC at the wrong moment.
- Adds `_close_query_result(qr)` helper and wraps all 14 leaking call sites. `AsyncConnection.execute` returns the same sync `QueryResult` type via `run_in_executor`, so one helper handles both sync and awaited paths.

## Reproduction & verification

Standalone via `load_wal.py` against a 1,361-mutation WAL:

| | Exit | Stderr tail |
|---|---|---|
| Pre-fix | 1 | `Fatal Python error: Segmentation fault` in `real_ladybug/query_result.py:132 (close)` from `__del__` during asyncio loop teardown |
| Post-fix | 0 | clean — last line is `Replay complete: 1361 replayed, 0 skipped, 0 errors` |

Service-level reload also recovers — the silent process death between "Replay complete" and the next `_log` call no longer occurs.

## Test plan

- [x] Standalone reproduction via `load_wal.py` (above)
- [ ] Reviewer: confirm change is appropriate at all three pre-existing leak sites (`setup_schema`, `build_indices_and_constraints`, `execute_query`) — bundling them avoids leaving a known-buggy `__del__` path armed
- [ ] Optional follow-up: harden `real_ladybug.QueryResult.__del__` to no-op when the parent connection is closed (defense in depth — out of scope here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)