### PR TITLE
Restructure extract_edges.extract_attributes for cache-friendly layout

### DIFF
--- a/graphiti_core/prompts/extract_edges.py
+++ b/graphiti_core/prompts/extract_edges.py
@@ -139,14 +139,8 @@ You may use information from the PREVIOUS MESSAGES only to disambiguate referenc
 
 
 def extract_attributes(context: dict[str, Any]) -> list[Message]:
-    return [
-        Message(
-            role='system',
-            content='You are a fact attribute extraction specialist. NEVER hallucinate or infer values not explicitly stated.',
-        ),
-        Message(
-            role='user',
-            content=f"""
+    sys_prompt = """You are a fact attribute extraction specialist. NEVER hallucinate or infer values not explicitly stated.
+
 Given the following FACT, its REFERENCE TIME, and any EXISTING ATTRIBUTES, extract or update
 attributes based on the information explicitly stated in the fact. Use the provided attribute
 descriptions to understand how each attribute should be determined.
@@ -156,8 +150,9 @@ Guidelines:
 2. Only use information stated in the FACT to set attribute values.
 3. Use REFERENCE TIME to resolve any relative temporal expressions in the fact.
 4. Preserve existing attribute values unless the fact explicitly provides new information.
+"""
 
-<FACT>
+    user_prompt = f"""<FACT>
 {context['fact']}
 </FACT>
 
@@ -168,8 +163,11 @@ Guidelines:
 <EXISTING ATTRIBUTES>
 {to_prompt_json(context['existing_attributes'])}
 </EXISTING ATTRIBUTES>
-""",
-        ),
+"""
+
+    return [
+        Message(role='system', content=sys_prompt),
+        Message(role='user', content=user_prompt),
     ]
 
 


### PR DESCRIPTION
## Summary

Move the static guideline text from the user message of `extract_attributes` into its system message, leaving only the dynamic XML-tagged context blocks (`<FACT>`, `<REFERENCE TIME>`, `<EXISTING ATTRIBUTES>`) in the user message. This matches the pattern already applied to the `edge` function in the same file.

## Problem

The `extract_attributes` prompt function in `graphiti_core/prompts/extract_edges.py` mixes static instruction text with dynamic substitutions inside the user message. Static content cannot be cached by LLM providers — it must be in the system message to be eligible for prompt caching. The `edge` function in the same file was already restructured in `ec69d97`; `extract_attributes` was not.

## Approach

### Approach

This is a single-function refactor within one file. The implementation moves the two static text blocks (opening paragraph + Guidelines list) from the user message of `extract_attributes` into its system message, leaving only the three dynamic XML blocks in the user message. No logic changes, no interface changes, no new files.

The `edge` function directly above in the same file is the reference pattern: use local `sys_prompt` and `user_prompt` f-string variables, return `[Message(role='system', content=sys_prompt), Message(role='user', content=user_prompt)]`.

The worktree branch is currently 14 commits behind `origin/liminis`. The Implement agent must rebase onto `origin/liminis` before making any changes — the current `extract_attributes` content in this worktree matches what is on `origin/liminis` exactly (confirmed by reading the file), so there should be no conflict.

**No ADR required.** The pattern is already established by the `edge` function in the same file and documented in `docs/prompt_caching.md`. A new contributor can derive the rationale from those two references.

**No documentation updates required.** `docs/prompt_caching.md` already covers the `system-block` cache mode and the restructuring pattern. This change is internal to a single prompt function with no user-facing or API-contract impact.

### New/Modified Files

| File | Change |
|------|--------|
| `graphiti_core/prompts/extract_edges.py` | Restructure `extract_attributes`: move static paragraph + Guidelines list into `sys_prompt`; leave only `<FACT>`, `<REFERENCE TIME>`, `<EXISTING ATTRIBUTES>` blocks in `user_prompt` |

### Key Decisions

- **System message content**: The existing one-liner (`'You are a fact attribute extraction specialist. NEVER hallucinate or infer values not explicitly stated.'`) is incorporated into `sys_prompt` along with the static paragraph and Guidelines. The "NEVER hallucinate" instruction already present in the system message is preserved — it need not be deduplicated with guideline #1, since the spec requires verbatim preservation of all instruction text.
- **Variable naming**: Use `sys_prompt` / `user_prompt` local variables (matching the `edge` function exactly) rather than inlining strings into `Message(content=...)` calls. This is purely stylistic consistency with the established pattern.
- **Triple-quoted f-strings**: Follow the convention established in commit `a9dc729` — use triple-quoted f-strings for both `sys_prompt` and `user_prompt` to avoid mid-sentence line breaks.

### Task Checklist

- [ ] Task 1: Rebase the worktree branch (`fabrik/issue-59`) onto `origin/liminis` to pick up the 14 commits that landed after the Specify stage
- [ ] Task 2: Restructure `extract_attributes` in `graphiti_core/prompts/extract_edges.py` — extract `sys_prompt` variable containing the existing role sentence plus the static paragraph and four-item Guidelines list; extract `user_prompt` variable containing only the three dynamic XML blocks (`<FACT>`, `<REFERENCE TIME>`, `<EXISTING ATTRIBUTES>`); return `[Message(role='system', content=sys_prompt), Message(role='user', content=user_prompt)]`
- [ ] Task 3: Run `make format && make lint` and fix any issues
- [ ] Task 4: Run `make test -k "not _int"` and confirm all unit tests pass
- [ ] Task 5: Commit the change with a message following the repository's `fix:`/`refactor:` prefix convention

### Risks

- **Worktree is 14 commits behind `origin/liminis`**: Task 1 (rebase) must complete before Task 2. The rebase is expected to be clean since `extract_edges.py` was not modified in those 14 commits — but if a conflict does occur, resolve it by using `origin/liminis` as the base and re-applying the restructure on top.
- **No layout test for `extract_edges.py`**: The spec explicitly excludes test additions, so there is no automated guard against a layout regression. Implement must verify the structure manually (system message has static text only, user message has dynamic blocks only) before committing.

---
Used 7/50 turns, 3k input / 2k output tokens.

## Verification

Restructured `extract_attributes` in `graphiti_core/prompts/extract_edges.py` to match the cache-friendly layout already used by the `edge` function: moved the static opening paragraph and four-item Guidelines list from the user message into the system message (`sys_prompt`), leaving only the three dynamic XML blocks (`<FACT>`, `<REFERENCE TIME>`, `<EXISTING ATTRIBUTES>`) in the user message (`user_prompt`). The branch was already at `origin/liminis` tip so no rebase was needed. All 489 unit tests pass (2 pre-existing WAL driver failures unrelated to this change); the changed file is lint-clean.

---

Closes #59