### PR TITLE
Add merge_entities operation for cleaning up duplicates in existing graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,79 @@ You can use Docker Compose to quickly start the required services:
 
   This will start the FalkorDB Docker service and related components.
 
+## Cleaning up duplicate entities
+
+Over time — especially after a bug fix or schema change — a graph can accumulate duplicate entity nodes
+representing the same real-world entity under slightly different names or labels. Graphiti provides
+`merge_entities` to collapse these duplicates without re-ingesting the source corpus.
+
+### Core API
+
+```python
+from graphiti_core import Graphiti
+from graphiti_core.graphiti import MergeRequest
+
+graphiti = Graphiti(graph_driver=driver)
+
+# Merge one duplicate into a survivor
+result = await graphiti.merge_entities(
+    survivor_uuid='uuid-of-canonical-entity',
+    duplicate_uuids=['uuid-of-dup-1', 'uuid-of-dup-2'],
+)
+print(f'Merged {result.merged_count} node(s)')
+print(f'Rewired {result.edges_rewired} edges, relinked {result.episodes_relinked} episodes')
+print(f'Labels after merge: {result.labels_after}')
+```
+
+Use `dry_run=True` to preview changes without writing to the graph:
+
+```python
+preview = await graphiti.merge_entities(
+    survivor_uuid='uuid-of-canonical-entity',
+    duplicate_uuids=['uuid-of-dup'],
+    dry_run=True,
+)
+# preview has the same shape as a real result — no writes were made
+```
+
+For bulk cleanup, use the batch variant:
+
+```python
+merges = [
+    MergeRequest(survivor_uuid='canonical-a', duplicate_uuids=['dup-a1', 'dup-a2']),
+    MergeRequest(survivor_uuid='canonical-b', duplicate_uuids=['dup-b1']),
+]
+results = await graphiti.merge_entities_batch(merges=merges, dry_run=False)
+for r in results:
+    if r.error:
+        print(f'  {r.survivor_uuid}: FAILED — {r.error}')
+    else:
+        print(f'  {r.survivor_uuid}: merged {r.merged_count} dup(s)')
+```
+
+### MCP tools
+
+The MCP server exposes two write tools for AI assistant workflows:
+
+- `knowledge_merge_entities(survivor_uuid, duplicate_uuids, dry_run=False)` — single merge
+- `knowledge_merge_entities_batch(merges, dry_run=False)` — batch merge
+
+Both tools respect `dry_run` for safe previewing before committing changes.
+
+### Merge semantics
+
+| Field | Behavior |
+|-------|----------|
+| `uuid`, `name`, `group_id`, `created_at`, `attributes` | Kept from survivor — never changed |
+| `labels` | Union: `sorted(set(survivor.labels) \| set(dup.labels))` |
+| `summary` | Survivor lines kept; unique dup lines appended |
+| `name_embedding` | Kept from survivor — no recomputation |
+| EntityEdge endpoints | Rewired from dup → survivor; collisions deduplicated |
+| Episodic `MENTIONS` edges | Redirected from dup → survivor; duplicates removed |
+
+> **Note:** A `suggest_duplicates → human review → merge_entities` end-to-end example will be added
+> in a future release once `suggest_duplicates` is implemented.
+
 ## MCP Server
 
 The `mcp_server` directory contains a Model Context Protocol (MCP) server implementation for Graphiti. This server

--- a/adrs/001-merge-entities-no-explicit-transactions.md
+++ b/adrs/001-merge-entities-no-explicit-transactions.md
@@ -1,0 +1,58 @@
+# ADR 001: merge_entities — no explicit database transactions
+
+**Status:** Accepted
+**Date:** 2026-04-30
+**Issue:** #54 — Add merge_entities operation for cleaning up duplicates in existing graphs
+
+## Context
+
+The `merge_entities` operation performs a multi-step write sequence for each duplicate node:
+
+1. Rewire entity edge endpoints (fetch → modify `source_node_uuid` / `target_node_uuid` → save each edge)
+2. Deduplicate colliding edges (delete)
+3. Rewire episodic MENTIONS edges (fetch → update `target_node_uuid` → save or delete)
+4. Save updated survivor (union of labels, appended summary)
+5. Delete duplicate node (`DETACH DELETE`)
+
+Each step is a separate database round-trip. If the process crashes between steps, the graph is left in a partially-merged state.
+
+The question is: should these steps be wrapped in a single explicit database transaction?
+
+## Decision
+
+**No explicit transactions.** The orchestration in `Graphiti.merge_entities()` issues each step as a separate auto-committed query, matching the existing pattern of all other multi-step `Graphiti` public methods (`add_episode`, `remove_episode`, `add_triplet`, etc.).
+
+## Rationale
+
+### 1. FalkorDB, LadybugDB, and Neptune do not support real multi-statement transactions
+
+All three backends use a `_SessionTransaction` shim (see `graphiti_core/driver/driver.py`) that executes queries immediately rather than buffering them in a real transaction. Wrapping the merge in a `driver.transaction()` context on these backends provides no atomicity guarantee — it is a no-op from a consistency standpoint.
+
+### 2. No existing precedent for explicit transactions in Graphiti public methods
+
+None of `add_episode`, `remove_episode`, `add_triplet`, or `search_` wrap multi-step writes in explicit transactions. Introducing explicit transactions only for `merge_entities` would create an inconsistent API surface: callers of Neo4j would get atomicity guarantees that callers of FalkorDB/LadybugDB/Neptune do not.
+
+### 3. merge_entities is a cleanup operation, not a hot path
+
+Merge is invoked manually (or via MCP) for legacy graph cleanup, not on every ingestion request. The consequence of partial failure (some edges rewired but duplicate node not yet deleted) is a temporarily inconsistent graph, not data loss. Re-running `merge_entities` with the same inputs is idempotent: already-rewired edges simply don't match the duplicate anymore, and the operation completes cleanly.
+
+### 4. Idempotency mitigates partial failure risk
+
+If `merge_entities` is interrupted mid-run, the caller can safely re-invoke it. The operation fetches the current state of edges and MENTIONS at runtime and only rewires edges that still point to the duplicate. Edges already rewired in a prior run will not be re-processed.
+
+## Consequences
+
+- **On Neo4j**: merge is not atomic. A crash between steps leaves the graph in a partially-merged state. Re-running the operation recovers cleanly.
+- **On FalkorDB / LadybugDB / Neptune**: same behaviour — no atomicity guarantee exists regardless.
+- **Callers must treat merge as best-effort atomic** and be prepared to re-run it in the event of failure.
+- **Docstring documents this**: `Graphiti.merge_entities()` explicitly states the best-effort atomicity guarantee in its docstring.
+
+## Alternatives considered
+
+### Wrap in `driver.transaction()` on Neo4j only
+
+Would provide atomicity on Neo4j but create a different execution model per backend (transactional on Neo4j, non-transactional elsewhere). The divergence would be invisible to callers and difficult to test. Rejected for consistency.
+
+### Compensating restore on partial failure
+
+If step N fails, undo steps 1…N-1. This is complex to implement correctly (requires saving pre-merge state), introduces new failure modes, and still doesn't help on backends without real transactions. Rejected as over-engineering for a cleanup operation.

--- a/graphiti_core/driver/falkordb/operations/episodic_edge_ops.py
+++ b/graphiti_core/driver/falkordb/operations/episodic_edge_ops.py
@@ -175,3 +175,18 @@ class FalkorEpisodicEdgeOperations(EpisodicEdgeOperations):
             limit=limit,
         )
         return [_episodic_edge_from_record(r) for r in records]
+
+    async def get_by_entity_uuid(
+        self,
+        executor: QueryExecutor,
+        entity_uuid: str,
+    ) -> list[EpisodicEdge]:
+        query = (
+            """
+            MATCH (n:Episodic)-[e:MENTIONS]->(m:Entity {uuid: $entity_uuid})
+            RETURN
+            """
+            + EPISODIC_EDGE_RETURN
+        )
+        records, _, _ = await executor.execute_query(query, entity_uuid=entity_uuid)
+        return [_episodic_edge_from_record(r) for r in records]

--- a/graphiti_core/driver/ladybug/operations/entity_edge_ops.py
+++ b/graphiti_core/driver/ladybug/operations/entity_edge_ops.py
@@ -187,10 +187,14 @@ class LadybugEntityEdgeOperations(EntityEdgeOperations):
         executor: QueryExecutor,
         node_uuid: str,
     ) -> list[EntityEdge]:
-        query = """
-            MATCH (n:Entity {uuid: $node_uuid})-[:RELATES_TO]->(e:RelatesToNode_)-[:RELATES_TO]->(m:Entity)
+        query = (
+            """
+            MATCH (n:Entity)-[:RELATES_TO]->(e:RelatesToNode_)-[:RELATES_TO]->(m:Entity)
+            WHERE n.uuid = $node_uuid OR m.uuid = $node_uuid
             RETURN
-            """ + get_entity_edge_return_query(GraphProvider.LADYBUG)
+            """
+            + get_entity_edge_return_query(GraphProvider.LADYBUG)
+        )
         records, _, _ = await executor.execute_query(query, node_uuid=node_uuid)
         return [parse_ladybug_entity_edge(r) for r in records]
 

--- a/graphiti_core/driver/ladybug/operations/episodic_edge_ops.py
+++ b/graphiti_core/driver/ladybug/operations/episodic_edge_ops.py
@@ -183,3 +183,18 @@ class LadybugEpisodicEdgeOperations(EpisodicEdgeOperations):
             limit=limit,
         )
         return [_episodic_edge_from_record(r) for r in records]
+
+    async def get_by_entity_uuid(
+        self,
+        executor: QueryExecutor,
+        entity_uuid: str,
+    ) -> list[EpisodicEdge]:
+        query = (
+            """
+            MATCH (n:Episodic)-[e:MENTIONS]->(m:Entity {uuid: $entity_uuid})
+            RETURN
+            """
+            + EPISODIC_EDGE_RETURN
+        )
+        records, _, _ = await executor.execute_query(query, entity_uuid=entity_uuid)
+        return [_episodic_edge_from_record(r) for r in records]

--- a/graphiti_core/driver/neo4j/operations/episodic_edge_ops.py
+++ b/graphiti_core/driver/neo4j/operations/episodic_edge_ops.py
@@ -176,3 +176,18 @@ class Neo4jEpisodicEdgeOperations(EpisodicEdgeOperations):
             routing_='r',
         )
         return [_episodic_edge_from_record(r) for r in records]
+
+    async def get_by_entity_uuid(
+        self,
+        executor: QueryExecutor,
+        entity_uuid: str,
+    ) -> list[EpisodicEdge]:
+        query = (
+            """
+            MATCH (n:Episodic)-[e:MENTIONS]->(m:Entity {uuid: $entity_uuid})
+            RETURN
+            """
+            + EPISODIC_EDGE_RETURN
+        )
+        records, _, _ = await executor.execute_query(query, entity_uuid=entity_uuid, routing_='r')
+        return [_episodic_edge_from_record(r) for r in records]

--- a/graphiti_core/driver/neptune/operations/episodic_edge_ops.py
+++ b/graphiti_core/driver/neptune/operations/episodic_edge_ops.py
@@ -175,3 +175,18 @@ class NeptuneEpisodicEdgeOperations(EpisodicEdgeOperations):
             limit=limit,
         )
         return [_episodic_edge_from_record(r) for r in records]
+
+    async def get_by_entity_uuid(
+        self,
+        executor: QueryExecutor,
+        entity_uuid: str,
+    ) -> list[EpisodicEdge]:
+        query = (
+            """
+            MATCH (n:Episodic)-[e:MENTIONS]->(m:Entity {uuid: $entity_uuid})
+            RETURN
+            """
+            + EPISODIC_EDGE_RETURN
+        )
+        records, _, _ = await executor.execute_query(query, entity_uuid=entity_uuid)
+        return [_episodic_edge_from_record(r) for r in records]

--- a/graphiti_core/driver/operations/episodic_edge_ops.py
+++ b/graphiti_core/driver/operations/episodic_edge_ops.py
@@ -76,3 +76,10 @@ class EpisodicEdgeOperations(ABC):
         limit: int | None = None,
         uuid_cursor: str | None = None,
     ) -> list[EpisodicEdge]: ...
+
+    @abstractmethod
+    async def get_by_entity_uuid(
+        self,
+        executor: QueryExecutor,
+        entity_uuid: str,
+    ) -> list[EpisodicEdge]: ...

--- a/graphiti_core/edges.py
+++ b/graphiti_core/edges.py
@@ -568,7 +568,8 @@ class EntityEdge(Edge):
         """
         if driver.provider == GraphProvider.LADYBUG:
             match_query = """
-                MATCH (n:Entity {uuid: $node_uuid})-[:RELATES_TO]->(e:RelatesToNode_)-[:RELATES_TO]->(m:Entity)
+                MATCH (n:Entity)-[:RELATES_TO]->(e:RelatesToNode_)-[:RELATES_TO]->(m:Entity)
+                WHERE n.uuid = $node_uuid OR m.uuid = $node_uuid
             """
 
         records, _, _ = await driver.execute_query(

--- a/graphiti_core/edges.py
+++ b/graphiti_core/edges.py
@@ -260,6 +260,23 @@ class EpisodicEdge(Edge):
             raise GroupsEdgesNotFoundError(group_ids)
         return edges
 
+    @classmethod
+    async def get_by_entity_uuid(cls, driver: GraphDriver, entity_uuid: str):
+        if driver.episodic_edge_ops is not None:
+            return await driver.episodic_edge_ops.get_by_entity_uuid(driver, entity_uuid)
+
+        records, _, _ = await driver.execute_query(
+            """
+            MATCH (n:Episodic)-[e:MENTIONS]->(m:Entity {uuid: $entity_uuid})
+            RETURN
+            """
+            + EPISODIC_EDGE_RETURN,
+            entity_uuid=entity_uuid,
+            routing_='r',
+        )
+
+        return [get_episodic_edge_from_record(record) for record in records]
+
 
 class EntityEdge(Edge):
     name: str = Field(description='name of the edge, relation name')

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -1783,6 +1783,8 @@ class Graphiti:
         if survivor_uuid in duplicate_uuids:
             raise ValueError(f'survivor_uuid {survivor_uuid!r} must not appear in duplicate_uuids')
 
+        duplicate_uuids = list(dict.fromkeys(duplicate_uuids))
+
         # Fetch and validate all duplicates before any writes
         validated_dups: list[EntityNode] = []
         for dup_uuid in duplicate_uuids:

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -1805,54 +1805,54 @@ class Graphiti:
         labels_after = list(survivor.labels)
         summary_after = survivor.summary or ''
 
-        if not dry_run:
-            # Fetch survivor's existing entity edges for collision detection
-            survivor_edges = await EntityEdge.get_by_node_uuid(self.driver, survivor_uuid)
-            survivor_edge_keys: set[tuple[str, str, str, str]] = {
-                (e.source_node_uuid, e.target_node_uuid, e.name, e.fact)
-                for e in survivor_edges
-            }
+        # Always fetch survivor's existing edges for collision/dedup detection so
+        # that dry-run mode can compute accurate counts without making any writes.
+        survivor_edges = await EntityEdge.get_by_node_uuid(self.driver, survivor_uuid)
+        survivor_edge_keys: set[tuple[str, str, str, str]] = {
+            (e.source_node_uuid, e.target_node_uuid, e.name, e.fact)
+            for e in survivor_edges
+        }
 
-            # Fetch survivor's existing MENTIONS edges for dedup detection
-            survivor_mentions = await EpisodicEdge.get_by_entity_uuid(self.driver, survivor_uuid)
-            survivor_episode_uuids: set[str] = {e.source_node_uuid for e in survivor_mentions}
+        survivor_mentions = await EpisodicEdge.get_by_entity_uuid(self.driver, survivor_uuid)
+        survivor_episode_uuids: set[str] = {e.source_node_uuid for e in survivor_mentions}
 
         for dup in validated_dups:
-            if not dry_run:
-                # --- Edge rewiring ---
-                dup_edges = await EntityEdge.get_by_node_uuid(self.driver, dup.uuid)
-                edges_to_delete: list[str] = []
-                for edge in dup_edges:
-                    new_src = survivor_uuid if edge.source_node_uuid == dup.uuid else edge.source_node_uuid
-                    new_tgt = survivor_uuid if edge.target_node_uuid == dup.uuid else edge.target_node_uuid
-                    key = (new_src, new_tgt, edge.name, edge.fact)
-                    if key in survivor_edge_keys:
-                        edges_to_delete.append(edge.uuid)
-                    else:
-                        edge.source_node_uuid = new_src
-                        edge.target_node_uuid = new_tgt
+            # --- Edge rewiring ---
+            dup_edges = await EntityEdge.get_by_node_uuid(self.driver, dup.uuid)
+            edges_to_delete: list[str] = []
+            for edge in dup_edges:
+                new_src = survivor_uuid if edge.source_node_uuid == dup.uuid else edge.source_node_uuid
+                new_tgt = survivor_uuid if edge.target_node_uuid == dup.uuid else edge.target_node_uuid
+                key = (new_src, new_tgt, edge.name, edge.fact)
+                if key in survivor_edge_keys:
+                    edges_to_delete.append(edge.uuid)
+                else:
+                    edge.source_node_uuid = new_src
+                    edge.target_node_uuid = new_tgt
+                    if not dry_run:
                         await edge.save(self.driver)
-                        survivor_edge_keys.add(key)
-                        edges_rewired += 1
-                if edges_to_delete:
-                    await Edge.delete_by_uuids(self.driver, edges_to_delete)
+                    survivor_edge_keys.add(key)
+                    edges_rewired += 1
+            if edges_to_delete and not dry_run:
+                await Edge.delete_by_uuids(self.driver, edges_to_delete)
 
-                # --- MENTIONS rewiring ---
-                dup_mentions = await EpisodicEdge.get_by_entity_uuid(self.driver, dup.uuid)
-                mentions_to_delete: list[str] = []
-                for mention in dup_mentions:
-                    episode_uuid = mention.source_node_uuid
-                    if episode_uuid in survivor_episode_uuids:
-                        mentions_to_delete.append(mention.uuid)
-                    else:
-                        mention.target_node_uuid = survivor_uuid
+            # --- MENTIONS rewiring ---
+            dup_mentions = await EpisodicEdge.get_by_entity_uuid(self.driver, dup.uuid)
+            mentions_to_delete: list[str] = []
+            for mention in dup_mentions:
+                episode_uuid = mention.source_node_uuid
+                if episode_uuid in survivor_episode_uuids:
+                    mentions_to_delete.append(mention.uuid)
+                else:
+                    mention.target_node_uuid = survivor_uuid
+                    if not dry_run:
                         await mention.save(self.driver)
-                        survivor_episode_uuids.add(episode_uuid)
-                        episodes_relinked += 1
-                if mentions_to_delete:
-                    await Edge.delete_by_uuids(self.driver, mentions_to_delete)
+                    survivor_episode_uuids.add(episode_uuid)
+                    episodes_relinked += 1
+            if mentions_to_delete and not dry_run:
+                await Edge.delete_by_uuids(self.driver, mentions_to_delete)
 
-            # --- Label union and summary merge (computed even in dry_run) ---
+            # --- Label union and summary merge ---
             labels_after = sorted(set(labels_after) | set(dup.labels))
 
             existing_lines = set(summary_after.splitlines())

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -134,6 +134,21 @@ class AddTripletResults(BaseModel):
     edges: list[EntityEdge]
 
 
+class MergeEntitiesResult(BaseModel):
+    survivor_uuid: str
+    merged_count: int
+    edges_rewired: int
+    episodes_relinked: int
+    labels_after: list[str]
+    summary_after: str
+    error: str | None = None
+
+
+class MergeRequest(BaseModel):
+    survivor_uuid: str
+    duplicate_uuids: list[str]
+
+
 class Graphiti:
     def __init__(
         self,
@@ -1732,3 +1747,173 @@ class Graphiti:
         from graphiti_core.search.search_utils import invalidate_embedding_cache
 
         invalidate_embedding_cache('all')
+
+    async def merge_entities(
+        self,
+        survivor_uuid: str,
+        duplicate_uuids: list[str],
+        dry_run: bool = False,
+    ) -> MergeEntitiesResult:
+        """Merge duplicate entity nodes into a single survivor node.
+
+        Rewires all EntityEdge endpoints and Episodic MENTIONS edges from each
+        duplicate to the survivor, unions labels, deduplicates summary lines, then
+        deletes each duplicate node.
+
+        This operation is best-effort atomic: on Neo4j each step runs in its own
+        auto-committed transaction. On FalkorDB, LadybugDB, and Neptune there is no
+        real transaction support — a failure mid-merge will leave the graph in a
+        partially-merged state.
+
+        Args:
+            survivor_uuid: UUID of the entity node that survives the merge.
+            duplicate_uuids: UUIDs of entity nodes to collapse into the survivor.
+            dry_run: If True, compute and return the result but make no writes.
+
+        Returns:
+            MergeEntitiesResult describing what was (or would be) changed.
+
+        Raises:
+            NodeNotFoundError: If the survivor UUID is not found.
+            ValueError: If survivor_uuid appears in duplicate_uuids, or if any
+                duplicate has a different group_id than the survivor.
+        """
+        survivor = await EntityNode.get_by_uuid(self.driver, survivor_uuid)
+
+        if survivor_uuid in duplicate_uuids:
+            raise ValueError(f'survivor_uuid {survivor_uuid!r} must not appear in duplicate_uuids')
+
+        # Fetch and validate all duplicates before any writes
+        validated_dups: list[EntityNode] = []
+        for dup_uuid in duplicate_uuids:
+            try:
+                dup = await EntityNode.get_by_uuid(self.driver, dup_uuid)
+            except NodeNotFoundError:
+                logger.warning(f'merge_entities: duplicate UUID {dup_uuid!r} not found; skipping')
+                continue
+            if dup.group_id != survivor.group_id:
+                raise ValueError(
+                    f'duplicate {dup_uuid!r} has group_id {dup.group_id!r} which differs '
+                    f"from survivor's group_id {survivor.group_id!r}; cross-partition merges "
+                    'are not supported'
+                )
+            validated_dups.append(dup)
+
+        merged_count = 0
+        edges_rewired = 0
+        episodes_relinked = 0
+        labels_after = list(survivor.labels)
+        summary_after = survivor.summary or ''
+
+        if not dry_run:
+            # Fetch survivor's existing entity edges for collision detection
+            survivor_edges = await EntityEdge.get_by_node_uuid(self.driver, survivor_uuid)
+            survivor_edge_keys: set[tuple[str, str, str, str]] = {
+                (e.source_node_uuid, e.target_node_uuid, e.name, e.fact)
+                for e in survivor_edges
+            }
+
+            # Fetch survivor's existing MENTIONS edges for dedup detection
+            survivor_mentions = await EpisodicEdge.get_by_entity_uuid(self.driver, survivor_uuid)
+            survivor_episode_uuids: set[str] = {e.source_node_uuid for e in survivor_mentions}
+
+        for dup in validated_dups:
+            if not dry_run:
+                # --- Edge rewiring ---
+                dup_edges = await EntityEdge.get_by_node_uuid(self.driver, dup.uuid)
+                edges_to_delete: list[str] = []
+                for edge in dup_edges:
+                    new_src = survivor_uuid if edge.source_node_uuid == dup.uuid else edge.source_node_uuid
+                    new_tgt = survivor_uuid if edge.target_node_uuid == dup.uuid else edge.target_node_uuid
+                    key = (new_src, new_tgt, edge.name, edge.fact)
+                    if key in survivor_edge_keys:
+                        edges_to_delete.append(edge.uuid)
+                    else:
+                        edge.source_node_uuid = new_src
+                        edge.target_node_uuid = new_tgt
+                        await edge.save(self.driver)
+                        survivor_edge_keys.add(key)
+                        edges_rewired += 1
+                if edges_to_delete:
+                    await Edge.delete_by_uuids(self.driver, edges_to_delete)
+
+                # --- MENTIONS rewiring ---
+                dup_mentions = await EpisodicEdge.get_by_entity_uuid(self.driver, dup.uuid)
+                mentions_to_delete: list[str] = []
+                for mention in dup_mentions:
+                    episode_uuid = mention.source_node_uuid
+                    if episode_uuid in survivor_episode_uuids:
+                        mentions_to_delete.append(mention.uuid)
+                    else:
+                        mention.target_node_uuid = survivor_uuid
+                        await mention.save(self.driver)
+                        survivor_episode_uuids.add(episode_uuid)
+                        episodes_relinked += 1
+                if mentions_to_delete:
+                    await Edge.delete_by_uuids(self.driver, mentions_to_delete)
+
+            # --- Label union and summary merge (computed even in dry_run) ---
+            labels_after = sorted(set(labels_after) | set(dup.labels))
+
+            existing_lines = set(summary_after.splitlines())
+            for line in (dup.summary or '').splitlines():
+                if line not in existing_lines:
+                    summary_after = (summary_after + '\n' + line).strip()
+                    existing_lines.add(line)
+
+            if not dry_run:
+                survivor.labels = labels_after
+                survivor.summary = summary_after
+                await survivor.save(self.driver)
+                await Node.delete_by_uuids(self.driver, [dup.uuid])
+
+            merged_count += 1
+
+        return MergeEntitiesResult(
+            survivor_uuid=survivor_uuid,
+            merged_count=merged_count,
+            edges_rewired=edges_rewired,
+            episodes_relinked=episodes_relinked,
+            labels_after=labels_after,
+            summary_after=summary_after,
+        )
+
+    async def merge_entities_batch(
+        self,
+        merges: list[MergeRequest],
+        dry_run: bool = False,
+    ) -> list[MergeEntitiesResult]:
+        """Merge multiple sets of duplicate entities in sequence.
+
+        Each merge in the list is processed independently. If one merge fails,
+        successful merges already committed are not rolled back; the failed entry
+        receives an MergeEntitiesResult with error set and merged_count=0.
+
+        Args:
+            merges: List of MergeRequest objects, each specifying a survivor_uuid
+                and duplicate_uuids to collapse into it.
+            dry_run: If True, no writes are made for any merge in the batch.
+
+        Returns:
+            One MergeEntitiesResult per entry in merges, in the same order.
+        """
+        results: list[MergeEntitiesResult] = []
+        for req in merges:
+            try:
+                result = await self.merge_entities(
+                    survivor_uuid=req.survivor_uuid,
+                    duplicate_uuids=req.duplicate_uuids,
+                    dry_run=dry_run,
+                )
+            except Exception as exc:
+                result = MergeEntitiesResult(
+                    survivor_uuid=req.survivor_uuid,
+                    merged_count=0,
+                    edges_rewired=0,
+                    episodes_relinked=0,
+                    labels_after=[],
+                    summary_after='',
+                    error=str(exc),
+                )
+            results.append(result)
+        return results

--- a/mcp_server/src/graphiti_mcp_server.py
+++ b/mcp_server/src/graphiti_mcp_server.py
@@ -14,6 +14,7 @@ from typing import Any, Optional
 from dotenv import load_dotenv
 from graphiti_core import Graphiti
 from graphiti_core.edges import EntityEdge
+from graphiti_core.graphiti import MergeRequest
 from graphiti_core.nodes import EpisodeType, EpisodicNode
 from graphiti_core.search.search_filters import SearchFilters
 from graphiti_core.utils.maintenance.graph_data_operations import clear_data
@@ -26,6 +27,7 @@ from models.response_types import (
     EpisodeSearchResponse,
     ErrorResponse,
     FactSearchResponse,
+    MergeEntitiesResponse,
     NodeResult,
     NodeSearchResponse,
     StatusResponse,
@@ -751,6 +753,103 @@ async def get_status() -> StatusResponse:
             status='error',
             message=f'Graphiti MCP server is running but database connection failed: {error_msg}',
         )
+
+
+@mcp.tool()
+async def knowledge_merge_entities(
+    survivor_uuid: str,
+    duplicate_uuids: list[str],
+    dry_run: bool = False,
+) -> MergeEntitiesResponse | ErrorResponse:
+    """Merge duplicate entity nodes into a single survivor node.
+
+    Rewires all EntityEdge endpoints and episodic MENTIONS edges from each
+    duplicate UUID to the survivor, unions their labels, deduplicates summary
+    lines, then deletes each duplicate node.
+
+    Use dry_run=True to preview what would change without making any writes.
+    The returned MergeEntitiesResponse is identical in shape whether dry_run
+    is True or False, but no graph modifications are committed in dry-run mode.
+
+    Args:
+        survivor_uuid: UUID of the entity node that survives the merge.
+        duplicate_uuids: UUIDs of entity nodes to collapse into the survivor.
+        dry_run: If True, compute and return the result but make no writes.
+    """
+    global graphiti_service
+
+    if graphiti_service is None:
+        return ErrorResponse(error='Graphiti service not initialized')
+
+    try:
+        client = await graphiti_service.get_client()
+        result = await client.merge_entities(
+            survivor_uuid=survivor_uuid,
+            duplicate_uuids=duplicate_uuids,
+            dry_run=dry_run,
+        )
+        prefix = '[DRY RUN] ' if dry_run else ''
+        return MergeEntitiesResponse(
+            message=f'{prefix}Merged {result.merged_count} duplicate(s) into {survivor_uuid}',
+            survivor_uuid=result.survivor_uuid,
+            merged_count=result.merged_count,
+            edges_rewired=result.edges_rewired,
+            episodes_relinked=result.episodes_relinked,
+            labels_after=result.labels_after,
+            summary_after=result.summary_after,
+            error=result.error,
+        )
+    except Exception as e:
+        error_msg = str(e)
+        logger.error(f'Error merging entities: {error_msg}')
+        return ErrorResponse(error=f'Error merging entities: {error_msg}')
+
+
+@mcp.tool()
+async def knowledge_merge_entities_batch(
+    merges: list[MergeRequest],
+    dry_run: bool = False,
+) -> list[MergeEntitiesResponse] | ErrorResponse:
+    """Merge multiple sets of duplicate entity nodes in sequence.
+
+    Each entry in merges is processed independently. If one merge fails the
+    others still proceed; the failed entry returns a result with error set and
+    merged_count=0.
+
+    Use dry_run=True to preview all merges without making any writes.
+
+    Args:
+        merges: List of objects, each with survivor_uuid and duplicate_uuids.
+        dry_run: If True, compute and return results but make no writes.
+    """
+    global graphiti_service
+
+    if graphiti_service is None:
+        return ErrorResponse(error='Graphiti service not initialized')
+
+    try:
+        client = await graphiti_service.get_client()
+        results = await client.merge_entities_batch(merges=merges, dry_run=dry_run)
+        prefix = '[DRY RUN] ' if dry_run else ''
+        return [
+            MergeEntitiesResponse(
+                message=f'{prefix}Merged {r.merged_count} duplicate(s) into {r.survivor_uuid}'
+                if r.error is None
+                else f'Failed: {r.error}',
+                survivor_uuid=r.survivor_uuid,
+                merged_count=r.merged_count,
+                edges_rewired=r.edges_rewired,
+                episodes_relinked=r.episodes_relinked,
+                labels_after=r.labels_after,
+                summary_after=r.summary_after,
+                error=r.error,
+            )
+            for r in results
+        ]
+    except Exception as e:
+        error_msg = str(e)
+        logger.error(f'Error in batch merge: {error_msg}')
+        return ErrorResponse(error=f'Error in batch merge: {error_msg}')
 
 
 @mcp.custom_route('/health', methods=['GET'])

--- a/mcp_server/src/models/response_types.py
+++ b/mcp_server/src/models/response_types.py
@@ -41,3 +41,14 @@ class EpisodeSearchResponse(TypedDict):
 class StatusResponse(TypedDict):
     status: str
     message: str
+
+
+class MergeEntitiesResponse(TypedDict):
+    message: str
+    survivor_uuid: str
+    merged_count: int
+    edges_rewired: int
+    episodes_relinked: int
+    labels_after: list[str]
+    summary_after: str
+    error: str | None

--- a/tests/test_merge_int.py
+++ b/tests/test_merge_int.py
@@ -109,19 +109,6 @@ async def _get_mentions_count(driver, entity_uuid: str) -> int:
     return int(results[0]['cnt'])
 
 
-async def _get_entity_edge_endpoint_count(driver, entity_uuid: str) -> int:
-    """Count entity edges touching entity_uuid as either source or target."""
-    results, _, _ = await driver.execute_query(
-        """
-        MATCH (n:Entity {uuid: $uuid})-[e:RELATES_TO]-(m:Entity)
-        RETURN COUNT(e) AS cnt
-        """,
-        uuid=entity_uuid,
-        routing_='r',
-    )
-    return int(results[0]['cnt'])
-
-
 # ---------------------------------------------------------------------------
 # Happy path: two duplicate entities merged into survivor
 # ---------------------------------------------------------------------------

--- a/tests/test_merge_int.py
+++ b/tests/test_merge_int.py
@@ -245,10 +245,12 @@ async def test_merge_entities_dry_run(graph_driver, mock_embedder):
         dry_run=True,
     )
 
-    # Result shape is valid
+    # Result shape is valid with accurate counts (dry-run still computes what would change)
     assert isinstance(result, MergeEntitiesResult)
     assert result.survivor_uuid == survivor.uuid
     assert result.merged_count == 1
+    assert result.edges_rewired == 1
+    assert result.episodes_relinked == 1
     assert result.error is None
 
     # Graph is unchanged

--- a/tests/test_merge_int.py
+++ b/tests/test_merge_int.py
@@ -1,0 +1,480 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import logging
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+
+from graphiti_core.edges import EntityEdge, EpisodicEdge
+from graphiti_core.errors import NodeNotFoundError
+from graphiti_core.graphiti import Graphiti, MergeEntitiesResult, MergeRequest
+from graphiti_core.nodes import EntityNode, EpisodeType, EpisodicNode
+from tests.helpers_test import get_node_count, group_id, group_id_2
+
+pytest_plugins = ('pytest_asyncio',)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+EMBEDDING_DIM = 384
+
+
+def _node(name: str, labels: list[str], gid: str = group_id, summary: str = '') -> EntityNode:
+    return EntityNode(
+        uuid=str(uuid4()),
+        name=name,
+        group_id=gid,
+        labels=labels,
+        created_at=datetime.now(),
+        name_embedding=[0.1] * EMBEDDING_DIM,
+        summary=summary,
+        attributes={},
+    )
+
+
+def _episode(gid: str = group_id) -> EpisodicNode:
+    return EpisodicNode(
+        uuid=str(uuid4()),
+        name='test_episode',
+        group_id=gid,
+        created_at=datetime.now(),
+        source=EpisodeType.text,
+        source_description='test',
+        content='test content',
+        valid_at=datetime.now(),
+        entity_edges=[],
+    )
+
+
+def _entity_edge(
+    src_uuid: str,
+    tgt_uuid: str,
+    gid: str = group_id,
+    name: str = 'RELATES_TO',
+    fact: str = 'default fact',
+) -> EntityEdge:
+    return EntityEdge(
+        uuid=str(uuid4()),
+        source_node_uuid=src_uuid,
+        target_node_uuid=tgt_uuid,
+        group_id=gid,
+        name=name,
+        fact=fact,
+        fact_embedding=[0.2] * EMBEDDING_DIM,
+        created_at=datetime.now(),
+        episodes=[],
+    )
+
+
+def _mentions(episode_uuid: str, entity_uuid: str, gid: str = group_id) -> EpisodicEdge:
+    return EpisodicEdge(
+        uuid=str(uuid4()),
+        source_node_uuid=episode_uuid,
+        target_node_uuid=entity_uuid,
+        group_id=gid,
+        created_at=datetime.now(),
+    )
+
+
+async def _graphiti(graph_driver):
+    g = Graphiti(graph_driver=graph_driver)
+    return g
+
+
+async def _get_mentions_count(driver, entity_uuid: str) -> int:
+    results, _, _ = await driver.execute_query(
+        'MATCH (n:Episodic)-[e:MENTIONS]->(m:Entity {uuid: $uuid}) RETURN COUNT(e) AS cnt',
+        uuid=entity_uuid,
+        routing_='r',
+    )
+    return int(results[0]['cnt'])
+
+
+async def _get_entity_edge_endpoint_count(driver, entity_uuid: str) -> int:
+    """Count entity edges touching entity_uuid as either source or target."""
+    results, _, _ = await driver.execute_query(
+        """
+        MATCH (n:Entity {uuid: $uuid})-[e:RELATES_TO]-(m:Entity)
+        RETURN COUNT(e) AS cnt
+        """,
+        uuid=entity_uuid,
+        routing_='r',
+    )
+    return int(results[0]['cnt'])
+
+
+# ---------------------------------------------------------------------------
+# Happy path: two duplicate entities merged into survivor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_merge_entities_happy_path(graph_driver, mock_embedder):
+    """Merge two duplicate entity nodes; verify edges/MENTIONS are rewired."""
+    g = await _graphiti(graph_driver)
+
+    survivor = _node('Visualization Data Service', ['Entity', 'Service'])
+    dup = _node('Visualization Data Service', ['Entity', 'DataService'])
+    third = _node('Consumer', ['Entity'])
+
+    for node in [survivor, dup, third]:
+        await node.save(graph_driver)
+
+    # Edges: third -> dup, and dup -> third
+    edge_in = _entity_edge(third.uuid, dup.uuid, fact='Consumer uses VDS')
+    edge_out = _entity_edge(dup.uuid, third.uuid, fact='VDS serves Consumer')
+    await edge_in.save(graph_driver)
+    await edge_out.save(graph_driver)
+
+    # Episode MENTIONS dup
+    ep = _episode()
+    await ep.save(graph_driver)
+    mention = _mentions(ep.uuid, dup.uuid)
+    await mention.save(graph_driver)
+
+    result = await g.merge_entities(
+        survivor_uuid=survivor.uuid,
+        duplicate_uuids=[dup.uuid],
+    )
+
+    # dup node is gone
+    dup_count = await get_node_count(graph_driver, [dup.uuid])
+    assert dup_count == 0, 'duplicate node should be deleted'
+
+    # survivor still exists
+    survivor_count = await get_node_count(graph_driver, [survivor.uuid])
+    assert survivor_count == 1, 'survivor node should still exist'
+
+    # labels are unioned
+    assert sorted(result.labels_after) == sorted({'Entity', 'Service', 'DataService'})
+
+    # edge endpoints rewired to survivor
+    assert result.edges_rewired == 2
+
+    # episode now mentions survivor, not dup
+    assert result.episodes_relinked == 1
+    dup_mentions = await _get_mentions_count(graph_driver, dup.uuid)
+    assert dup_mentions == 0
+    survivor_mentions = await _get_mentions_count(graph_driver, survivor.uuid)
+    assert survivor_mentions == 1
+
+    # result counters
+    assert result.merged_count == 1
+    assert result.survivor_uuid == survivor.uuid
+    assert result.error is None
+
+    await g.close()
+
+
+# ---------------------------------------------------------------------------
+# Summary line-deduplication
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_merge_entities_summary_dedup(graph_driver, mock_embedder):
+    """Duplicate summary lines are not repeated; unique lines are appended."""
+    g = await _graphiti(graph_driver)
+
+    survivor = _node('Alpha', ['Entity'], summary='Line A\nLine B')
+    dup = _node('Alpha', ['Entity'], summary='Line B\nLine C')
+
+    for node in [survivor, dup]:
+        await node.save(graph_driver)
+
+    result = await g.merge_entities(survivor_uuid=survivor.uuid, duplicate_uuids=[dup.uuid])
+
+    lines = set(result.summary_after.splitlines())
+    assert 'Line A' in lines
+    assert 'Line B' in lines
+    assert 'Line C' in lines
+    # Line B should appear exactly once
+    assert result.summary_after.count('Line B') == 1
+
+    await g.close()
+
+
+# ---------------------------------------------------------------------------
+# Dry-run: graph is unchanged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_merge_entities_dry_run(graph_driver, mock_embedder):
+    """dry_run=True returns a result but makes no writes."""
+    g = await _graphiti(graph_driver)
+
+    survivor = _node('SvcA', ['Entity', 'ServiceA'])
+    dup = _node('SvcA', ['Entity', 'ServiceB'])
+
+    for node in [survivor, dup]:
+        await node.save(graph_driver)
+
+    ep = _episode()
+    await ep.save(graph_driver)
+    mention = _mentions(ep.uuid, dup.uuid)
+    await mention.save(graph_driver)
+
+    edge = _entity_edge(dup.uuid, survivor.uuid, fact='SvcA fact')
+    await edge.save(graph_driver)
+
+    node_count_before = await get_node_count(graph_driver, [survivor.uuid, dup.uuid])
+
+    result = await g.merge_entities(
+        survivor_uuid=survivor.uuid,
+        duplicate_uuids=[dup.uuid],
+        dry_run=True,
+    )
+
+    # Result shape is valid
+    assert isinstance(result, MergeEntitiesResult)
+    assert result.survivor_uuid == survivor.uuid
+    assert result.merged_count == 1
+    assert result.error is None
+
+    # Graph is unchanged
+    node_count_after = await get_node_count(graph_driver, [survivor.uuid, dup.uuid])
+    assert node_count_after == node_count_before == 2
+
+    # dup still has its MENTIONS edge
+    dup_mentions = await _get_mentions_count(graph_driver, dup.uuid)
+    assert dup_mentions == 1
+
+    await g.close()
+
+
+# ---------------------------------------------------------------------------
+# Batch merge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_merge_entities_batch(graph_driver, mock_embedder):
+    """merge_entities_batch processes each pair and returns one result each."""
+    g = await _graphiti(graph_driver)
+
+    s1 = _node('Service1', ['Entity', 'S1'])
+    d1 = _node('Service1Dup', ['Entity', 'S1Dup'])
+    s2 = _node('Service2', ['Entity', 'S2'])
+    d2 = _node('Service2Dup', ['Entity', 'S2Dup'])
+
+    for node in [s1, d1, s2, d2]:
+        await node.save(graph_driver)
+
+    merges = [
+        MergeRequest(survivor_uuid=s1.uuid, duplicate_uuids=[d1.uuid]),
+        MergeRequest(survivor_uuid=s2.uuid, duplicate_uuids=[d2.uuid]),
+    ]
+
+    results = await g.merge_entities_batch(merges=merges)
+
+    assert len(results) == 2
+    assert results[0].survivor_uuid == s1.uuid
+    assert results[0].merged_count == 1
+    assert results[0].error is None
+    assert results[1].survivor_uuid == s2.uuid
+    assert results[1].merged_count == 1
+    assert results[1].error is None
+
+    # Both duplicates are deleted
+    assert await get_node_count(graph_driver, [d1.uuid]) == 0
+    assert await get_node_count(graph_driver, [d2.uuid]) == 0
+
+    await g.close()
+
+
+# ---------------------------------------------------------------------------
+# Missing duplicate UUID: skip with warning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_merge_entities_missing_duplicate(graph_driver, mock_embedder, caplog):
+    """Missing duplicate UUID is skipped with a warning; operation succeeds."""
+    g = await _graphiti(graph_driver)
+
+    survivor = _node('MySvc', ['Entity'])
+    await survivor.save(graph_driver)
+
+    nonexistent_uuid = str(uuid4())
+
+    with caplog.at_level(logging.WARNING, logger='graphiti_core.graphiti'):
+        result = await g.merge_entities(
+            survivor_uuid=survivor.uuid,
+            duplicate_uuids=[nonexistent_uuid],
+        )
+
+    assert result.merged_count == 0
+    assert result.error is None
+    assert any(nonexistent_uuid in record.message for record in caplog.records)
+
+    await g.close()
+
+
+# ---------------------------------------------------------------------------
+# group_id mismatch: raises ValueError before any write
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_merge_entities_group_id_mismatch(graph_driver, mock_embedder):
+    """Merging entities across group_id boundaries raises ValueError."""
+    g = await _graphiti(graph_driver)
+
+    survivor = _node('SvcA', ['Entity'], gid=group_id)
+    dup = _node('SvcA', ['Entity'], gid=group_id_2)
+
+    for node in [survivor, dup]:
+        await node.save(graph_driver)
+
+    node_count_before = await get_node_count(graph_driver, [survivor.uuid, dup.uuid])
+
+    with pytest.raises(ValueError, match='group_id'):
+        await g.merge_entities(
+            survivor_uuid=survivor.uuid,
+            duplicate_uuids=[dup.uuid],
+        )
+
+    # No writes happened
+    node_count_after = await get_node_count(graph_driver, [survivor.uuid, dup.uuid])
+    assert node_count_after == node_count_before
+
+    await g.close()
+
+
+# ---------------------------------------------------------------------------
+# Survivor in duplicate_uuids raises ValueError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_merge_entities_survivor_in_duplicates(graph_driver, mock_embedder):
+    """Passing survivor_uuid inside duplicate_uuids raises ValueError."""
+    g = await _graphiti(graph_driver)
+
+    node = _node('SelfMerge', ['Entity'])
+    await node.save(graph_driver)
+
+    with pytest.raises(ValueError):
+        await g.merge_entities(
+            survivor_uuid=node.uuid,
+            duplicate_uuids=[node.uuid],
+        )
+
+    await g.close()
+
+
+# ---------------------------------------------------------------------------
+# Survivor not found raises NodeNotFoundError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_merge_entities_survivor_not_found(graph_driver, mock_embedder):
+    """Non-existent survivor UUID raises NodeNotFoundError."""
+    g = await _graphiti(graph_driver)
+
+    with pytest.raises(NodeNotFoundError):
+        await g.merge_entities(
+            survivor_uuid=str(uuid4()),
+            duplicate_uuids=[str(uuid4())],
+        )
+
+    await g.close()
+
+
+# ---------------------------------------------------------------------------
+# Edge deduplication: colliding edges are removed, not duplicated
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_merge_entities_edge_dedup(graph_driver, mock_embedder):
+    """Edges with identical (src, tgt, name, fact) after rewiring are deduplicated."""
+    g = await _graphiti(graph_driver)
+
+    survivor = _node('Alpha', ['Entity'])
+    dup = _node('AlphaDup', ['Entity'])
+    other = _node('Beta', ['Entity'])
+
+    for node in [survivor, dup, other]:
+        await node.save(graph_driver)
+
+    # Both survivor and dup have an edge to 'other' with the same fact
+    edge_survivor = _entity_edge(survivor.uuid, other.uuid, name='KNOWS', fact='shared fact')
+    edge_dup = _entity_edge(dup.uuid, other.uuid, name='KNOWS', fact='shared fact')
+    await edge_survivor.save(graph_driver)
+    await edge_dup.save(graph_driver)
+
+    result = await g.merge_entities(survivor_uuid=survivor.uuid, duplicate_uuids=[dup.uuid])
+
+    # The colliding edge was dropped, not rewired
+    assert result.edges_rewired == 0
+
+    # Only one edge remains from survivor to other
+    edges_after, _, _ = await graph_driver.execute_query(
+        """
+        MATCH (n:Entity {uuid: $survivor})-[e:RELATES_TO]-(m:Entity {uuid: $other})
+        RETURN COUNT(e) AS cnt
+        """,
+        survivor=survivor.uuid,
+        other=other.uuid,
+        routing_='r',
+    )
+    assert int(edges_after[0]['cnt']) == 1
+
+    await g.close()
+
+
+# ---------------------------------------------------------------------------
+# Batch partial failure: one bad merge doesn't block the others
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_merge_entities_batch_partial_failure(graph_driver, mock_embedder):
+    """A failed merge in a batch populates error; other merges still succeed."""
+    g = await _graphiti(graph_driver)
+
+    survivor = _node('GoodSvc', ['Entity'])
+    dup = _node('GoodSvcDup', ['Entity'])
+    await survivor.save(graph_driver)
+    await dup.save(graph_driver)
+
+    bad_survivor_uuid = str(uuid4())
+
+    merges = [
+        MergeRequest(survivor_uuid=bad_survivor_uuid, duplicate_uuids=[str(uuid4())]),
+        MergeRequest(survivor_uuid=survivor.uuid, duplicate_uuids=[dup.uuid]),
+    ]
+
+    results = await g.merge_entities_batch(merges=merges)
+
+    assert len(results) == 2
+    # First merge failed (bad survivor)
+    assert results[0].error is not None
+    assert results[0].merged_count == 0
+    # Second merge succeeded
+    assert results[1].error is None
+    assert results[1].merged_count == 1
+
+    await g.close()


### PR DESCRIPTION
## Summary

Add a `merge_entities` operation that takes a survivor entity UUID and a list of duplicate entity UUIDs, collapses the duplicates into the survivor, rewires all `EntityEdge` endpoints, re-points episodic `MENTIONS` graph edges, unions labels and summaries, and deletes the duplicate nodes. Expose it as a method on the `Graphiti` class and as an MCP write tool. Include a dry-run mode and a batch variant for processing bulk duplicate lists.

## Problem

The dedup label-gating bug (#52) and the lack of multi-label semantics (#53) have produced graphs with significant duplicate-entity contamination. In a real production RFC-ADR graph: 1234 duplicate-pair candidates at similarity threshold 0.85, against only 1001 entities total. Re-ingesting the source corpus to fix the graph is impractical — entity extraction and deduplication are the expensive LLM steps, and running them again would cost real money.

What's needed is an in-graph cleanup path: given a set of entity UUIDs to collapse, produce a single canonical survivor with all graph relationships intact.

This issue is the action side of the suggest/review/merge workflow for legacy graph cleanup. It is independent of #52 and #53 — it is useful even without those fixes (for manually identified same-as merges), and more useful with them (as a retroactive cleanup pass after the new dedup semantics are in place).

## Approach

### Approach

The merge operation is implemented in three layers: a new abstract method on `EpisodicEdgeOperations` for MENTIONS lookup (needed for MENTIONS rewiring), orchestration logic in `Graphiti.merge_entities()` / `merge_entities_batch()` using existing driver operation primitives, and thin MCP wrapper tools.

**MENTIONS rewiring decision**: Add `get_by_entity_uuid` to `EpisodicEdgeOperations` and all four driver implementations. All four backends use identical Cypher patterns (`MATCH (n:Episodic)-[e:MENTIONS]->(m:Entity {uuid: $entity_uuid})`), making this a low-effort addition with 4 near-identical one-method implementations. The alternative (inline Cypher in `GraphMaintenanceOperations`) would bypass the existing operations abstraction entirely.

**Driver placement decision**: No new method on `GraphMaintenanceOperations`. All merge orchestration lives in `graphiti.py`, using existing `entity_node_ops`, `entity_edge_ops`, and the new `episodic_edge_ops.get_by_entity_uuid`. This matches how `add_episode`, `remove_episode`, and other Graphiti methods work.

**Transaction decision**: No explicit transaction wrapping. The codebase has no precedent for multi-step transaction use in `Graphiti` public methods. The `_SessionTransaction` on FalkorDB/LadybugDB/Neptune executes immediately anyway. Document in the docstring that merge is best-effort atomic (ACID only on Neo4j). This is ADR-worthy.

**Batch failure representation**: Add `error: str | None = None` to `MergeEntitiesResult`. Failed merges get `merged_count=0` and a populated `error` field. This preserves `len(results) == len(merges)` without raising across the whole batch.

**MergeRequest type for batch**: Define as a Pydantic `BaseModel` (not `TypedDict` or raw dict) in `graphiti_core/graphiti.py` alongside `MergeEntitiesResult`. MCP type annotations derive schema from Pydantic models, ensuring the batch tool has a useful schema.

**Validation order**: Fetch survivor, fetch all duplicates, validate all `group_id` checks and self-merge check before any write. This satisfies the spec's "raise before any writes" requirement.

**Result type location**: `MergeEntitiesResult` and `MergeRequest` in `graphiti_core/graphiti.py` alongside `AddEpisodeResults`. No new `types.py` file.

**MCP response**: New `MergeEntitiesResponse` TypedDict in `mcp_server/src/models/response_types.py`.

**README**: Add a `merge_entities` usage section as a placeholder; note the `suggest_duplicates → review → merge` example will be completed in a future issue.

### New/Modified Files

| File | Change |
|------|--------|
| `graphiti_core/graphiti.py` | Add `MergeEntitiesResult`, `MergeRequest` models; add `merge_entities()` and `merge_entities_batch()` methods to `Graphiti` |
| `graphiti_core/driver/operations/episodic_edge_ops.py` | Add abstract `get_by_entity_uuid` method |
| `graphiti_core/driver/neo4j/operations/episodic_edge_ops.py` | Implement `get_by_entity_uuid` |
| `graphiti_core/driver/falkordb/operations/episodic_edge_ops.py` | Implement `get_by_entity_uuid` |
| `graphiti_core/driver/ladybug/operations/episodic_edge_ops.py` | Implement `get_by_entity_uuid` |
| `graphiti_core/driver/neptune/operations/episodic_edge_ops.py` | Implement `get_by_entity_uuid` |
| `mcp_server/src/models/response_types.py` | Add `MergeEntitiesResponse` TypedDict |
| `mcp_server/src/graphiti_mcp_server.py` | Add `knowledge_merge_entities` and `knowledge_merge_entities_batch` tools |
| `tests/test_merge_int.py` | New file: integration tests for all merge scenarios |
| `README.md` | Add `merge_entities` usage section |
| `adrs/NNN-merge-entities-no-explicit-transactions.md` | New ADR: document best-effort atomicity decision |

### Key Decisions

- **`get_by_entity_uuid` goes on `EpisodicEdgeOperations`**: Keeps MENTIONS lookup consistent with the existing operations abstraction; all four implementations are nearly identical Cypher, so the overhead is small.
- **No new method on `GraphMaintenanceOperations`**: All primitives needed exist or are added via `EpisodicEdgeOperations`. Adding to `GraphMaintenanceOperations` would be a second abstract interface with 4 more implementations for no benefit.
- **No explicit transactions**: Matches codebase pattern; FalkorDB/LadybugDB/Neptune don't support real transactions anyway. Documented in docstring + ADR.
- **`MergeRequest` as Pydantic `BaseModel`**: MCP's `@mcp.tool()` derives JSON schema from type annotations; `list[dict]` produces an unusable schema; `list[MergeRequest]` produces a well-typed schema automatically.
- **`error` field on `MergeEntitiesResult`**: Preserves `len(results) == len(merges)` invariant in batch mode without allowing partial failure to corrupt the results list shape.

### Task Checklist

- [ ] Task 1: Add `MergeEntitiesResult` (Pydantic model with `survivor_uuid`, `merged_count`, `edges_rewired`, `episodes_relinked`, `labels_after`, `summary_after`, `error: str | None = None`) and `MergeRequest` (Pydantic model with `survivor_uuid`, `duplicate_uuids`) to `graphiti_core/graphiti.py` alongside `AddEpisodeResults`
- [ ] Task 2: Add abstract method `get_by_entity_uuid(executor, entity_uuid: str) -> list[EpisodicEdge]` to `graphiti_core/driver/operations/episodic_edge_ops.py`
- [ ] Task 3: Implement `get_by_entity_uuid` in all four driver-specific `episodic_edge_ops.py` files (Neo4j, FalkorDB, LadybugDB, Neptune) — Cypher: `MATCH (n:Episodic)-[e:MENTIONS]->(m:Entity {uuid: $entity_uuid}) RETURN <EPISODIC_EDGE_RETURN>` following each backend's existing pattern for `routing_` and query execution
- [ ] Task 4: Implement `Graphiti.merge_entities(survivor_uuid, duplicate_uuids, dry_run=False)` in `graphiti_core/graphiti.py`:
  - Fetch survivor via `entity_node_ops.get_by_uuid` (raise `NodeNotFoundError` if missing)
  - Validate `survivor_uuid not in duplicate_uuids` (raise `ValueError`)
  - For each dup: fetch node (skip with warning log if missing), validate `dup.group_id == survivor.group_id` (raise `ValueError` if not), validate ALL before any writes
  - Write phase (skipped in dry-run): for each validated dup: (a) fetch dup's entity edges + survivor's entity edges, rewire dup edges' `source_node_uuid`/`target_node_uuid` to survivor, identify collisions by `(source, target, name, fact)` key, save non-duplicate edges, delete collision edges; (b) fetch dup's MENTIONS edges via `episodic_edge_ops.get_by_entity_uuid`, for each: if same-episode MENTIONS survivor already exists, delete it, else save with `target_node_uuid = survivor.uuid`; (c) compute `labels_after = sorted(set(survivor.labels) | set(dup.labels))` and `summary_after` (line-dedup append); (d) save updated survivor; (e) delete dup via `entity_node_ops.delete_by_uuids`
  - Accumulate counters into `MergeEntitiesResult`
- [ ] Task 5: Implement `Graphiti.merge_entities_batch(merges: list[MergeRequest], dry_run=False)` — iterate, call `merge_entities` per entry, catch exceptions, populate `error` field on failure, return `list[MergeEntitiesResult]`
- [ ] Task 6: Add `MergeEntitiesResponse` TypedDict to `mcp_server/src/models/response_types.py` with fields matching `MergeEntitiesResult` (plus `message: str`)
- [ ] Task 7: Add `knowledge_merge_entities(survivor_uuid, duplicate_uuids, dry_run=False)` MCP tool to `graphiti_mcp_server.py` — docstring must explain dry-run (preview changes without writes), call `client.merge_entities(...)`, return `MergeEntitiesResponse | ErrorResponse`
- [ ] Task 8: Add `knowledge_merge_entities_batch(merges: list[MergeRequest], dry_run=False)` MCP tool to `graphiti_mcp_server.py` — import `MergeRequest` from `graphiti_core.graphiti`, call `client.merge_entities_batch(...)`, return list of results wrapped in a response dict
- [ ] Task 9: Write integration tests in `tests/test_merge_int.py` covering: happy path (two entities with different labels merged; verify one node remains, union labels, all edges rewired, all MENTIONS redirected), dry-run (graph unchanged after dry-run call), batch (list of pairs merged, one result per entry), missing duplicate UUID (operation succeeds, warning logged), `group_id` mismatch (ValueError raised before any write)
- [ ] Task 10: Add README section "Cleaning up duplicate entities" documenting `merge_entities` signature, return type, and dry-run usage; note that a `suggest_duplicates → review → merge` end-to-end example will be added in a future issue once `suggest_duplicates` is implemented
- [ ] Task 11: Create ADR `adrs/NNN-merge-entities-no-explicit-transactions.md` documenting the decision to not use explicit transactions for merge operations (with rationale: FalkorDB/LadybugDB/Neptune lack real transaction support; existing codebase pattern uses no multi-step transactions; best-effort atomic on all backends)

### Risks

1. **LadybugDB `entity_edge_ops.get_by_node_uuid` correctness**: The implementer must verify that the LadybugDB `get_by_node_uuid` correctly matches both `(Entity)-[:RELATES_TO]->(RelatesToNode_)` and `(RelatesToNode_)-[:RELATES_TO]->(Entity)` patterns, so the edge rewiring step fetches all edges touching the dup. If the LadybugDB implementation is broken here, rewired edges will be missed.

2. **MENTIONS dedup check requires O(n) lookup per MENTIONS edge**: After redirecting each MENTIONS edge to the survivor, we need to check if the survivor already has a MENTIONS edge from the same episode. This is done by comparing `source_node_uuid` (the episode UUID) against all MENTIONS edges already pointing to the survivor. Fetch survivor's MENTIONS before the write loop; check against an in-memory set of episode UUIDs.

3. **Batch partial failure semantics**: The `error` field on `MergeEntitiesResult` is new and callers must check it. MCP tools should surface the `error` field clearly in the response so AI callers know which merges failed.

4. **ADR directory creation**: No `adrs/` directory exists in the repository. The implementer must create the directory and the first ADR file, then determine the appropriate numbering convention (start at `001` or match another scheme).

5. **Neptune round-trip embeddings**: `entity_edge_ops.save` on Neptune re-serializes embeddings. The fetch-then-save cycle in edge rewiring exercises this path. If the Neptune driver doesn't correctly round-trip comma-separated embedding strings, the rewired edge will have a corrupted `fact_embedding`. Integration tests do not cover Neptune (no Neptune test fixture), so this risk remains until manual testing.

---
Used 25/50 turns, 8k input / 10k output tokens.

## Verification

Implemented `merge_entities` and `merge_entities_batch` on the `Graphiti` class in `graphiti_core/graphiti.py`, including `MergeEntitiesResult` and `MergeRequest` Pydantic types. Added `EpisodicEdge.get_by_entity_uuid` as a new abstract method on `EpisodicEdgeOperations` with implementations across all four backends (Neo4j, FalkorDB, LadybugDB, Neptune), plus a corresponding classmethod on `EpisodicEdge`. Exposed both operations as MCP tools (`knowledge_merge_entities`, `knowledge_merge_entities_batch`) with dry-run semantics documented in their docstrings. Added 9 integration test cases in `tests/test_merge_int.py` covering happy path, dry-run, batch, missing duplicate, group_id mismatch, self-merge, edge deduplication, and partial batch failure; also added a README usage section and ADR 001 documenting the no-explicit-transactions decision.

---

Closes #54