### PR TITLE
fix: make entity dedup candidate search label-agnostic

### DIFF
--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -377,7 +377,7 @@ async def _collect_candidate_nodes(
     return [_merge_candidate_nodes(result, existing_nodes_override) for result in search_results]
 
 
-def _build_dedup_search_filter(node: EntityNode) -> SearchFilters:
+def _build_dedup_search_filter(_node: EntityNode) -> SearchFilters:
     """Return an unfiltered SearchFilters for dedup candidate search.
 
     Label-scoped filtering was removed because the same real-world entity can receive
@@ -392,7 +392,7 @@ async def _semantic_candidate_search(
     clients: GraphitiClients,
     extracted_nodes: list[EntityNode],
 ) -> list[list[EntityNode]]:
-    """Run hybrid HNSW+BM25 candidate search per extracted node with entity-type filtering.
+    """Run hybrid HNSW+BM25 candidate search per extracted node without label filtering.
 
     For each node, HNSW and BM25 results are fetched concurrently, merged HNSW-first,
     deduplicated by UUID, and capped at NODE_DEDUP_CANDIDATE_LIMIT.

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -21,10 +21,9 @@ from collections.abc import Awaitable, Callable
 from time import time
 from typing import Any, cast
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 
 from graphiti_core.edges import EntityEdge
-from graphiti_core.errors import NodeLabelValidationError
 from graphiti_core.graphiti_types import GraphitiClients
 from graphiti_core.helpers import semaphore_gather
 from graphiti_core.llm_client import LLMClient
@@ -379,19 +378,14 @@ async def _collect_candidate_nodes(
 
 
 def _build_dedup_search_filter(node: EntityNode) -> SearchFilters:
-    """Return a SearchFilters that restricts candidates to the node's specific type.
+    """Return an unfiltered SearchFilters for dedup candidate search.
 
-    Untyped nodes (only the generic 'Entity' label) fall back to unfiltered search.
+    Label-scoped filtering was removed because the same real-world entity can receive
+    different labels across extraction calls, which would hide cross-label duplicates
+    from the candidate pool. The downstream exact-name and fuzzy-match passes are
+    already label-agnostic and handle disambiguation without label gating.
     """
-    specific_labels = [label for label in node.labels if label != 'Entity']
-    if not specific_labels:
-        return SearchFilters()
-    try:
-        # Use the first specific label only: multi-label filters have inconsistent semantics
-        # across backends (OR on Neo4j/FalkorDB vs AND on Ladybug).
-        return SearchFilters(node_labels=[specific_labels[0]])
-    except (NodeLabelValidationError, ValidationError):
-        return SearchFilters()
+    return SearchFilters()
 
 
 async def _semantic_candidate_search(

--- a/tests/utils/maintenance/test_node_operations.py
+++ b/tests/utils/maintenance/test_node_operations.py
@@ -1106,17 +1106,8 @@ async def test_semantic_candidate_search_typed_node_uses_unfiltered_search(monke
 
 
 # ---------------------------------------------------------------------------
-# Cross-label dedup regression tests (Tasks 5, 6, 7)
+# Cross-label dedup regression tests
 # ---------------------------------------------------------------------------
-
-
-def test_build_dedup_search_filter_typed_node_returns_unfiltered():
-    """A typed node with a specific label always produces an unfiltered SearchFilters."""
-    node = EntityNode(
-        name='Visualization Data Service', group_id='group', labels=['Entity', 'Technology']
-    )
-    result = _build_dedup_search_filter(node)
-    assert result.node_labels is None
 
 
 @pytest.mark.asyncio

--- a/tests/utils/maintenance/test_node_operations.py
+++ b/tests/utils/maintenance/test_node_operations.py
@@ -932,7 +932,7 @@ async def test_batch_summaries_calls_llm_for_long_summary():
 def test_build_dedup_search_filter_typed_node():
     node = EntityNode(name='Alice', group_id='group', labels=['Entity', 'Person'])
     result = _build_dedup_search_filter(node)
-    assert result.node_labels == ['Person']
+    assert result.node_labels is None
 
 
 def test_build_dedup_search_filter_untyped_node():
@@ -941,10 +941,9 @@ def test_build_dedup_search_filter_untyped_node():
     assert result.node_labels is None
 
 
-def test_build_dedup_search_filter_invalid_label_falls_back():
-    # model_construct bypasses EntityNode validation so we can inject an invalid label
-    # (contains a space — fails SAFE_CYPHER_IDENTIFIER_PATTERN). SearchFilters raises
-    # pydantic.ValidationError (wrapping NodeLabelValidationError) which must be caught.
+def test_build_dedup_search_filter_typed_node_with_invalid_label_returns_unfiltered():
+    # model_construct bypasses EntityNode validation to inject an invalid label.
+    # The filter is unconditionally unfiltered so label validity is irrelevant.
     node = EntityNode.model_construct(
         name='Test',
         group_id='group',
@@ -1075,8 +1074,8 @@ async def test_semantic_candidate_search_untyped_node_uses_unfiltered_search(mon
 
 
 @pytest.mark.asyncio
-async def test_semantic_candidate_search_typed_node_uses_label_filter(monkeypatch):
-    """A typed node passes SearchFilters(node_labels=['Person']) to both search paths."""
+async def test_semantic_candidate_search_typed_node_uses_unfiltered_search(monkeypatch):
+    """A typed node passes SearchFilters() with no label filter to both search paths."""
     captured_filters: list[SearchFilters] = []
 
     async def capturing_hnsw(driver, query_vector, search_filter, group_ids, limit, min_score):
@@ -1103,4 +1102,74 @@ async def test_semantic_candidate_search_typed_node_uses_label_filter(monkeypatc
     await _semantic_candidate_search(clients, [extracted])
 
     assert len(captured_filters) == 2
-    assert all(f.node_labels == ['Person'] for f in captured_filters)
+    assert all(f.node_labels is None for f in captured_filters)
+
+
+# ---------------------------------------------------------------------------
+# Cross-label dedup regression tests (Tasks 5, 6, 7)
+# ---------------------------------------------------------------------------
+
+
+def test_build_dedup_search_filter_typed_node_returns_unfiltered():
+    """A typed node with a specific label always produces an unfiltered SearchFilters."""
+    node = EntityNode(
+        name='Visualization Data Service', group_id='group', labels=['Entity', 'Technology']
+    )
+    result = _build_dedup_search_filter(node)
+    assert result.node_labels is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_extracted_nodes_cross_label_exact_match_no_llm_call(monkeypatch):
+    """Extracted node resolves to existing node with a different specific label via exact-name match without LLM."""
+    existing = EntityNode(
+        name='Visualization Data Service', group_id='group', labels=['Service', 'Entity']
+    )
+    extracted = EntityNode(
+        name='Visualization Data Service', group_id='group', labels=['Technology', 'Entity']
+    )
+
+    clients, llm_generate = _make_clients()
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations._semantic_candidate_search',
+        _semantic_candidates([[existing]]),
+    )
+
+    resolved, uuid_map, _ = await resolve_extracted_nodes(
+        clients,
+        [extracted],
+        episode=_make_episode(),
+        previous_episodes=[],
+    )
+
+    assert resolved[0].uuid == existing.uuid
+    assert uuid_map[extracted.uuid] == existing.uuid
+    llm_generate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resolve_extracted_nodes_cross_label_same_name_produces_duplicate_pair(monkeypatch):
+    """Two nodes with the same name but different specific labels produce a duplicate_pairs entry."""
+    existing = EntityNode(
+        name='Visualization Data Service', group_id='group', labels=['Service', 'Entity']
+    )
+    extracted = EntityNode(
+        name='Visualization Data Service', group_id='group', labels=['Technology', 'Entity']
+    )
+
+    clients, _ = _make_clients()
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations._semantic_candidate_search',
+        _semantic_candidates([[existing]]),
+    )
+
+    _, _, duplicate_pairs = await resolve_extracted_nodes(
+        clients,
+        [extracted],
+        episode=_make_episode(),
+        previous_episodes=[],
+    )
+
+    assert len(duplicate_pairs) == 1
+    assert duplicate_pairs[0][0].uuid == extracted.uuid
+    assert duplicate_pairs[0][1].uuid == existing.uuid


### PR DESCRIPTION
## Summary

- `_build_dedup_search_filter` previously applied a label filter to both the HNSW and BM25 candidate searches during entity deduplication, hiding cross-label duplicates from the pool
- The same real-world entity (e.g. `"Visualization Data Service"`) extracted with label `Technology` on one pass and `Service` on another would never be seen as a duplicate because each search only returned candidates matching its own label
- Fix: `_build_dedup_search_filter` now returns `SearchFilters()` unconditionally — the downstream exact-name and fuzzy-match passes in `dedup_helpers.py` are already label-agnostic and handle disambiguation without the label gate

## Key changes

- **`graphiti_core/utils/maintenance/node_operations.py`**: Replaced the label-scoped `_build_dedup_search_filter` body with `return SearchFilters()`. Removed the now-unused `NodeLabelValidationError` and `ValidationError` imports.
- **`tests/utils/maintenance/test_node_operations.py`**:
  - Updated `test_build_dedup_search_filter_typed_node` to assert `node_labels is None` (was `['Person']`)
  - Renamed and updated `test_semantic_candidate_search_typed_node_uses_label_filter` → `test_semantic_candidate_search_typed_node_uses_unfiltered_search`
  - Renamed `test_build_dedup_search_filter_invalid_label_falls_back` → `test_build_dedup_search_filter_typed_node_with_invalid_label_returns_unfiltered`
  - Added 3 regression tests: `test_build_dedup_search_filter_typed_node_returns_unfiltered`, `test_resolve_extracted_nodes_cross_label_exact_match_no_llm_call`, `test_resolve_extracted_nodes_cross_label_same_name_produces_duplicate_pair`

## How to test

```bash
DISABLE_FALKORDB=1 DISABLE_LADYBUG=1 DISABLE_NEPTUNE=1 pytest tests/utils/maintenance/test_node_operations.py --timeout=60 -q
```

All 44 tests pass, including the 3 new regression tests that verify cross-label dedup catches the exact-name match case without an LLM call and produces the correct `duplicate_pairs` entry.

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)