### PR TITLE
Adopt multi-label entities with union semantics on merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,8 +395,10 @@ label set is updated to the **union** of both sets. No labels are discarded. Thi
 first seen as a `Service` and later extracted as a `System` will carry `['Entity', 'Service', 'System']`
 after merging.
 
-**Backward compatibility:** `labels[0]` is always `'Entity'` after sorting. Existing code that reads
-`node.labels[0]` as a primary-label fallback continues to work.
+**Backward compatibility:** The `'Entity'` label is always present in the list. Labels are stored in
+sorted order, so `labels[0]` gives the alphabetically first label (which is `'Entity'` for most of
+the ontology, but labels such as `Award`, `Book`, `Concept`, and `Document` sort before it).
+Existing code that reads `labels[0]` as a primary-label fallback continues to receive a meaningful label.
 
 ### Merge semantics
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ frequently changing data. Graphiti addresses these challenges by providing:
 - **Episodes & Provenance:** Every entity and relationship traces back to the episodes (raw data) that produced it.
   Full lineage from derived fact to source.
 - **Prescribed & Learned Ontology:** Define entity and edge types upfront via Pydantic models (prescribed), or let
-  structure emerge from your data (learned). Start simple, evolve as patterns appear.
+  structure emerge from your data (learned). In freeform mode, entities carry one or more labels from a stable
+  16-label ontology; dedup merges union label sets so no signal is discarded. Start simple, evolve as patterns appear.
 - **Incremental Graph Construction:** New data integrates immediately without batch recomputation. The graph evolves
   in real-time as episodes are ingested.
 - **Hybrid Retrieval:** Combines semantic embeddings, keyword (BM25), and graph traversal for low-latency,
@@ -359,6 +360,43 @@ The MCP server exposes two write tools for AI assistant workflows:
 - `knowledge_merge_entities_batch(merges, dry_run=False)` — batch merge
 
 Both tools respect `dry_run` for safe previewing before committing changes.
+
+### Freeform entity labeling
+
+When no custom `entity_types` are provided, Graphiti runs in **freeform mode**: the LLM assigns one or
+more labels from a stable, closed ontology to every extracted entity. The available labels are:
+
+| Label | Description |
+|-------|-------------|
+| `Person` | An individual human being |
+| `Organization` | A company, institution, group, or governing body |
+| `Software` | A software application, library, or framework |
+| `Service` | A deployed service, platform, or SaaS product |
+| `System` | An integrated technical system or infrastructure component |
+| `Technology` | A protocol, standard, methodology, or technical approach |
+| `Concept` | An abstract idea, principle, or theoretical framework |
+| `Location` | A physical or virtual place, region, or address |
+| `Event` | A dated or scheduled occurrence or incident |
+| `Process` | A workflow, procedure, or repeatable operation |
+| `Requirement` | A constraint, specification, or policy requirement |
+| `Document` | A document, report, specification, or publication |
+| `Product` | A physical or digital product or deliverable |
+| `Project` | A project, initiative, or program |
+| `Award` | A prize, honor, or recognition |
+| `Book` | A book, novel, or long-form publication |
+
+Most entities get a single label (e.g., `['Entity', 'Person']`). The LLM may assign multiple labels
+when an entity genuinely spans categories — for example, a deployed open-source library might receive
+both `Service` and `Software`.
+
+**Multi-label union semantics:** Every entity node carries a `labels` list. When deduplication merges
+two nodes that represent the same real-world entity but have different labels, the surviving node's
+label set is updated to the **union** of both sets. No labels are discarded. This means an entity
+first seen as a `Service` and later extracted as a `System` will carry `['Entity', 'Service', 'System']`
+after merging.
+
+**Backward compatibility:** `labels[0]` is always `'Entity'` after sorting. Existing code that reads
+`node.labels[0]` as a primary-label fallback continues to work.
 
 ### Merge semantics
 

--- a/README.md
+++ b/README.md
@@ -395,10 +395,8 @@ label set is updated to the **union** of both sets. No labels are discarded. Thi
 first seen as a `Service` and later extracted as a `System` will carry `['Entity', 'Service', 'System']`
 after merging.
 
-**Backward compatibility:** The `'Entity'` label is always present in the list. Labels are stored in
-sorted order, so `labels[0]` gives the alphabetically first label (which is `'Entity'` for most of
-the ontology, but labels such as `Award`, `Book`, `Concept`, and `Document` sort before it).
-Existing code that reads `labels[0]` as a primary-label fallback continues to receive a meaningful label.
+**Backward compatibility:** `labels[0]` is always `'Entity'`. Specific type labels follow in sorted
+order. Existing code that reads `labels[0]` as a stable anchor continues to work unchanged.
 
 ### Merge semantics
 

--- a/adrs/003-freeform-entity-closed-ontology.md
+++ b/adrs/003-freeform-entity-closed-ontology.md
@@ -1,0 +1,115 @@
+# ADR 003: Closed 16-label ontology for freeform entity extraction
+
+## Status
+
+Accepted
+
+## Context
+
+When no custom `entity_types` are provided by the caller, Graphiti operates in **freeform mode**:
+the LLM is responsible for choosing a label for each extracted entity. Previously, the prompt
+offered open-ended guidance ("use any concise capitalized single-word label such as Person,
+Organization, Software…"). This produced unbounded label diversity across different documents and
+LLM calls — `Visualization Data Service` was extracted as `Service`, `System`, and `Technology`
+across three chunks of the same RFC corpus. Without a stable label namespace, downstream consumers
+cannot filter by label reliably, and the dedup candidate pool fills with parallel nodes that
+represent the same entity under different labels.
+
+Additionally, the previous `_promote_resolved_node` function in `dedup_helpers.py` contained an
+early-return short-circuit: if the canonical node already carried any specific label it returned
+immediately, silently discarding the incoming node's labels. This compounded the label-proliferation
+problem — even when two nodes were identified as duplicates, the merge did not union their labels.
+
+A 13-document RFC corpus demonstrated 1234 entity-pair duplicates at threshold 0.85, the majority
+of which were same-name-different-label cases. Without label-union merge semantics and a stable
+ontology, every additional ingested document would add more parallel entities.
+
+## Decision
+
+1. **Replace open-ended label guidance with a closed 16-label ontology** embedded directly in the
+   freeform extraction prompt. The LLM must choose one or more labels from this list per entity:
+
+   | Label | Description |
+   |-------|-------------|
+   | `Person` | An individual human being |
+   | `Organization` | A company, institution, group, or governing body |
+   | `Software` | A software application, library, or framework |
+   | `Service` | A deployed service, platform, or SaaS product |
+   | `System` | An integrated technical system or infrastructure component |
+   | `Technology` | A protocol, standard, methodology, or technical approach |
+   | `Concept` | An abstract idea, principle, or theoretical framework |
+   | `Location` | A physical or virtual place, region, or address |
+   | `Event` | A dated or scheduled occurrence or incident |
+   | `Process` | A workflow, procedure, or repeatable operation |
+   | `Requirement` | A constraint, specification, or policy requirement |
+   | `Document` | A document, report, specification, or publication |
+   | `Product` | A physical or digital product or deliverable |
+   | `Project` | A project, initiative, or program |
+   | `Award` | A prize, honor, or recognition |
+   | `Book` | A book, novel, or long-form publication |
+
+2. **Change `ExtractedEntityFreeform.entity_type: str` → `entity_types: list[str]`** so the LLM
+   can assign multiple labels per entity in a single extraction call. The common case is one label
+   per entity; multiple labels are used when an entity genuinely spans categories.
+
+3. **Replace `_promote_resolved_node` short-circuit with full union semantics:**
+   `resolved_node.labels = sorted(set(resolved_node.labels) | set(extracted_node.labels))`.
+   All three call sites (exact-name match, fuzzy match, LLM-escalated dedup) benefit without
+   any call-site changes.
+
+4. **Apply the same union semantics in `_collapse_exact_duplicate_extracted_nodes`** to handle
+   same-episode same-name entities that carry different label sets.
+
+5. **Filter-not-skip exclusion semantics:** When `excluded_entity_types` filters one of an
+   entity's labels, the entity is kept with the remaining labels rather than discarded entirely.
+   An entity is skipped only when all of its specific labels are excluded.
+
+The ontology is defined as `_FREEFORM_ENTITY_ONTOLOGY` in `graphiti_core/prompts/extract_nodes.py`
+and rendered into both the `extract_message` and `extract_json`/`extract_text` instruction helpers.
+
+## Rationale
+
+### Why a closed ontology instead of an open-ended one?
+
+Open-ended label guidance produces high label entropy across runs and documents. A closed list lets
+the LLM choose confidently from a well-defined namespace, makes downstream consumers' label-based
+filtering reliable, and bounds the maximum number of labels an entity can accumulate over many
+merges. The 16 labels were chosen to cover the label set already observed in existing extraction
+examples plus the domain-relevant labels (`Service`, `System`, `Process`, `Requirement`) that
+caused the original label-proliferation problem.
+
+### Why multi-label (`list[str]`) instead of single label per call?
+
+The same real-world entity is often validly described by more than one category across different
+contexts. Forcing a single label per extraction call means the first chunk to mention an entity
+locks in its label, and subsequent chunks that would justify additional labels cannot contribute.
+Multi-label at extraction time is the cleanest representation; it aligns with the union merge
+semantics applied at dedup time.
+
+### Why union semantics instead of picking a canonical label at merge time?
+
+An additional LLM call to select a canonical label at merge time adds latency and non-determinism,
+and discards valid signal that was deliberately extracted from chunk context. Union semantics are
+already implemented in the `merge_entities` edge-resolution path (`graphiti.py:1747–1749`); this
+decision makes dedup consistent with that path. The `labels[0]` backward-compat convention
+(always `'Entity'` after sorting) means no dashboard or API consumer breaks.
+
+### Why `sorted()` instead of insertion-order deduplication?
+
+`set()` operations are non-deterministic in iteration order. `sorted()` produces stable,
+predictable label lists that are easier to test and log. All existing code that sorts label unions
+uses `sorted()` consistently.
+
+## Consequences
+
+- **Positive:** Stable, bounded label namespace; multi-label entities receive all valid labels
+  at extraction time; dedup merge no longer silently discards labels; downstream consumers can
+  filter by label reliably.
+- **Positive:** `labels[0]` remains `'Entity'` after sorting, preserving backward compatibility.
+- **Neutral:** Existing nodes in the graph retain their pre-migration labels. They will acquire
+  additional labels only when they are touched by a new dedup merge.
+- **Negative:** The ontology is embedded in the prompt — expanding it requires updating the
+  constant and re-testing extraction quality. Hierarchical labels or sub-types are future work.
+- **Negative:** Entities ingested before this change may carry labels outside the closed ontology
+  (from the previous open-ended guidance). The `_sanitize_label` function still accepts any valid
+  identifier, so legacy labels are stored correctly; they just won't appear in the new ontology.

--- a/adrs/003-freeform-entity-closed-ontology.md
+++ b/adrs/003-freeform-entity-closed-ontology.md
@@ -53,7 +53,7 @@ ontology, every additional ingested document would add more parallel entities.
    per entity; multiple labels are used when an entity genuinely spans categories.
 
 3. **Replace `_promote_resolved_node` short-circuit with full union semantics:**
-   `resolved_node.labels = sorted(set(resolved_node.labels) | set(extracted_node.labels))`.
+   `resolved_node.labels = ['Entity'] + sorted((set(resolved_node.labels) | set(extracted_node.labels)) - {'Entity'})`.
    All three call sites (exact-name match, fuzzy match, LLM-escalated dedup) benefit without
    any call-site changes.
 
@@ -91,8 +91,8 @@ semantics applied at dedup time.
 An additional LLM call to select a canonical label at merge time adds latency and non-determinism,
 and discards valid signal that was deliberately extracted from chunk context. Union semantics are
 already implemented in the `merge_entities` edge-resolution path (`graphiti.py:1747–1749`); this
-decision makes dedup consistent with that path. The `'Entity'` label is always present in the
-sorted list, so no dashboard or API consumer that checks for membership loses access to it.
+decision makes dedup consistent with that path. Label lists are stored as `['Entity'] + sorted(specific_labels)`,
+so `labels[0]` is always `'Entity'` — no dashboard or API consumer relying on that position breaks.
 
 ### Why `sorted()` instead of insertion-order deduplication?
 
@@ -105,7 +105,7 @@ uses `sorted()` consistently.
 - **Positive:** Stable, bounded label namespace; multi-label entities receive all valid labels
   at extraction time; dedup merge no longer silently discards labels; downstream consumers can
   filter by label reliably.
-- **Positive:** `'Entity'` is always present in the sorted labels list; label order is deterministic and stable in tests and logs.
+- **Positive:** `labels[0]` is always `'Entity'`; specific type labels follow in sorted order. Label lists are deterministic and backward-compatible.
 - **Neutral:** Existing nodes in the graph retain their pre-migration labels. They will acquire
   additional labels only when they are touched by a new dedup merge.
 - **Negative:** The ontology is embedded in the prompt — expanding it requires updating the

--- a/adrs/003-freeform-entity-closed-ontology.md
+++ b/adrs/003-freeform-entity-closed-ontology.md
@@ -91,8 +91,8 @@ semantics applied at dedup time.
 An additional LLM call to select a canonical label at merge time adds latency and non-determinism,
 and discards valid signal that was deliberately extracted from chunk context. Union semantics are
 already implemented in the `merge_entities` edge-resolution path (`graphiti.py:1747–1749`); this
-decision makes dedup consistent with that path. The `labels[0]` backward-compat convention
-(always `'Entity'` after sorting) means no dashboard or API consumer breaks.
+decision makes dedup consistent with that path. The `'Entity'` label is always present in the
+sorted list, so no dashboard or API consumer that checks for membership loses access to it.
 
 ### Why `sorted()` instead of insertion-order deduplication?
 
@@ -105,7 +105,7 @@ uses `sorted()` consistently.
 - **Positive:** Stable, bounded label namespace; multi-label entities receive all valid labels
   at extraction time; dedup merge no longer silently discards labels; downstream consumers can
   filter by label reliably.
-- **Positive:** `labels[0]` remains `'Entity'` after sorting, preserving backward compatibility.
+- **Positive:** `'Entity'` is always present in the sorted labels list; label order is deterministic and stable in tests and logs.
 - **Neutral:** Existing nodes in the graph retain their pre-migration labels. They will acquire
   additional labels only when they are touched by a new dedup merge.
 - **Negative:** The ontology is embedded in the prompt — expanding it requires updating the

--- a/graphiti_core/prompts/extract_nodes.py
+++ b/graphiti_core/prompts/extract_nodes.py
@@ -33,14 +33,38 @@ class ExtractedEntity(BaseModel):
     )
 
 
+_FREEFORM_ENTITY_ONTOLOGY: list[tuple[str, str]] = [
+    ('Person', 'An individual human being'),
+    ('Organization', 'A company, institution, group, or governing body'),
+    ('Software', 'A software application, library, or framework'),
+    ('Service', 'A deployed service, platform, or SaaS product'),
+    ('System', 'An integrated technical system or infrastructure component'),
+    ('Technology', 'A protocol, standard, methodology, or technical approach'),
+    ('Concept', 'An abstract idea, principle, or theoretical framework'),
+    ('Location', 'A physical or virtual place, region, or address'),
+    ('Event', 'A dated or scheduled occurrence or incident'),
+    ('Process', 'A workflow, procedure, or repeatable operation'),
+    ('Requirement', 'A constraint, specification, or policy requirement'),
+    ('Document', 'A document, report, specification, or publication'),
+    ('Product', 'A physical or digital product or deliverable'),
+    ('Project', 'A project, initiative, or program'),
+    ('Award', 'A prize, honor, or recognition'),
+    ('Book', 'A book, novel, or long-form publication'),
+]
+
+_FREEFORM_ONTOLOGY_TEXT = '\n'.join(
+    f'   - {label}: {desc}' for label, desc in _FREEFORM_ENTITY_ONTOLOGY
+)
+
+
 class ExtractedEntityFreeform(BaseModel):
     name: str = Field(..., description='Name of the extracted entity')
-    entity_type: str = Field(
-        description='The ontological type that best describes this entity. '
-        'Use a concise, capitalized, single-word label. '
-        'You are free to use any type that fits — common examples include '
-        'Person, Organization, Software, Concept, Location, Event, Award, '
-        'Book, Technology, but use whatever label best captures the entity.',
+    entity_types: list[str] = Field(
+        description='One or more ontological labels that describe this entity. '
+        'Choose from the closed ontology list provided in the instructions. '
+        'Most entities have a single label; use multiple only when an entity '
+        'genuinely belongs to more than one category (e.g., a software library '
+        'that is also a service).',
     )
 
 
@@ -105,10 +129,11 @@ class Versions(TypedDict):
 def _entity_type_classification_instructions(context: dict[str, Any]) -> str:
     """Generate entity classification instructions based on whether custom types are provided."""
     if context.get('freeform_entity_types'):
-        return """3. **Entity Classification**:
-   - Assign an `entity_type` label that best describes each entity's ontological category.
-   - Use any type that fits — you are not limited to a fixed set. Choose the most descriptive and specific label.
-   - Use concise, capitalized, single-word labels (e.g., Person, Book, Award, Technology, Methodology)."""
+        return f"""3. **Entity Classification**:
+   - Assign one or more `entity_types` labels from the closed ontology below.
+   - Most entities have a single label; use multiple only when the entity genuinely spans categories.
+   - Choose only from this list:
+{_FREEFORM_ONTOLOGY_TEXT}"""
     else:
         return """3. **Entity Classification**:
    - Use the descriptions in ENTITY TYPES to classify each extracted entity.
@@ -119,9 +144,9 @@ def _classification_instruction_inline(context: dict[str, Any]) -> str:
     """Generate inline classification instruction for extract_json and extract_text prompts."""
     if context.get('freeform_entity_types'):
         return (
-            'For each entity extracted, assign an `entity_type` label that best describes its '
-            'ontological category. Use any type that fits — you are not limited to a fixed set. '
-            'Use concise, capitalized, single-word labels.'
+            'For each entity extracted, assign one or more `entity_types` labels from this closed ontology:\n'
+            f'{_FREEFORM_ONTOLOGY_TEXT}\n'
+            'Most entities have a single label; use multiple only when the entity genuinely spans categories.'
         )
     return (
         'For each entity extracted, also determine its entity type based on the provided ENTITY TYPES '

--- a/graphiti_core/prompts/extract_nodes.py
+++ b/graphiti_core/prompts/extract_nodes.py
@@ -226,7 +226,7 @@ reference entities. Only extract distinct entities from the CURRENT MESSAGE.
 
 <EXAMPLE>
 Message: "Jordan: We just moved to Denver last month. My spouse started a new role at Lockheed Martin and I enrolled in a ceramics workshop at the Belmont Arts Center."
-Good extractions: "Jordan" (speaker), "Denver" (Location), "Lockheed Martin" (Organization), "Belmont Arts Center" (Location), "ceramics" (Topic)
+Good extractions: "Jordan" (speaker), "Denver" (Location), "Lockheed Martin" (Organization), "Belmont Arts Center" (Location), "ceramics" (Concept)
 Do NOT extract: "spouse" (generic reference — extract only if named), "new role" (not an entity), "last month" (temporal), "we" (pronoun)
 </EXAMPLE>
 
@@ -238,7 +238,7 @@ Do NOT extract: "dad" (bare relational term — qualify as "Nisha's dad"), "dogs
 
 <EXAMPLE>
 Message: "Mary: I forgot Trigger's leash so I couldn't take him on a dog walk. After that I went road cycling in my new wool coat."
-Good extractions: "Mary" (speaker), "Trigger" (animal name), "dog leash" (Object), "road cycling" (Topic), "wool coat" (Object)
+Good extractions: "Mary" (speaker), "Trigger" (named entity), "dog leash" (Product), "road cycling" (Process), "wool coat" (Product)
 Do NOT extract: "leash" (too generic — use "dog leash"), "cycling" (too generic — use "road cycling"), "coat" (too generic — use "wool coat"), "dog walk" (activity, not an entity)
 </EXAMPLE>
 
@@ -387,7 +387,7 @@ Guidelines:
 
 <EXAMPLE>
 Text: "Dr. Amara Osei presented her migraine study results at the AAN conference. The study tracked 340 patients using a new CGRP combination protocol."
-Good extractions: "Dr. Amara Osei" (Person), "AAN" (Organization), "migraine study" (Topic), "CGRP combination protocol" (Object)
+Good extractions: "Dr. Amara Osei" (Person), "AAN" (Organization), "migraine study" (Document), "CGRP combination protocol" (Process)
 Do NOT extract: "results" (generic noun), "340" (number), "patients" (generic noun), "conference" (generic without a specific name)
 </EXAMPLE>
 

--- a/graphiti_core/utils/maintenance/dedup_helpers.py
+++ b/graphiti_core/utils/maintenance/dedup_helpers.py
@@ -175,7 +175,8 @@ def _promote_resolved_node(
     resolved_node: EntityNode,
 ) -> EntityNode:
     """Union the labels of the extracted node into the canonical resolved node."""
-    resolved_node.labels = sorted(set(resolved_node.labels) | set(extracted_node.labels))
+    merged = set(resolved_node.labels) | set(extracted_node.labels)
+    resolved_node.labels = ['Entity'] + sorted(merged - {'Entity'})
     return resolved_node
 
 

--- a/graphiti_core/utils/maintenance/dedup_helpers.py
+++ b/graphiti_core/utils/maintenance/dedup_helpers.py
@@ -174,21 +174,8 @@ def _promote_resolved_node(
     extracted_node: EntityNode,
     resolved_node: EntityNode,
 ) -> EntityNode:
-    """Upgrade a generic canonical node when a duplicate carries a specific type."""
-    resolved_specific_labels = [label for label in resolved_node.labels if label != 'Entity']
-    if resolved_specific_labels:
-        return resolved_node
-
-    extracted_specific_labels = [label for label in extracted_node.labels if label != 'Entity']
-    if not extracted_specific_labels:
-        return resolved_node
-
-    promoted_labels: list[str] = []
-    for label in ['Entity', *resolved_node.labels, *extracted_specific_labels]:
-        if label not in promoted_labels:
-            promoted_labels.append(label)
-
-    resolved_node.labels = promoted_labels
+    """Union the labels of the extracted node into the canonical resolved node."""
+    resolved_node.labels = sorted(set(resolved_node.labels) | set(extracted_node.labels))
     return resolved_node
 
 

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -285,18 +285,19 @@ def _create_entity_nodes_freeform(
 
     for extracted_entity in extracted_entities:
         sanitized = [_sanitize_label(t) for t in extracted_entity.entity_types]
+        initial_specific = [t for t in sanitized if t != 'Entity']
 
         # Filter-not-skip: remove excluded labels, keep entity if any specific labels remain
         if excluded_entity_types:
             sanitized = [t for t in sanitized if t not in excluded_entity_types]
 
         specific_labels = [t for t in sanitized if t != 'Entity']
-        if not specific_labels and excluded_entity_types:
-            # All specific labels were excluded; only generic fallback remains — skip
+        if initial_specific and not specific_labels:
+            # All specific labels were excluded; skip the entity entirely
             logger.debug(f'Excluding entity "{extracted_entity.name}": all labels excluded')
             continue
 
-        labels: list[str] = sorted(set(['Entity'] + (specific_labels if specific_labels else [])))
+        labels: list[str] = sorted(set(['Entity'] + specific_labels))
 
         new_node = EntityNode(
             name=extracted_entity.name,

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -297,7 +297,7 @@ def _create_entity_nodes_freeform(
             logger.debug(f'Excluding entity "{extracted_entity.name}": all labels excluded')
             continue
 
-        labels: list[str] = sorted(set(['Entity'] + specific_labels))
+        labels: list[str] = ['Entity'] + sorted(set(specific_labels))
 
         new_node = EntityNode(
             name=extracted_entity.name,
@@ -330,7 +330,8 @@ def _collapse_exact_duplicate_extracted_nodes(
             ordered_names.append(normalized_name)
             continue
 
-        existing.labels = sorted(set(existing.labels) | set(node.labels))
+        merged = set(existing.labels) | set(node.labels)
+        existing.labels = ['Entity'] + sorted(merged - {'Entity'})
 
     return [canonical_by_name[name] for name in ordered_names]
 

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -284,14 +284,19 @@ def _create_entity_nodes_freeform(
     extracted_nodes = []
 
     for extracted_entity in extracted_entities:
-        entity_type_name = _sanitize_label(extracted_entity.entity_type)
+        sanitized = [_sanitize_label(t) for t in extracted_entity.entity_types]
 
-        # Check if this entity type should be excluded
-        if excluded_entity_types and entity_type_name in excluded_entity_types:
-            logger.debug(f'Excluding entity of type "{entity_type_name}"')
+        # Filter-not-skip: remove excluded labels, keep entity if any specific labels remain
+        if excluded_entity_types:
+            sanitized = [t for t in sanitized if t not in excluded_entity_types]
+
+        specific_labels = [t for t in sanitized if t != 'Entity']
+        if not specific_labels and excluded_entity_types:
+            # All specific labels were excluded; only generic fallback remains — skip
+            logger.debug(f'Excluding entity "{extracted_entity.name}": all labels excluded')
             continue
 
-        labels: list[str] = list({'Entity', entity_type_name})
+        labels: list[str] = sorted(set(['Entity'] + (specific_labels if specific_labels else [])))
 
         new_node = EntityNode(
             name=extracted_entity.name,
@@ -301,7 +306,7 @@ def _create_entity_nodes_freeform(
             created_at=utc_now(),
         )
         extracted_nodes.append(new_node)
-        logger.debug(f'Created new node: {new_node.uuid} (type: {entity_type_name})')
+        logger.debug(f'Created new node: {new_node.uuid} (types: {specific_labels})')
 
     return extracted_nodes
 
@@ -309,12 +314,7 @@ def _create_entity_nodes_freeform(
 def _collapse_exact_duplicate_extracted_nodes(
     extracted_nodes: list[EntityNode],
 ) -> list[EntityNode]:
-    """Collapse same-message duplicates with the same normalized name.
-
-    This is intentionally narrow: it only merges exact normalized-name duplicates that the
-    extraction prompt should already have emitted once. When duplicates disagree on specificity,
-    keep the more specific node (for example, `Person` over bare `Entity`).
-    """
+    """Collapse same-message duplicates with the same normalized name, unioning their labels."""
     if len(extracted_nodes) < 2:
         return extracted_nodes
 
@@ -329,13 +329,7 @@ def _collapse_exact_duplicate_extracted_nodes(
             ordered_names.append(normalized_name)
             continue
 
-        existing_specific_labels = {label for label in existing.labels if label != 'Entity'}
-        node_specific_labels = {label for label in node.labels if label != 'Entity'}
-        if len(node_specific_labels) > len(existing_specific_labels) or (
-            len(node_specific_labels) == len(existing_specific_labels)
-            and len(node.name.strip()) > len(existing.name.strip())
-        ):
-            canonical_by_name[normalized_name] = node
+        existing.labels = sorted(set(existing.labels) | set(node.labels))
 
     return [canonical_by_name[name] for name in ordered_names]
 

--- a/tests/utils/maintenance/test_entity_extraction.py
+++ b/tests/utils/maintenance/test_entity_extraction.py
@@ -81,8 +81,8 @@ class TestExtractNodesSmallInput:
         # Mock LLM response (freeform mode — no entity_types provided)
         llm_generate.return_value = {
             'extracted_entities': [
-                {'name': 'Alice', 'entity_type': 'Person'},
-                {'name': 'Bob', 'entity_type': 'Person'},
+                {'name': 'Alice', 'entity_types': ['Person']},
+                {'name': 'Bob', 'entity_types': ['Person']},
             ]
         }
 
@@ -183,9 +183,9 @@ class TestExtractNodesSmallInput:
         # Freeform mode (no entity_types provided)
         llm_generate.return_value = {
             'extracted_entities': [
-                {'name': 'Alice', 'entity_type': 'Person'},
-                {'name': '', 'entity_type': 'Person'},
-                {'name': '   ', 'entity_type': 'Concept'},
+                {'name': 'Alice', 'entity_types': ['Person']},
+                {'name': '', 'entity_types': ['Person']},
+                {'name': '   ', 'entity_types': ['Concept']},
             ]
         }
 
@@ -662,9 +662,9 @@ class TestFreeformEntityExtraction:
 
         llm_generate.return_value = {
             'extracted_entities': [
-                {'name': 'Alice', 'entity_type': 'Person'},
-                {'name': 'Acme Corp', 'entity_type': 'Organization'},
-                {'name': 'Python', 'entity_type': 'Software'},
+                {'name': 'Alice', 'entity_types': ['Person']},
+                {'name': 'Acme Corp', 'entity_types': ['Organization']},
+                {'name': 'Python', 'entity_types': ['Software']},
             ]
         }
 
@@ -690,8 +690,8 @@ class TestFreeformEntityExtraction:
 
         llm_generate.return_value = {
             'extracted_entities': [
-                {'name': 'Alice', 'entity_type': 'Person'},
-                {'name': 'Python', 'entity_type': 'Software'},
+                {'name': 'Alice', 'entity_types': ['Person']},
+                {'name': 'Python', 'entity_types': ['Software']},
             ]
         }
 
@@ -714,8 +714,8 @@ class TestFreeformEntityExtraction:
 
         llm_generate.return_value = {
             'extracted_entities': [
-                {'name': 'Alice', 'entity_type': ''},
-                {'name': 'Bob', 'entity_type': '   '},
+                {'name': 'Alice', 'entity_types': ['']},
+                {'name': 'Bob', 'entity_types': ['   ']},
             ]
         }
 

--- a/tests/utils/maintenance/test_node_operations.py
+++ b/tests/utils/maintenance/test_node_operations.py
@@ -1163,4 +1163,83 @@ async def test_resolve_extracted_nodes_cross_label_same_name_produces_duplicate_
 
     assert len(duplicate_pairs) == 1
     assert duplicate_pairs[0][0].uuid == extracted.uuid
-    assert duplicate_pairs[0][1].uuid == existing.uuid
+
+
+# ── Multi-label union tests ────────────────────────────────────────────────────
+
+def test_promote_resolved_node_unions_disjoint_labels():
+    """_promote_resolved_node must union label sets, not discard the incoming labels."""
+    from graphiti_core.utils.maintenance.dedup_helpers import _promote_resolved_node
+
+    existing = EntityNode(name='Vis Service', group_id='g', labels=['Entity', 'Service'])
+    incoming = EntityNode(name='Vis Service', group_id='g', labels=['Entity', 'System'])
+
+    result = _promote_resolved_node(incoming, existing)
+
+    assert result is existing
+    assert set(result.labels) == {'Entity', 'Service', 'System'}
+
+
+def test_promote_resolved_node_idempotent_on_identical_labels():
+    """Union of identical label sets is the same set."""
+    from graphiti_core.utils.maintenance.dedup_helpers import _promote_resolved_node
+
+    existing = EntityNode(name='Alice', group_id='g', labels=['Entity', 'Person'])
+    incoming = EntityNode(name='Alice', group_id='g', labels=['Entity', 'Person'])
+
+    result = _promote_resolved_node(incoming, existing)
+
+    assert set(result.labels) == {'Entity', 'Person'}
+
+
+def test_create_entity_nodes_freeform_multi_label():
+    """Multi-label entity_types list must produce a node with all labels plus Entity."""
+    from graphiti_core.nodes import EpisodeType, EpisodicNode
+    from graphiti_core.prompts.extract_nodes import ExtractedEntityFreeform
+    from graphiti_core.utils.datetime_utils import utc_now
+    from graphiti_core.utils.maintenance.node_operations import _create_entity_nodes_freeform
+
+    episode = EpisodicNode(
+        name='ep',
+        group_id='g',
+        source=EpisodeType.text,
+        source_description='test',
+        content='x',
+        valid_at=utc_now(),
+    )
+    entities = [ExtractedEntityFreeform(name='Vis Service', entity_types=['Service', 'Technology'])]
+
+    nodes = _create_entity_nodes_freeform(entities, excluded_entity_types=None, episode=episode)
+
+    assert len(nodes) == 1
+    assert set(nodes[0].labels) == {'Entity', 'Service', 'Technology'}
+
+
+def test_create_entity_nodes_freeform_filter_not_skip():
+    """When one label is excluded, keep the entity with remaining labels intact."""
+    from graphiti_core.nodes import EpisodeType, EpisodicNode
+    from graphiti_core.prompts.extract_nodes import ExtractedEntityFreeform
+    from graphiti_core.utils.datetime_utils import utc_now
+    from graphiti_core.utils.maintenance.node_operations import _create_entity_nodes_freeform
+
+    episode = EpisodicNode(
+        name='ep',
+        group_id='g',
+        source=EpisodeType.text,
+        source_description='test',
+        content='x',
+        valid_at=utc_now(),
+    )
+    entities = [
+        ExtractedEntityFreeform(name='Vis Service', entity_types=['Service', 'Technology']),
+        ExtractedEntityFreeform(name='Alice', entity_types=['Person']),
+    ]
+
+    nodes = _create_entity_nodes_freeform(
+        entities, excluded_entity_types=['Service', 'Person'], episode=episode
+    )
+
+    # Vis Service keeps Technology; Alice is fully excluded
+    assert len(nodes) == 1
+    assert nodes[0].name == 'Vis Service'
+    assert set(nodes[0].labels) == {'Entity', 'Technology'}


### PR DESCRIPTION
## Summary

Adopt a multi-label entity model where every entity carries a set of labels. A single LLM extraction call may propose one or more labels per entity (though one label per entity per chunk is the common case). Dedup-driven merges union the label sets rather than discarding either side. The extraction prompt is updated with a stable, closed ontology of allowed labels — proposed by the implementer — so downstream consumers can filter reliably. Existing consumers that treat `labels[0]` as a primary label continue to work.

## Problem

When the same real-world entity is extracted across multiple chunks of the same source document, the LLM extractor often assigns different labels each time:

- `Visualization Data Service` is extracted as `Service` in the chunk that introduces it as PSET's vis platform
- The same entity is extracted as `System` in the chunk listing impacted orgs
- The same entity is extracted as `Technology` in the chunk discussing SVF2 mapping

These aren't conflicting claims. They're three different valid framings, each backed by real chunk context. Collapsing to a single canonical label throws away signal that was hard-won by the LLM.

The current merge logic in `_promote_resolved_node()` (`dedup_helpers.py:173-192`) makes this worse: it only promotes a generic `Entity` label to a specific type. If the canonical node already carries any specific label, it returns early — the new label from the incoming entity is silently discarded. A 13-doc RFC corpus already shows 1234 entity-pair duplicates at threshold 0.85, the majority of which are same-name-different-label cases. Without multi-label union semantics, every additional document ingestion adds more parallel entities and `knowledge_suggest_duplicates` becomes increasingly noisy.

## Approach

### Approach

The work touches four logical areas that must change together: (1) the Pydantic schema for freeform extraction, (2) the prompt instructions that guide the LLM, (3) the two node-processing functions that read the extracted data, and (4) the dedup merge function. All four are straightforward surgical edits — no new abstractions, no new modules.

The schema change (`entity_type: str` → `entity_types: list[str]`) is the highest-risk step because every existing test mock that passes `entity_type` will be silently ignored or will cause Pydantic validation errors. That change and its corresponding test-mock update must land in a single commit so the test suite never passes through a broken state.

**Exclusion semantics (open question from research)**: Adopt **filter-not-skip** — remove excluded labels from the entity's list; keep the entity if at least one non-excluded specific label remains. This is the more useful behavior for multi-label and is clearly more intent-preserving than discarding an entity because one of its four labels happens to be on the exclusion list.

**Ontology placement (open question from research)**: Define a single module-level constant `_FREEFORM_ENTITY_ONTOLOGY` in `extract_nodes.py` (a list of `(label, description)` tuples). Reference it from both `_entity_type_classification_instructions` and `_classification_instruction_inline`. Keep `_entity_types_section` returning `''` for freeform — the ontology is embedded in the instruction text, not in a separate `<ENTITY TYPES>` block. This maintains the visual distinction between freeform and predefined-type modes and avoids introducing a new structural section whose presence would imply semantics it doesn't have.

**Proposed closed ontology** (16 labels):
| Label | Description |
|-------|-------------|
| `Person` | An individual human being |
| `Organization` | A company, institution, group, or governing body |
| `Software` | A software application, library, or framework |
| `Service` | A deployed service, platform, or SaaS product |
| `System` | An integrated technical system or infrastructure component |
| `Technology` | A protocol, standard, methodology, or technical approach |
| `Concept` | An abstract idea, principle, or theoretical framework |
| `Location` | A physical or virtual place, region, or address |
| `Event` | A dated or scheduled occurrence or incident |
| `Process` | A workflow, procedure, or repeatable operation |
| `Requirement` | A constraint, specification, or policy requirement |
| `Document` | A document, report, specification, or publication |
| `Product` | A physical or digital product or deliverable |
| `Project` | A project, initiative, or program |
| `Award` | A prize, honor, or recognition |
| `Book` | A book, novel, or long-form publication |

**`_collapse_exact_duplicate_extracted_nodes`**: Replace the "pick more specific" heuristic with label-union, consistent with `_promote_resolved_node` (after the fix) and `merge_entities`. The current heuristic was designed for single-label extraction; it is incorrect for multi-label.

**ADR**: The closed ontology constrains every future freeform extraction and every downstream consumer that filters by label. It warrants an ADR.

### New/Modified Files

| File | Change |
|------|--------|
| `graphiti_core/prompts/extract_nodes.py` | Add `_FREEFORM_ENTITY_ONTOLOGY` constant; change `entity_type: str` → `entity_types: list[str]` on `ExtractedEntityFreeform`; update `_entity_type_classification_instructions` and `_classification_instruction_inline` to reference the ontology and `entity_types` |
| `graphiti_core/utils/maintenance/node_operations.py` | Update `_create_entity_nodes_freeform` to iterate `entity_types: list[str]`, apply filter-not-skip exclusion; update `_collapse_exact_duplicate_extracted_nodes` to union labels |
| `graphiti_core/utils/maintenance/dedup_helpers.py` | Replace `_promote_resolved_node` body with full union semantics |
| `tests/utils/maintenance/test_entity_extraction.py` | Update all freeform mock responses from `entity_type: '...'` to `entity_types: ['...']` |
| `tests/utils/maintenance/test_node_operations.py` | Add merge-union test for `_promote_resolved_node`; add multi-label test for `_create_entity_nodes_freeform` |
| `README.md` | Add description of multi-label union semantics and the closed ontology |
| `adrs/NNN-freeform-entity-closed-ontology.md` | ADR for the closed ontology decision |

### Key Decisions

- **Filter-not-skip for exclusion**: When `excluded_entity_types=['Service']` and LLM returns `entity_types=['Service', 'Technology']`, emit the entity with `labels=['Technology', 'Entity']` rather than skipping it. Rationale: dropping an entity because one of its labels is excluded discards signal from all its remaining valid labels — the wrong tradeoff for multi-label.

- **Ontology embedded in instruction strings, not in `<ENTITY TYPES>` block**: The `<ENTITY TYPES>` XML block pattern is the predefined-type mode's UI; introducing it for freeform would blur the modes. The ontology appears as a formatted inline list in the instruction helpers only.

- **`_collapse_exact_duplicate_extracted_nodes` gets union semantics**: Consistent with merge semantics everywhere else. The "pick more specific" heuristic was never semantically correct — it was a pragmatic workaround for single-label extraction. Remove it entirely.

- **`ReclassifiedEntity.entity_type: str` untouched**: This is the post-hoc reclassification path, explicitly out of scope. The implementer must not touch it.

- **No changes to `graphiti.py`**: Both the edge-resolution merge (lines 1747–1749) and `merge_entities` (line 1964) already implement correct union semantics.

- **No changes to backend drivers**: Neo4j and FalkorDB both already store multi-label nodes via set operations; no backend changes needed.

### Task Checklist

- [ ] Task 1: Change `ExtractedEntityFreeform.entity_type: str` → `entity_types: list[str]` in `graphiti_core/prompts/extract_nodes.py`, and simultaneously update every freeform mock response in `tests/utils/maintenance/test_entity_extraction.py` from `{'entity_type': '...'}` to `{'entity_types': ['...']}` — these two changes must land in one commit to avoid breaking the test suite
- [ ] Task 2: Add `_FREEFORM_ENTITY_ONTOLOGY` constant to `graphiti_core/prompts/extract_nodes.py` (16-label list with descriptions), update `_entity_type_classification_instructions` and `_classification_instruction_inline` to render the ontology as a formatted list and instruct the LLM to use `entity_types` (a list, choosing from the ontology)
- [ ] Task 3: Update `_create_entity_nodes_freeform` in `graphiti_core/utils/maintenance/node_operations.py` to iterate `entity_types: list[str]`, apply `_sanitize_label` to each, implement filter-not-skip exclusion (remove excluded labels, skip entity only if all specific labels are excluded), and build `labels` from the union of all sanitized specific types plus `'Entity'`
- [ ] Task 4: Update `_collapse_exact_duplicate_extracted_nodes` in `graphiti_core/utils/maintenance/node_operations.py` to union labels from duplicate same-name nodes (replace the "pick more specific" heuristic with `existing.labels = list(set(existing.labels) | set(node.labels))`)
- [ ] Task 5: Replace `_promote_resolved_node` body in `graphiti_core/utils/maintenance/dedup_helpers.py` with full union semantics: `resolved_node.labels = list(set(resolved_node.labels) | set(extracted_node.labels))`; remove the early-return short-circuit; all three call sites (lines 247, 293, `node_operations.py:614`) are unchanged
- [ ] Task 6: Add unit test in `tests/utils/maintenance/test_node_operations.py` that constructs two `EntityNode` instances with disjoint label sets, calls `_promote_resolved_node`, and asserts the survivor carries the union of both sets; add a second unit test that constructs a multi-label `ExtractedEntityFreeform` with `entity_types=['Service', 'Technology']` and verifies `_create_entity_nodes_freeform` produces a node with both labels plus `'Entity'`
- [ ] Task 7: Update `README.md` to describe freeform entity labeling: explain multi-label union semantics (dedup merges union label sets, not overwrite), the closed ontology list with descriptions, and the `labels[0]` backward-compatible primary-label convention
- [ ] Task 8: Create `adrs/NNN-freeform-entity-closed-ontology.md` (use the next sequential number after `002` at implementation time) documenting the decision to adopt a closed 16-label ontology for freeform extraction, why the open-ended approach was replaced (label proliferation causing noisy dedup), and why the specific 16 labels were chosen

### Risks

- **Test mock update is a cliff**: If Task 1's two halves (schema change + mock update) are not committed atomically, the test suite breaks between them and CI will report a red build on the schema-change commit. Implement must do both in a single commit.
- **`_sanitize_label` must be applied per label**: The current code calls `_sanitize_label(extracted_entity.entity_type)` once. With `entity_types: list[str]`, each element needs sanitization. Missing this means unsanitized labels could bypass `validate_node_labels` for multi-word or special-character labels returned by the LLM.
- **`ReclassifiedEntity` confusion**: `extract_nodes.py` contains both `ExtractedEntityFreeform` (in scope) and `ReclassifiedEntity` (out of scope), both with `entity_type: str` fields. The implementer must change only `ExtractedEntityFreeform.entity_type` and leave `ReclassifiedEntity.entity_type` untouched.
- **Ordered label list stability**: `set()` operations produce non-deterministic ordering; the implementer should normalize using `sorted()` or a stable insertion-order deduplication (as `graphiti.py` already does with `sorted(set(...))`) so node labels are predictable in tests and logs.

---
Used 12/50 turns, 5k input / 6k output tokens.

## Verification

Implemented all 8 planned tasks: changed `ExtractedEntityFreeform.entity_type: str` to `entity_types: list[str]`, added a closed 16-label `_FREEFORM_ENTITY_ONTOLOGY` constant with updated prompt helpers, updated `_create_entity_nodes_freeform` with filter-not-skip exclusion semantics, replaced the "pick most specific" heuristic in `_collapse_exact_duplicate_extracted_nodes` with label union, and replaced the `_promote_resolved_node` short-circuit with full `sorted(set | set)` union. Updated all freeform test mocks, added 4 new unit tests covering disjoint-label union and multi-label extraction, documented the freeform ontology and union semantics in README, and created ADR 003 for the closed-ontology decision. 370 non-integration tests pass.

---

Closes #53