### PR TITLE
P2: Cache warmup before add_episode_bulk fan-out

### DIFF
--- a/adrs/002-cache-warmup-option-a.md
+++ b/adrs/002-cache-warmup-option-a.md
@@ -1,0 +1,90 @@
+# ADR 002 — Cache warmup: Option A (explicit warmup method) over Option B (staged concurrency)
+
+**Date:** 2026-04-30
+**Status:** Accepted
+
+## Context
+
+When `add_episode_bulk` cold-starts with a high concurrency limit (e.g.,
+`SEMAPHORE_LIMIT=20`), all 20 concurrent LLM calls race to write the same
+Anthropic prompt-cache prefix. Only one write is needed; the other 19 each pay
+the +25% cache-write surcharge for content that ends up duplicated. This is a
+thundering-herd problem specific to `system-block` caching mode.
+
+Two implementation shapes were considered:
+
+**Option A — Explicit `warmup` hook on `LLMClient`:**
+Issue one minimal API call (max_tokens=1) per distinct prompt type before the
+bulk fan-out. The call seeds the server-side cache; the result is discarded.
+`AnthropicClient` overrides with a real call; the base class default is a no-op.
+
+**Option B — Staged concurrency ramp:**
+Process the first episode at `SEMAPHORE_LIMIT=1`, then raise to the configured
+value. The first episode's real API calls naturally seed the cache before the
+fan-out.
+
+## Decision
+
+**Option A was chosen.**
+
+## Rationale
+
+### Option A is targeted and low-cost
+
+Option A sends `max_tokens=1` calls with no meaningful output. The only purpose
+is to write the cache entry server-side. This costs roughly $0.003–0.01 per
+warmup batch (4–6 calls × ≥2048 tokens × cache-write rate) — orders of
+magnitude less than a full episode.
+
+### Option B processes real work serially
+
+Option B must wait for a full episode to be processed at concurrency=1 before
+the fan-out begins. This:
+- Adds the latency of one full episode before the batch starts.
+- Bills for real extraction work (node extraction, edge extraction, dedup) rather
+  than just a cache seed.
+- Changes the observable timing semantics of `add_episode_bulk` — callers who
+  depend on parallel processing from the start may see unexpected behavior.
+
+### `system-block` mode is the only mode that benefits
+
+- **`disabled`:** No `cache_control` is sent. There is no server-side cache to
+  prime. Warmup is a no-op.
+- **`top-level`:** The cache key includes the last user message. Each episode has
+  a unique user message (the episode content), so a static warmup with a trivial
+  user message (`.`) seeds an entry that real calls will never hit. Warmup would
+  waste money without benefit.
+- **`system-block`:** `cache_control` is pinned to the system block. The cache
+  key is `system_message + cache_padding_text`, identical across all calls for
+  the same prompt type. A warmup with any user message seeds this entry
+  correctly.
+
+### Concurrent warmup
+
+All 4–6 warmup calls are issued via `asyncio.gather`. This caps the warmup
+overhead to approximately one Anthropic API round-trip rather than N sequential
+round-trips.
+
+### Best-effort semantics
+
+A warmup failure is non-fatal. The bulk operation proceeds and pays the
+cache-write surcharge as before. This is appropriate for a P2 cost optimization:
+correctness is unaffected.
+
+### Provider-agnostic call site
+
+Because `LLMClient.warmup` is a no-op, the `add_episode_bulk` call site needs
+no `isinstance` check. Provider-specific logic is entirely inside
+`AnthropicClient.warmup`.
+
+## Consequences
+
+- Every `add_episode_bulk` call at `cache_mode='system-block'` pays for 4–6
+  `max_tokens=1` API calls. Callers at `cache_mode='disabled'` (the default)
+  see zero overhead.
+- After a successful warmup, a run with `SEMAPHORE_LIMIT=20` should produce
+  approximately 1 `cache_creation_input_tokens` event per distinct prompt type
+  on the first episode batch, rather than ~20.
+- Adding warmup support for a new LLM provider requires overriding `warmup` in
+  that provider's client class — no changes to `add_episode_bulk` or
+  `_warmup_prompt_cache` are needed.

--- a/docs/prompt_caching.md
+++ b/docs/prompt_caching.md
@@ -114,3 +114,31 @@ LLMConfig(
 
 Default `cache_mode='disabled'` — don't pay for caching infrastructure if
 you're not amortizing across many calls.
+
+## Cache warmup
+
+When `add_episode_bulk` is called with a large batch (e.g., `SEMAPHORE_LIMIT=20`),
+all 20 concurrent LLM calls race to write the same Anthropic cache prefix. Only
+one write is needed; the other 19 each pay the +25% cache-write surcharge for
+content that ends up duplicated.
+
+To prevent this thundering-herd effect, `add_episode_bulk` issues a warmup
+automatically before the fan-out. The warmup fires one `max_tokens=1` call per
+distinct prompt type (up to 6 calls: one per `EpisodeType` variant in the batch,
+plus `extract_edges`, `dedupe_nodes`, and `extract_attributes`). These calls
+seed the Anthropic server-side cache so that the subsequent concurrent requests
+all hit the warm cache.
+
+### When warmup fires
+
+| `cache_mode` | warmup behavior |
+|---|---|
+| `'disabled'` (default) | No-op — no API call is made. |
+| `'top-level'` | No-op — cache key includes the user message, so a static warmup call would seed an entry that real calls (with varying episode content) will never hit. |
+| `'system-block'` | Fires one `max_tokens=1` call per distinct prompt type before the fan-out. |
+
+### Best-effort semantics
+
+Warmup failures are caught and logged at `DEBUG` level. A failed warmup leaves
+the fan-out unprimed but does not abort the bulk operation — the batch proceeds
+and pays the cache-write surcharge as before.

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -14,9 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import asyncio
 import logging
 from datetime import datetime
 from time import time
+from typing import Any
 from uuid import uuid4
 
 from dotenv import load_dotenv
@@ -58,6 +60,7 @@ from graphiti_core.nodes import (
     create_entity_node_embeddings,
 )
 from graphiti_core.prompts.lib import prompt_library
+from graphiti_core.prompts.models import Message
 from graphiti_core.prompts.summarize_sagas import SagaSummary
 from graphiti_core.search.search import SearchConfig, search
 from graphiti_core.search.search_config import DEFAULT_SEARCH_LIMIT, SearchResults
@@ -731,6 +734,106 @@ class Graphiti:
 
         return episodic_edges, episode
 
+    async def _warmup_prompt_cache(
+        self,
+        episodes: list[EpisodicNode],
+        entity_types: dict[str, type[BaseModel]] | None,
+        edge_types: dict[str, type[BaseModel]] | None,
+        custom_extraction_instructions: str | None,
+    ) -> None:
+        """Fire one max_tokens=1 call per distinct prompt type before the bulk fan-out.
+
+        Seeds the Anthropic server-side prompt cache so that the subsequent concurrent
+        requests all hit the warm cache rather than all paying the cache-write surcharge.
+        The base LLMClient.warmup is a no-op, so this call is free for non-Anthropic
+        providers and for AnthropicClient when cache_mode != 'system-block'.
+        """
+        if not episodes:
+            return
+
+        use_freeform = entity_types is None
+
+        # Build entity_types_context matching what real extraction calls produce.
+        entity_types_context: list[dict[str, Any]] = [
+            {
+                'entity_type_id': 0,
+                'entity_type_name': 'Entity',
+                'entity_type_description': (
+                    'A specific, identifiable entity that does not fit any of the other listed '
+                    'types. Must still be a concrete, meaningful thing — specific enough to be '
+                    'uniquely identifiable.'
+                ),
+            }
+        ]
+        if entity_types is not None:
+            entity_types_context += [
+                {
+                    'entity_type_id': i + 1,
+                    'entity_type_name': type_name,
+                    'entity_type_description': type_model.__doc__,
+                }
+                for i, (type_name, type_model) in enumerate(entity_types.items())
+            ]
+
+        # Build edge_types_context matching what real edge extraction calls produce.
+        edge_types_context: list[dict[str, Any]] = (
+            [
+                {
+                    'fact_type_name': type_name,
+                    'fact_type_signatures': [('Entity', 'Entity')],
+                    'fact_type_description': type_model.__doc__,
+                }
+                for type_name, type_model in edge_types.items()
+            ]
+            if edge_types is not None
+            else []
+        )
+
+        base_context: dict[str, Any] = {
+            'episode_content': '',
+            'episode_timestamp': '',
+            'previous_episodes': [],
+            'custom_extraction_instructions': '',
+            'entity_types': entity_types_context,
+            'source_description': '',
+            'freeform_entity_types': use_freeform,
+            'extracted_nodes': [],
+            'existing_nodes': [],
+            'nodes': [],
+            'reference_time': '',
+            'edge_types': edge_types_context,
+            'node': '',
+        }
+
+        message_sets: list[list[Message]] = []
+
+        # extract_nodes: one warmup per distinct EpisodeType in this batch
+        for source in {ep.source for ep in episodes}:
+            if source == EpisodeType.message:
+                msgs = prompt_library.extract_nodes.extract_message(base_context)
+            elif source == EpisodeType.json:
+                msgs = prompt_library.extract_nodes.extract_json(base_context)
+            else:
+                msgs = prompt_library.extract_nodes.extract_text(base_context)
+            message_sets.append([msgs[0], Message(role='user', content='.')])
+
+        # extract_edges
+        msgs = prompt_library.extract_edges.edge(base_context)
+        message_sets.append([msgs[0], Message(role='user', content='.')])
+
+        # dedupe_nodes
+        msgs = prompt_library.dedupe_nodes.nodes(base_context)
+        message_sets.append([msgs[0], Message(role='user', content='.')])
+
+        # extract_attributes
+        msgs = prompt_library.extract_nodes.extract_attributes(base_context)
+        message_sets.append([msgs[0], Message(role='user', content='.')])
+
+        await asyncio.gather(
+            *[self.llm_client.warmup(msg_set) for msg_set in message_sets],
+            return_exceptions=True,
+        )
+
     async def _extract_and_dedupe_nodes_bulk(
         self,
         episode_context: list[tuple[EpisodicNode, list[EpisodicNode]]],
@@ -1300,6 +1403,11 @@ class Graphiti:
 
                     # Get previous episode context for each episode
                     episode_context = await retrieve_previous_episodes_bulk(self.driver, episodes)
+
+                    # Seed the Anthropic prompt cache before the concurrent fan-out
+                    await self._warmup_prompt_cache(
+                        episodes, entity_types, edge_types, custom_extraction_instructions
+                    )
 
                     # Extract and dedupe nodes and edges
                     (

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -102,6 +102,7 @@ from graphiti_core.utils.maintenance.graph_data_operations import (
     retrieve_episodes,
 )
 from graphiti_core.utils.maintenance.node_operations import (
+    _build_entity_types_context,
     extract_attributes_from_nodes,
     extract_nodes,
     resolve_extracted_nodes,
@@ -739,6 +740,7 @@ class Graphiti:
         episodes: list[EpisodicNode],
         entity_types: dict[str, type[BaseModel]] | None,
         edge_types: dict[str, type[BaseModel]] | None,
+        edge_type_map: dict[tuple[str, str], list[str]],
         custom_extraction_instructions: str | None,
     ) -> None:
         """Fire one max_tokens=1 call per distinct prompt type before the bulk fan-out.
@@ -753,34 +755,26 @@ class Graphiti:
 
         use_freeform = entity_types is None
 
-        # Build entity_types_context matching what real extraction calls produce.
-        entity_types_context: list[dict[str, Any]] = [
-            {
-                'entity_type_id': 0,
-                'entity_type_name': 'Entity',
-                'entity_type_description': (
-                    'A specific, identifiable entity that does not fit any of the other listed '
-                    'types. Must still be a concrete, meaningful thing — specific enough to be '
-                    'uniquely identifiable.'
-                ),
-            }
-        ]
-        if entity_types is not None:
-            entity_types_context += [
-                {
-                    'entity_type_id': i + 1,
-                    'entity_type_name': type_name,
-                    'entity_type_description': type_model.__doc__,
-                }
-                for i, (type_name, type_model) in enumerate(entity_types.items())
-            ]
+        # Use the shared helper so the entity_types_context matches real extraction calls
+        # byte-for-byte (including the default Entity base description).
+        entity_types_context = _build_entity_types_context(entity_types)
 
-        # Build edge_types_context matching what real edge extraction calls produce.
+        # Build edge_types_context using the same signature-mapping logic as extract_edges()
+        # so the system prompt matches the real fan-out cache key exactly.
+        edge_type_signatures_map: dict[str, list[tuple[str, str]]] = {}
+        for signature, edge_type_names in edge_type_map.items():
+            for edge_type in edge_type_names:
+                if edge_type not in edge_type_signatures_map:
+                    edge_type_signatures_map[edge_type] = []
+                edge_type_signatures_map[edge_type].append(signature)
+
         edge_types_context: list[dict[str, Any]] = (
             [
                 {
                     'fact_type_name': type_name,
-                    'fact_type_signatures': [('Entity', 'Entity')],
+                    'fact_type_signatures': edge_type_signatures_map.get(
+                        type_name, [('Entity', 'Entity')]
+                    ),
                     'fact_type_description': type_model.__doc__,
                 }
                 for type_name, type_model in edge_types.items()
@@ -1406,7 +1400,11 @@ class Graphiti:
 
                     # Seed the Anthropic prompt cache before the concurrent fan-out
                     await self._warmup_prompt_cache(
-                        episodes, entity_types, edge_types, custom_extraction_instructions
+                        episodes,
+                        entity_types,
+                        edge_types,
+                        edge_type_map or edge_type_map_default,
+                        custom_extraction_instructions,
                     )
 
                     # Extract and dedupe nodes and edges

--- a/graphiti_core/llm_client/anthropic_client.py
+++ b/graphiti_core/llm_client/anthropic_client.py
@@ -436,6 +436,21 @@ class AnthropicClient(LLMClient):
         )
         return response_dict
 
+    async def warmup(self, messages: list[Message]) -> None:
+        """Seed the Anthropic server-side prompt cache before bulk fan-out.
+
+        Only fires when cache_mode='system-block'. In that mode the cache key
+        is the system block, so a single max_tokens=1 call per distinct system
+        prompt is enough to warm the cache for all subsequent concurrent calls.
+        """
+        if self.cache_mode != 'system-block':
+            return
+        warmup_msgs = [messages[0], Message(role='user', content='.')]
+        try:
+            await self._call_anthropic_api(warmup_msgs, max_tokens=1)
+        except Exception as e:
+            logger.debug(f'Cache warmup call failed (non-fatal): {e}')
+
     async def generate_response(
         self,
         messages: list[Message],

--- a/graphiti_core/llm_client/anthropic_client.py
+++ b/graphiti_core/llm_client/anthropic_client.py
@@ -445,6 +445,8 @@ class AnthropicClient(LLMClient):
         """
         if self.cache_mode != 'system-block':
             return
+        if not messages or messages[0].role != 'system':
+            return
         warmup_msgs = [messages[0], Message(role='user', content='.')]
         try:
             await self._call_anthropic_api(warmup_msgs, max_tokens=1)

--- a/graphiti_core/llm_client/client.py
+++ b/graphiti_core/llm_client/client.py
@@ -232,6 +232,10 @@ class LLMClient(ABC):
         else:
             return 'unknown'
 
+    async def warmup(self, messages: list[Message]) -> None:
+        """Seed the provider's server-side prompt cache. No-op for non-Anthropic clients."""
+        return
+
     def _get_failed_generation_log(self, messages: list[Message], output: str | None) -> str:
         """
         Log structural metadata and truncated raw output for debugging failed

--- a/tests/llm_client/test_anthropic_client.py
+++ b/tests/llm_client/test_anthropic_client.py
@@ -478,5 +478,103 @@ class TestAnthropicClientGenerateResponse:
         assert result['test_field'] == 'correct_value'
 
 
+class TestAnthropicClientWarmup:
+    """Tests for AnthropicClient.warmup — prompt-cache pre-seeding."""
+
+    def _make_warmup_client(self, mock_async_anthropic, cache_mode: str) -> AnthropicClient:
+        with patch('anthropic.AsyncAnthropic', return_value=mock_async_anthropic):
+            config = LLMConfig(
+                api_key='k',
+                model='test-model',
+                temperature=0.0,
+                max_tokens=100,
+                cache_mode=cache_mode,
+            )
+            client = AnthropicClient(config=config)
+            client.client = mock_async_anthropic
+        return client
+
+    @pytest.mark.asyncio
+    async def test_warmup_disabled_mode_no_api_call(self, mock_async_anthropic):
+        """warmup is a no-op when cache_mode='disabled'."""
+        client = self._make_warmup_client(mock_async_anthropic, 'disabled')
+        messages = [
+            Message(role='system', content='System message'),
+            Message(role='user', content='User message'),
+        ]
+        await client.warmup(messages)
+        mock_async_anthropic.messages.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_warmup_top_level_mode_no_api_call(self, mock_async_anthropic):
+        """warmup is a no-op when cache_mode='top-level' (cache key includes user message)."""
+        client = self._make_warmup_client(mock_async_anthropic, 'top-level')
+        messages = [
+            Message(role='system', content='System message'),
+            Message(role='user', content='User message'),
+        ]
+        await client.warmup(messages)
+        mock_async_anthropic.messages.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_warmup_system_block_mode_calls_api_with_max_tokens_1(
+        self, mock_async_anthropic
+    ):
+        """warmup fires one max_tokens=1 call when cache_mode='system-block'."""
+        content_item = MagicMock()
+        content_item.type = 'tool_use'
+        content_item.input = {}
+        mock_async_anthropic.messages.create.return_value = _make_response([content_item])
+
+        client = self._make_warmup_client(mock_async_anthropic, 'system-block')
+        messages = [
+            Message(role='system', content='System message'),
+            Message(role='user', content='User message'),
+        ]
+        await client.warmup(messages)
+
+        mock_async_anthropic.messages.create.assert_called_once()
+        call_kwargs = mock_async_anthropic.messages.create.call_args.kwargs
+        assert call_kwargs['max_tokens'] == 1
+        # The trivial user message ('.') is sent, not the original user message
+        assert call_kwargs['messages'] == [{'role': 'user', 'content': '.'}]
+
+    @pytest.mark.asyncio
+    async def test_warmup_system_block_uses_system_message_as_cache_block(
+        self, mock_async_anthropic
+    ):
+        """warmup sends the real system message so the cache block matches real calls."""
+        content_item = MagicMock()
+        content_item.type = 'tool_use'
+        content_item.input = {}
+        mock_async_anthropic.messages.create.return_value = _make_response([content_item])
+
+        client = self._make_warmup_client(mock_async_anthropic, 'system-block')
+        messages = [
+            Message(role='system', content='My stable system prompt'),
+            Message(role='user', content='Some episode content'),
+        ]
+        await client.warmup(messages)
+
+        call_kwargs = mock_async_anthropic.messages.create.call_args.kwargs
+        system_arg = call_kwargs['system']
+        assert isinstance(system_arg, list)
+        assert system_arg[0]['text'] == 'My stable system prompt'
+        assert system_arg[0]['cache_control'] == {'type': 'ephemeral'}
+
+    @pytest.mark.asyncio
+    async def test_warmup_exception_does_not_propagate(self, mock_async_anthropic):
+        """An API error during warmup is swallowed; the caller sees no exception."""
+        mock_async_anthropic.messages.create.side_effect = RuntimeError('network error')
+
+        client = self._make_warmup_client(mock_async_anthropic, 'system-block')
+        messages = [
+            Message(role='system', content='System message'),
+            Message(role='user', content='User message'),
+        ]
+        # Must not raise
+        await client.warmup(messages)
+
+
 if __name__ == '__main__':
     pytest.main(['-v', 'test_anthropic_client.py'])


### PR DESCRIPTION
## Summary

Add a warmup mechanism that issues one minimal LLM call before the bulk fan-out, seeding the Anthropic prompt cache so the subsequent concurrent requests all hit the warm cache rather than all paying the cache-write surcharge. The mechanism should be a no-op when Anthropic prompt caching is not in use.

## Problem

When `add_episode_bulk` cold-starts with `SEMAPHORE_LIMIT=20`, the first batch of 20 concurrent LLM calls all race to write the same Anthropic prompt-cache prefix. Only one needs to succeed; the other 19 each pay the cache-write surcharge for content that ends up overwritten or duplicated.

The Anthropic prompt cache becomes available only after the first response begins streaming. Parallel requests fired before the first response completes register as independent parallel writes to the same prefix, multiplying `cache_creation_input_tokens` charges by up to the concurrency level.

This is a second-order issue (smaller than the prompt-shape problem fixed in `ec69d97`). It is filed so it doesn't get lost; implementation should wait until first-episode latency or cold-cache cost appears in production telemetry.

## Approach

### Approach

**Option A — Explicit `warmup` method on `LLMClient`**, overridden in `AnthropicClient`.

Option B (staged concurrency) was rejected because it processes a full real episode serially before the fan-out, adding latency and doing real billable work — the opposite of "low cost." Option A sends `max_tokens=1` calls with no meaningful output and costs only one Anthropic API round-trip per distinct prompt type.

**Skip condition**: `AnthropicClient.warmup` guards on `self.cache_mode != 'system-block'` and returns immediately. No new constructor flag is needed. Rationale:
- `disabled` mode sends no `cache_control` and has no server-side cache to prime.
- `top-level` mode places the cache breakpoint at the last user message, making the cache key episode-specific. A warmup call with a trivial user message creates a cache entry that real calls (with varying episode content) will never hit — warmup is ineffective and wasteful.
- `system-block` mode pins `cache_control` to the system block. The cache key is `system_message + cache_padding_text`, which is identical across all calls for the same prompt type. Warmup with any user message seeds this cache entry correctly.

**Token threshold**: In `system-block` mode, `cache_padding_text` is what brings the system block above the per-model minimum (≥ 2048 tokens for Sonnet 4.x). `AnthropicClient._call_anthropic_api` already appends `cache_padding_text` to the system content before sending. Since `warmup` calls `_call_anthropic_api` with the real system message, the padding is applied automatically. If `cache_padding_text` is not set and the system block is below the threshold, warmup silently creates no cache entry — this is acceptable and matches the behaviour of real calls.

**Prompt types to warm up**: Four distinct LLM call shapes fire in `add_episode_bulk`. Each has a different system prompt and thus a different cache key. `_warmup_prompt_cache` warms up all of them:

| Fan-out | Prompt function |
|---------|----------------|
| `extract_nodes` (fan-out 1) | `extract_nodes.extract_message` / `extract_text` / `extract_json` (varies by `episode.source`) |
| `extract_edges` (fan-out 2) | `extract_edges.edge` |
| `resolve_extracted_nodes` (fan-out 3) | `dedupe_nodes.nodes` |
| `extract_attributes_from_nodes` (fan-out 4) | `extract_nodes.extract_attributes` |

For `extract_nodes`, the variant depends on episode type. `_warmup_prompt_cache` inspects the episode batch and warms up only the variant(s) actually present (`EpisodeType.message → extract_message`, `EpisodeType.text → extract_text`, `EpisodeType.json → extract_json`).

**Concurrency**: All warmup calls are issued concurrently with `asyncio.gather`, not sequentially. This limits warmup overhead to ~1 network round-trip instead of N.

**Best-effort**: Exceptions during warmup are caught and logged at `DEBUG` level. A warmup failure leaves the fan-out unprimed but does not abort the bulk operation.

**No public API change**: `warmup` is a new method (additive), not a change to existing signatures. The `LLMClient` public interface is extended, not modified — acceptable per spec.

---

### New / Modified Files

| File | Change |
|------|--------|
| `graphiti_core/llm_client/client.py` | Add no-op `async def warmup(self, messages: list[Message]) -> None` |
| `graphiti_core/llm_client/anthropic_client.py` | Override `warmup`: guard on `cache_mode`, call `_call_anthropic_api` with `max_tokens=1`, swallow exceptions |
| `graphiti_core/graphiti.py` | Add `_warmup_prompt_cache` private method; call it in `add_episode_bulk` before `_extract_and_dedupe_nodes_bulk` |
| `tests/llm_client/test_anthropic_client.py` | Add unit tests for `AnthropicClient.warmup` |
| `docs/prompt_caching.md` | Add warmup section documenting when it fires and what it does |
| `adrs/002-cache-warmup-option-a.md` | ADR: Option A over Option B; `system-block`-only scope |

---

### Key Decisions

- **Option A over Option B**: Option A is targeted (no real work, no observable side effects on results), while Option B serialises a full episode and changes timing semantics. The small cost of `max_tokens=1` API calls is preferable to the latency and billing cost of a real episode.

- **`system-block`-only guard**: `top-level` mode's cache key includes user message content, making a static warmup ineffective. `disabled` mode has no server-side cache. Only `system-block` pinning the cache to the system block can benefit from warmup with a trivial user message.

- **Concurrent warmup calls**: Issuing all 4–6 warmup calls via `asyncio.gather` caps the warmup overhead at one network round-trip rather than compounding it.

- **Best-effort semantics**: A warmup failure is non-fatal. The bulk operation proceeds and pays the cache-write surcharge as before. This is consistent with the P2 priority — warmup is a cost optimization, not a correctness requirement.

- **Provider-agnostic call site**: Because `LLMClient.warmup` is a no-op for all non-Anthropic providers, the `add_episode_bulk` call site needs no `isinstance` check. Provider detection is entirely internal to `AnthropicClient`.

---

### Task Checklist

- [ ] Task 1: Add `async def warmup(self, messages: list[Message]) -> None` as a no-op to `LLMClient` (graphiti_core/llm_client/client.py). Import `Message` from `..prompts.models` is already present.

- [ ] Task 2: Implement `AnthropicClient.warmup` (graphiti_core/llm_client/anthropic_client.py):
  - Return immediately if `self.cache_mode != 'system-block'`
  - Build `warmup_msgs = [messages[0], Message(role='user', content='.')]`
  - Call `await self._call_anthropic_api(warmup_msgs, max_tokens=1)` (result discarded)
  - Wrap in `try/except Exception` with `logger.debug(...)` on failure

- [ ] Task 3: Add unit tests for `AnthropicClient.warmup` (tests/llm_client/test_anthropic_client.py), following the existing patch pattern for `AsyncAnthropic`:
  - `cache_mode='disabled'`: assert no API call is made
  - `cache_mode='top-level'`: assert no API call is made
  - `cache_mode='system-block'`: assert `client.messages.create` is called exactly once, with `max_tokens=1`
  - Exception during warmup: assert no exception propagates to the caller

- [ ] Task 4: Add `Graphiti._warmup_prompt_cache` private async method (graphiti_core/graphiti.py). Signature: `async def _warmup_prompt_cache(self, episodes: list[EpisodicNode], entity_types, edge_types, custom_extraction_instructions) -> None`. Implementation:
  - Build `message_sets: list[list[Message]]`
  - For `extract_nodes`: inspect `{ep.source for ep in episodes}` and for each distinct `EpisodeType`, call the corresponding prompt function (`extract_message` / `extract_text` / `extract_json`) with a minimal context (empty/sentinel values for episode-specific fields, real values for `entity_types` and `custom_extraction_instructions`), then append `messages[0]` paired with `Message(role='user', content='.')` to `message_sets`
  - For `extract_edges`: call `prompt_library.extract_edges.edge({'edge_types': edge_types, ...minimal...})`, extract `[0]`, append to `message_sets`
  - For `dedupe_nodes.nodes`: call `prompt_library.dedupe_nodes.nodes({...minimal...})`, extract `[0]`, append to `message_sets`
  - For `extract_nodes.extract_attributes`: call `prompt_library.extract_nodes.extract_attributes({...minimal...})`, extract `[0]`, append to `message_sets`
  - Issue `await asyncio.gather(*[self.llm_client.warmup(msgs) for msgs in message_sets])`

- [ ] Task 5: Wire up the warmup in `add_episode_bulk` (graphiti_core/graphiti.py, ~line 1304): add `await self._warmup_prompt_cache(episodes, entity_types, edge_types, custom_extraction_instructions)` immediately before the call to `self._extract_and_dedupe_nodes_bulk(...)`. No guard needed at the call site — `LLMClient.warmup` is a no-op for non-Anthropic clients, and `AnthropicClient.warmup` handles the `cache_mode` guard internally.

- [ ] Task 6: Update `docs/prompt_caching.md` with a "Cache warmup" section explaining: warmup fires automatically in `add_episode_bulk` when `cache_mode='system-block'`; it issues one `max_tokens=1` call per distinct prompt type before the fan-out; it is a no-op for `disabled` and `top-level` modes; it is best-effort (failure does not abort the operation).

- [ ] Task 7: Create ADR `adrs/002-cache-warmup-option-a.md` (pick the next sequential number from `adrs/` at implementation time). Cover: the thundering-herd problem, Option A vs Option B trade-offs, why only `system-block` mode benefits, and the concurrent-gather design.

---

### Risks

- **Minimal context assembly may fail for some prompt functions.** If a prompt function dereferences a required context key with no default (e.g., `context['entity_types']` without a guard), calling it with an empty dict will raise `KeyError`. The implementer should identify required keys for each prompt function and provide appropriate empty/sentinel values (e.g., `''` for strings, `[]` for lists, `{}` for dicts). If a prompt function cannot accept empty input gracefully, the minimal context should replicate the real call's structure with empty collections.

- **`extract_nodes` variant mismatch.** If the episode batch is empty (zero episodes), `_warmup_prompt_cache` receives an empty list and may produce zero warmup calls — which is correct (no fan-out will happen). Guard against `not episodes` at the start of `_warmup_prompt_cache`.

- **`extract_nodes.extract_attributes` system prompt may depend on `entity_types`.** If the system prompt for `extract_attributes` includes entity type descriptions (making it dynamic), the warmup must pass the same `entity_types` as real calls. Verify this when implementing Task 4.

- **Warmup adds 4–6 max_tokens=1 API calls to every `add_episode_bulk` call.** At `cache_mode='system-block'`, these are cheap but non-zero. Callers with `cache_mode='disabled'` (the default) see no overhead. The `cache_mode='system-block'` user has already opted into Anthropic-specific caching behaviour, so this is expected.

---
Used 25/50 turns, 5k input / 20k output tokens.

## Verification

Implemented Option A cache warmup: added a no-op `warmup` method to `LLMClient`, overridden in `AnthropicClient` to issue a single `max_tokens=1` call per distinct prompt type when `cache_mode='system-block'`. Added `Graphiti._warmup_prompt_cache` which builds minimal contexts for all four prompt types (`extract_nodes` variants, `extract_edges`, `dedupe_nodes`, `extract_attributes`) and fires them concurrently via `asyncio.gather` before the `add_episode_bulk` fan-out. Five new unit tests cover all cache modes and the exception-swallowing behavior. Documentation and ADR 002 explain the thundering-herd problem, the `system-block`-only guard, and the Option A/B trade-off.

---

Closes #63