### PR TITLE
Restructure dedupe_nodes.node and dedupe_nodes.node_list for cache-friendly layout

### DIFF
--- a/graphiti_core/prompts/dedupe_nodes.py
+++ b/graphiti_core/prompts/dedupe_nodes.py
@@ -51,16 +51,41 @@ class Versions(TypedDict):
 
 
 def node(context: dict[str, Any]) -> list[Message]:
-    return [
-        Message(
-            role='system',
-            content='You are an entity deduplication assistant. '
-            'NEVER fabricate entity names or mark distinct entities as duplicates.',
-        ),
-        Message(
-            role='user',
-            content=f"""
-<PREVIOUS MESSAGES>
+    sys_prompt = """You are an entity deduplication assistant.
+NEVER fabricate entity names or mark distinct entities as duplicates.
+
+Entities should only be considered duplicates if they refer to the *same real-world object or concept*.
+Semantic Equivalence: if a descriptive label in EXISTING ENTITIES clearly refers to a named entity in context, treat them as duplicates.
+
+NEVER mark entities as duplicates if:
+- They are related but distinct.
+- They have similar names or purposes but refer to separate instances or concepts.
+
+Task:
+1. Compare the NEW ENTITY against each EXISTING ENTITY (identified by `candidate_id`).
+2. If it refers to the same real-world object or concept, return the `candidate_id` of that match.
+3. Return `duplicate_candidate_id = -1` when there is no match or you are unsure.
+
+<EXAMPLE>
+NEW ENTITY: "Sam" (Person)
+EXISTING ENTITIES: [{"candidate_id": 0, "name": "Sam", "entity_types": ["Person"], "summary": "Sam enjoys hiking and photography"}]
+Result: duplicate_candidate_id = 0 (same person referenced in conversation)
+
+NEW ENTITY: "NYC"
+EXISTING ENTITIES: [{"candidate_id": 0, "name": "New York City", "entity_types": ["Location"]}, {"candidate_id": 1, "name": "New York Knicks", "entity_types": ["Organization"]}]
+Result: duplicate_candidate_id = 0 (same location, abbreviated name)
+
+NEW ENTITY: "Java" (programming language)
+EXISTING ENTITIES: [{"candidate_id": 0, "name": "Java", "entity_types": ["Location"], "summary": "An island in Indonesia"}]
+Result: duplicate_candidate_id = -1 (same name but distinct real-world things)
+
+NEW ENTITY: "Marco's car"
+EXISTING ENTITIES: [{"candidate_id": 0, "name": "Marco's vehicle", "entity_types": ["Entity"], "summary": "Marco drives a red sedan."}]
+Result: duplicate_candidate_id = 0 (synonym — "car" and "vehicle" refer to the same thing, same possessor)
+</EXAMPLE>
+"""
+
+    user_prompt = f"""<PREVIOUS MESSAGES>
 {to_prompt_json(context['previous_episodes'])}
 </PREVIOUS MESSAGES>
 
@@ -79,38 +104,11 @@ def node(context: dict[str, Any]) -> list[Message]:
 <EXISTING ENTITIES>
 {to_prompt_json(context['existing_nodes'])}
 </EXISTING ENTITIES>
+"""
 
-Entities should only be considered duplicates if they refer to the *same real-world object or concept*.
-Semantic Equivalence: if a descriptive label in EXISTING ENTITIES clearly refers to a named entity in context, treat them as duplicates.
-
-NEVER mark entities as duplicates if:
-- They are related but distinct.
-- They have similar names or purposes but refer to separate instances or concepts.
-
-Task:
-1. Compare the NEW ENTITY against each EXISTING ENTITY (identified by `candidate_id`).
-2. If it refers to the same real-world object or concept, return the `candidate_id` of that match.
-3. Return `duplicate_candidate_id = -1` when there is no match or you are unsure.
-
-<EXAMPLE>
-NEW ENTITY: "Sam" (Person)
-EXISTING ENTITIES: [{{"candidate_id": 0, "name": "Sam", "entity_types": ["Person"], "summary": "Sam enjoys hiking and photography"}}]
-Result: duplicate_candidate_id = 0 (same person referenced in conversation)
-
-NEW ENTITY: "NYC"
-EXISTING ENTITIES: [{{"candidate_id": 0, "name": "New York City", "entity_types": ["Location"]}}, {{"candidate_id": 1, "name": "New York Knicks", "entity_types": ["Organization"]}}]
-Result: duplicate_candidate_id = 0 (same location, abbreviated name)
-
-NEW ENTITY: "Java" (programming language)
-EXISTING ENTITIES: [{{"candidate_id": 0, "name": "Java", "entity_types": ["Location"], "summary": "An island in Indonesia"}}]
-Result: duplicate_candidate_id = -1 (same name but distinct real-world things)
-
-NEW ENTITY: "Marco's car"
-EXISTING ENTITIES: [{{"candidate_id": 0, "name": "Marco's vehicle", "entity_types": ["Entity"], "summary": "Marco drives a red sedan."}}]
-Result: duplicate_candidate_id = 0 (synonym — "car" and "vehicle" refer to the same thing, same possessor)
-</EXAMPLE>
-""",
-        ),
+    return [
+        Message(role='system', content=sys_prompt),
+        Message(role='user', content=user_prompt),
     ]
 
 
@@ -179,19 +177,9 @@ Your response MUST include EXACTLY {n} resolutions with IDs 0 through {n - 1}. D
 
 
 def node_list(context: dict[str, Any]) -> list[Message]:
-    return [
-        Message(
-            role='system',
-            content='You are an entity deduplication assistant that groups duplicate nodes by UUID.',
-        ),
-        Message(
-            role='user',
-            content=f"""
-Given the following context, deduplicate a list of nodes:
+    sys_prompt = """You are an entity deduplication assistant that groups duplicate nodes by UUID.
 
-<NODES>
-{to_prompt_json(context['nodes'])}
-</NODES>
+Given the following context, deduplicate a list of nodes:
 
 Task:
 1. Group nodes together such that all duplicate nodes are in the same list of uuids.
@@ -205,19 +193,27 @@ Guidelines:
 <EXAMPLE>
 Input nodes:
 [
-  {{"uuid": "a1", "name": "NYC", "summary": "New York City"}},
-  {{"uuid": "b2", "name": "New York City", "summary": "The city of New York"}},
-  {{"uuid": "c3", "name": "Los Angeles", "summary": "City in California"}}
+  {"uuid": "a1", "name": "NYC", "summary": "New York City"},
+  {"uuid": "b2", "name": "New York City", "summary": "The city of New York"},
+  {"uuid": "c3", "name": "Los Angeles", "summary": "City in California"}
 ]
 
 Result:
 [
-  {{"uuids": ["a1", "b2"], "summary": "New York City, also known as NYC"}},
-  {{"uuids": ["c3"], "summary": "City in California"}}
+  {"uuids": ["a1", "b2"], "summary": "New York City, also known as NYC"},
+  {"uuids": ["c3"], "summary": "City in California"}
 ]
 </EXAMPLE>
-""",
-        ),
+"""
+
+    user_prompt = f"""<NODES>
+{to_prompt_json(context['nodes'])}
+</NODES>
+"""
+
+    return [
+        Message(role='system', content=sys_prompt),
+        Message(role='user', content=user_prompt),
     ]
 
 


### PR DESCRIPTION
## Summary

Move all static content (task description, rules, and examples) from the user message to the system message in `dedupe_nodes.node` and `dedupe_nodes.node_list`. Keep only the per-call dynamic data in the user message. The output of each function remains a 2-element `list[Message]` with the same interface as `nodes`.

## Problem

Anthropic's prompt caching requires that cacheable content appear in the system message and remain stable across API calls. Currently, all three functions in `graphiti_core/prompts/dedupe_nodes.py` put static content (task rules, examples) in the user message alongside dynamic, per-call data. This prevents the static content from being cached, increasing latency and cost on every deduplication call.

The cache-friendly layout is: static content (rules, examples, task description, guidelines) → system message; dynamic, per-call content → user message. This restructure has been applied to `dedupe_nodes.nodes` (the reference implementation); the same treatment is needed for `dedupe_nodes.node` and `dedupe_nodes.node_list`.

## Approach

### Approach

Both `node()` and `node_list()` need the same mechanical transformation: extract all static content from the f-string user message into a plain-string system message, leaving only dynamic `context[...]` substitutions in the user message. The `nodes()` function (already restructured) serves as the exact structural template.

The single most important implementation detail is **brace escaping**: the current user messages are f-strings, so JSON example literals use `{{...}}` to produce literal braces. When those examples move to the plain-string system message they must use single `{...}` — just like `nodes()` does. Any double-brace left behind would corrupt the prompt text with literal `{{`.

No new files, no signature changes, no new tests, no documentation updates needed.

### New/Modified Files

| File | Change |
|------|--------|
| `graphiti_core/prompts/dedupe_nodes.py` | Move static content from user to system in `node()` and `node_list()` |

### Key Decisions

- **System message as a plain string (not f-string)**: Matching `nodes()` exactly. An f-string would require double-brace escaping in examples and risks accidental interpolation of stray `{` characters in prompt text. Plain string = no escaping, no risk.
- **`entity_type_description` stays in user message**: It varies per call (custom entity types can have arbitrary descriptions), so it cannot be in the system/cache block. This is a spec requirement confirmed by research.
- **No ADR**: This is mechanical application of the established cache-friendly prompt layout (already documented via ADR 002 and the `nodes()` reference implementation). No new design decision is being made.
- **No documentation update**: This is an internal prompt restructuring with no observable API, config, or behavioral change. `docs/prompt_caching.md` covers the caching strategy at the right level of abstraction.

### Task Checklist

- [ ] Task 1: Restructure `node()` — move static content (role/rules/task/examples) to a plain-string `sys_prompt`; keep only the five XML-tagged dynamic sections in an f-string `user_prompt`; fix brace escaping in all four examples (single `{` not `{{`)
- [ ] Task 2: Restructure `node_list()` — move static content (role/task/guidelines/NYC-LA example) to a plain-string `sys_prompt`; keep only the `<NODES>` XML section in an f-string `user_prompt`; fix brace escaping in the example
- [ ] Task 3: Run `make format && make lint` and confirm zero errors
- [ ] Task 4: Run `pytest tests/utils/maintenance/test_node_operations.py` and confirm all tests pass

### Risks

- **Brace escaping errors**: The only realistic implementation mistake. Mitigation: after writing each system string, grep for `{{` or `}}` in the new system message content and fix any found — there should be none.
- **Accidental f-string on system message**: If `sys_prompt = f"""..."""` is used instead of `sys_prompt = """..."""`, the braces in the examples will be treated as interpolations and raise a `KeyError` or produce wrong output. Mitigation: explicit check that neither `sys_prompt` assignment uses `f"""`.

---
Used 7/50 turns, 3k input / 2k output tokens.

## Verification

Restructured `dedupe_nodes.node` and `dedupe_nodes.node_list` in `graphiti_core/prompts/dedupe_nodes.py` to follow the cache-friendly layout: static content (role description, rules, task, and examples) moved to a plain-string system message, leaving only per-call XML-tagged dynamic data in the user f-string. Double-brace escaping from the old f-string examples was corrected to single braces in the new plain system strings. All 43 tests in `test_node_operations.py` pass, and `dedupe_nodes.py` is lint- and format-clean.

---

Closes #60