### PR TITLE
replay_wal_ladybug blocks the event loop — progress events can't stream during replay

### DIFF
--- a/adrs/004-wal-replay-threading-boundary.md
+++ b/adrs/004-wal-replay-threading-boundary.md
@@ -1,0 +1,117 @@
+# ADR 004: WAL Replay Threading Boundary
+
+**Status**: Accepted  
+**Date**: 2026-05-04  
+**Related**: verveguy/graphiti#48
+
+## Context
+
+`replay_wal_ladybug()` replays JSONL WAL files into a LadybugDB database.
+The body is synchronous: JSONL parsing, `BEGIN TRANSACTION`, repeated
+`conn.execute()` calls, and `COMMIT`. On production workspaces this takes
+20+ minutes.
+
+Because `replay_wal_ladybug()` is an `async def` called from an asyncio event
+loop, this synchronous work completely starves the event loop. No other
+coroutines can run, including the progress-drain loop in the calling service
+layer that streams `notifications/progress` events to clients.
+
+A partial fix (Option B) added `asyncio.sleep(0)` yields at batch boundaries
+and between WAL files. These reduced burst length but did not solve the
+problem: within a single large batch (up to ~30 seconds of CPU work), the
+event loop was still blocked.
+
+## Decision
+
+Move the synchronous replay body off the asyncio event loop using
+`asyncio.to_thread()`.
+
+A new module-level function `_sync_replay_wal_ladybug()` contains the pure
+synchronous body (JSONL parsing, `ladybug.Connection` creation, batch loop,
+binary-split retry, `conn.close()`). The public `replay_wal_ladybug()` async
+function dispatches to it via:
+
+```python
+replayed, skipped, errors = await asyncio.to_thread(
+    _sync_replay_wal_ladybug,
+    driver.db if driver is not None else None,
+    wal_files,
+    from_seq,
+    dry_run,
+    batch_size,
+)
+```
+
+The event loop is then free to schedule the progress-drain coroutine and
+stream events in real time throughout the replay.
+
+### Threading boundary: why `driver.db`, not `LadybugDriver`
+
+`LadybugDriver.__init__()` creates a `kuzu.AsyncConnection`. The internals of
+`AsyncConnection.__init__()` may capture the running asyncio event loop or
+post work onto it. Creating a `LadybugDriver` from a worker thread that is not
+the event loop thread is therefore unsafe and can cause silent failures or
+wrong-loop errors.
+
+The safe split:
+
+| What | Where |
+|------|-------|
+| `LadybugDriver(db=db)` construction | Event loop (before `asyncio.to_thread()`) |
+| `driver.db` (a `kuzu.Database` handle) | Passed into worker thread as argument |
+| `ladybug.Connection(driver.db)` creation | Worker thread (sync, for batch transactions) |
+| `driver.build_indices_and_constraints()` | Event loop (after thread completes) |
+| `driver.close()` | Event loop (in `finally`, always runs) |
+
+`ladybug.Connection` is documented as not thread-safe for concurrent access,
+but since the replay thread is the only consumer of `conn` during replay (it
+is a local variable, not shared), this is safe.
+
+### Exception propagation
+
+`asyncio.to_thread()` re-raises worker thread exceptions on the event loop
+transparently. `conn.close()` is in `_sync_replay_wal_ladybug()`'s own
+`try/finally` and always runs on the worker thread. `driver.close()` is in
+the outer async function's `finally` and always runs on the event loop, even
+if the thread raises.
+
+### Option B yields removed
+
+The `asyncio.sleep(0)` calls from Option B are removed. Running in a thread
+means the event loop is always free; cooperative yielding within the sync body
+is pointless.
+
+## Cross-repo dependency: WalProgressHandler thread-safety
+
+The `WalProgressHandler` lives in `liminis-framework`. Its `emit()` method
+calls `asyncio.Queue.put_nowait()` synchronously. Once replay runs in a worker
+thread, `logger.info()` calls inside `_sync_replay_wal_ladybug()` invoke
+`emit()` from the worker thread — which makes `put_nowait()` on an asyncio
+queue unsafe (not thread-safe from outside the event loop thread).
+
+The fix in `liminis-framework` is to capture `asyncio.get_running_loop()` at
+handler creation and replace `queue.put_nowait(item)` with
+`loop.call_soon_threadsafe(queue.put_nowait, item)` in `emit()`. This work is
+tracked in liminis-framework#142 and #148.
+
+**Impact**: After this graphiti-core PR ships, the event loop is unblocked and
+the drain coroutine can run. However, progress events will not be correctly
+delivered until `liminis-framework` is also updated. The two PRs together
+complete live streaming.
+
+## Prior art
+
+`asyncio.to_thread()` is already used in this codebase in
+`graphiti_core/llm_client/gliner2_client.py` to offload synchronous GLiNER2
+model inference. The same pattern applies here.
+
+## Consequences
+
+- The event loop is free throughout WAL replay; progress-drain coroutines and
+  other concurrent async work are no longer starved.
+- `_sync_replay_wal_ladybug()` is a module-level function (not a nested
+  closure) to keep the callable simple and testable.
+- The threading boundary (create `LadybugDriver` on the event loop; pass only
+  `driver.db` into the thread) is non-obvious and not encoded in types. This
+  ADR documents it so future contributors do not accidentally move
+  `LadybugDriver` construction into the thread.

--- a/graphiti_core/driver/ladybug_driver.py
+++ b/graphiti_core/driver/ladybug_driver.py
@@ -500,58 +500,29 @@ def _deserialize_wal_params(params: dict[str, Any]) -> dict[str, Any]:
     return converted
 
 
-async def replay_wal_ladybug(
-    wal_dir: str | Path,
-    db: str,
-    from_seq: int = 0,
-    dry_run: bool = False,
-    batch_size: int = 10000,
-) -> int:
-    """Replay WAL files into a LadybugDB database.
+def _sync_replay_wal_ladybug(
+    db_handle: Any | None,
+    wal_files: list[Path],
+    from_seq: int,
+    dry_run: bool,
+    batch_size: int,
+) -> tuple[int, int, int]:
+    """Synchronous WAL replay body — runs in a worker thread via asyncio.to_thread().
 
-    Creates a LadybugDriver WITHOUT WAL (to avoid re-logging replayed
-    mutations), reads JSONL files in filename order, and executes each
-    mutation.
+    Owns the ladybug.Connection lifecycle. Returns (replayed, skipped, errors).
 
-    Uses BEGIN TRANSACTION / COMMIT batching for ~60x speedup over
-    per-mutation implicit transactions. On batch failure, uses binary-split
-    retry to isolate the failing mutation(s) while preserving all good
-    mutations. See LadybugDB/ladybug#386.
-
-    FalkorDB-era WAL entries (produced by wal_dump.py) wrap embedding
-    parameters in `vecf32($...)` which LadybugDB does not support; those
-    wrappers are stripped in-place before execution. Pure LadybugDB-era
-    entries are unaffected.
-
-    Args:
-        wal_dir: Directory containing WAL .jsonl files.
-        db: LadybugDB database path.
-        from_seq: Skip events with seq < from_seq (for partial replay).
-        dry_run: If True, parse and validate but don't execute.
-        batch_size: Mutations per transaction commit (default 10000).
-
-    Returns:
-        Number of mutations replayed.
+    db_handle must be a kuzu.Database instance created on the event loop before
+    this function is called. See adrs/004-wal-replay-threading-boundary.md.
     """
     import real_ladybug as ladybug
 
-    wal_path = Path(wal_dir)
-    if not wal_path.is_dir():
-        raise FileNotFoundError(f'WAL directory not found: {wal_path}')
-
-    wal_files = sorted(wal_path.glob('*.jsonl'))
-    if not wal_files:
-        logger.info('No WAL files found in %s', wal_path)
-        return 0
-
-    driver: LadybugDriver | None = None
-    conn = None
+    conn: Any | None = None
     replayed = 0
     skipped = 0
     errors = 0
 
     def _replay_batch(
-        conn: ladybug.Connection,
+        conn: Any,
         mutations: list[tuple[int, str, dict]],
     ) -> tuple[int, int]:
         """Replay a batch in a single transaction with binary-split retry."""
@@ -577,10 +548,8 @@ async def replay_wal_ladybug(
             return left_r + right_r, left_e + right_e
 
     try:
-        if not dry_run:
-            # No wal_dir — we don't want to re-log replayed mutations
-            driver = LadybugDriver(db=db)
-            conn = ladybug.Connection(driver.db)
+        if not dry_run and db_handle is not None:
+            conn = ladybug.Connection(db_handle)
             # NOTE: build_indices_and_constraints is called AFTER replay,
             # not before. LadybugDB HNSW indexes block in-place vector column
             # updates via MERGE...SET, so we bulk-load data first, then
@@ -590,13 +559,6 @@ async def replay_wal_ladybug(
 
         for wal_file in wal_files:
             logger.info('Replaying %s...', wal_file.name)
-
-            # Yield between files so UI progress updates smoothly. The
-            # between-batch yield (after COMMIT) is only every ~10s of
-            # wall time in fat files, which causes UI updates to arrive
-            # in 10-second bursts. Yielding per file keeps file-progress
-            # events draining at ~100ms intervals.
-            await asyncio.sleep(0)
 
             with open(wal_file, encoding='utf-8') as f:
                 for line_num, line in enumerate(f, 1):
@@ -624,11 +586,6 @@ async def replay_wal_ladybug(
                     if dry_run:
                         logger.debug('DRY RUN seq=%d: %s', seq, cypher[:80])
                         replayed += 1
-                        # Yield periodically during dry_run too — the JSON
-                        # parse + regex work can still block the event loop
-                        # on large WALs (e.g. 900k mutations).
-                        if replayed % batch_size == 0:
-                            await asyncio.sleep(0)
                         continue
 
                     if conn is None:
@@ -646,28 +603,97 @@ async def replay_wal_ladybug(
                             replayed,
                             errors,
                         )
-                        # Yield so other coroutines (e.g. progress-drain loops
-                        # listening on logging handlers) can run.  Without
-                        # this yield, replay_wal_ladybug pegs the event loop
-                        # and any concurrent `await` (in the calling service)
-                        # is starved until the replay completes.
-                        await asyncio.sleep(0)
 
         # Flush remaining batch
         if not dry_run and conn is not None and batch:
             batch_r, batch_e = _replay_batch(conn, batch)
             replayed += batch_r
             errors += batch_e
-            await asyncio.sleep(0)
 
     finally:
         if conn is not None:
             conn.close()
+
+    return replayed, skipped, errors
+
+
+async def replay_wal_ladybug(
+    wal_dir: str | Path,
+    db: str,
+    from_seq: int = 0,
+    dry_run: bool = False,
+    batch_size: int = 10000,
+) -> int:
+    """Replay WAL files into a LadybugDB database.
+
+    Creates a LadybugDriver WITHOUT WAL (to avoid re-logging replayed
+    mutations), reads JSONL files in filename order, and executes each
+    mutation.
+
+    Uses BEGIN TRANSACTION / COMMIT batching for ~60x speedup over
+    per-mutation implicit transactions. On batch failure, uses binary-split
+    retry to isolate the failing mutation(s) while preserving all good
+    mutations. See LadybugDB/ladybug#386.
+
+    FalkorDB-era WAL entries (produced by wal_dump.py) wrap embedding
+    parameters in `vecf32($...)` which LadybugDB does not support; those
+    wrappers are stripped in-place before execution. Pure LadybugDB-era
+    entries are unaffected.
+
+    The synchronous replay body runs in a worker thread via asyncio.to_thread()
+    so the event loop remains free to schedule concurrent coroutines (e.g.
+    progress-drain loops) throughout the replay. See
+    adrs/004-wal-replay-threading-boundary.md.
+
+    Args:
+        wal_dir: Directory containing WAL .jsonl files.
+        db: LadybugDB database path.
+        from_seq: Skip events with seq < from_seq (for partial replay).
+        dry_run: If True, parse and validate but don't execute.
+        batch_size: Mutations per transaction commit (default 10000).
+
+    Returns:
+        Number of mutations replayed.
+    """
+    wal_path = Path(wal_dir)
+    if not wal_path.is_dir():
+        raise FileNotFoundError(f'WAL directory not found: {wal_path}')
+
+    wal_files = sorted(wal_path.glob('*.jsonl'))
+    if not wal_files:
+        logger.info('No WAL files found in %s', wal_path)
+        return 0
+
+    driver: LadybugDriver | None = None
+    replayed = 0
+    skipped = 0
+    errors = 0
+
+    try:
+        if not dry_run:
+            # LadybugDriver is constructed on the event loop — its __init__
+            # creates a kuzu.AsyncConnection which must not be created from a
+            # worker thread. Only driver.db (the raw kuzu.Database handle)
+            # crosses into the thread. See adrs/004-wal-replay-threading-boundary.md.
+            driver = LadybugDriver(db=db)
+
+        replayed, skipped, errors = await asyncio.to_thread(
+            _sync_replay_wal_ladybug,
+            driver.db if driver is not None else None,
+            wal_files,
+            from_seq,
+            dry_run,
+            batch_size,
+        )
+
+    finally:
         if driver is not None:
-            if not dry_run and replayed > 0:
-                logger.info('Building indices and constraints on replayed data...')
-                await driver.build_indices_and_constraints()
-            await driver.close()
+            try:
+                if not dry_run and replayed > 0:
+                    logger.info('Building indices and constraints on replayed data...')
+                    await driver.build_indices_and_constraints()
+            finally:
+                await driver.close()
 
     logger.info(
         'Replay complete: %d replayed, %d skipped (seq < %d), %d errors',

--- a/graphiti_core/driver/ladybug_driver.py
+++ b/graphiti_core/driver/ladybug_driver.py
@@ -645,6 +645,12 @@ async def replay_wal_ladybug(
     progress-drain loops) throughout the replay. See
     adrs/004-wal-replay-threading-boundary.md.
 
+    Thread-safety note: all logger.* calls inside the replay body execute from
+    the worker thread. Any logging handler that bridges into an asyncio.Queue
+    (e.g. WalProgressHandler) must use loop.call_soon_threadsafe() instead of
+    queue.put_nowait() to avoid corrupting the queue from outside the event loop
+    thread. See the cross-repo dependency section in ADR 004.
+
     Args:
         wal_dir: Directory containing WAL .jsonl files.
         db: LadybugDB database path.

--- a/tests/driver/test_wal_replay_ladybug.py
+++ b/tests/driver/test_wal_replay_ladybug.py
@@ -1,0 +1,121 @@
+"""
+Copyright 2024, Zep Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from graphiti_core.driver.ladybug_driver import replay_wal_ladybug
+
+
+def _write_wal_file(wal_dir, filename, entries):
+    """Write a JSONL WAL file with the given entries."""
+    path = wal_dir / filename
+    with open(path, 'w', encoding='utf-8') as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + '\n')
+    return path
+
+
+def _make_entry(seq):
+    return {
+        'seq': seq,
+        'ts': '2026-03-24T00:00:00Z',
+        'db': 'testdb',
+        'cypher': f'CREATE (n:Node{seq})',
+        'params': {},
+    }
+
+
+class TestReplayWalLadybug:
+    """Tests for replay_wal_ladybug() using dry_run mode (no DB dependency)."""
+
+    @pytest.mark.asyncio
+    async def test_dry_run_returns_correct_count(self, tmp_path):
+        """dry_run replay of 5 WAL entries must return exactly 5."""
+        wal_dir = tmp_path / 'wal'
+        wal_dir.mkdir()
+        _write_wal_file(
+            wal_dir,
+            '20260324_000000_abc123_0000.jsonl',
+            [_make_entry(i) for i in range(5)],
+        )
+
+        count = await replay_wal_ladybug(wal_dir, db=':memory:', dry_run=True)
+        assert count == 5
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(30)
+    async def test_dry_run_does_not_block_event_loop(self, tmp_path):
+        """The event loop must remain schedulable while replay runs.
+
+        A concurrent coroutine that increments a counter with asyncio.sleep()
+        should advance during replay — not be starved until replay completes.
+        """
+        wal_dir = tmp_path / 'wal'
+        wal_dir.mkdir()
+        _write_wal_file(
+            wal_dir,
+            '20260324_000000_abc123_0000.jsonl',
+            [_make_entry(i) for i in range(50_000)],
+        )
+
+        counter = {'value': 0}
+        done = asyncio.Event()
+
+        async def increment_while_running():
+            while not done.is_set():
+                counter['value'] += 1
+                await asyncio.sleep(0.01)
+
+        task = asyncio.create_task(increment_while_running())
+        try:
+            count = await replay_wal_ladybug(wal_dir, db=':memory:', dry_run=True)
+        finally:
+            done.set()
+            await task
+
+        assert count == 50_000
+        assert counter['value'] > 0, (
+            'Counter never advanced during replay — event loop was blocked'
+        )
+
+    @pytest.mark.asyncio
+    async def test_dry_run_empty_directory_returns_zero(self, tmp_path):
+        wal_dir = tmp_path / 'wal'
+        wal_dir.mkdir()
+
+        count = await replay_wal_ladybug(wal_dir, db=':memory:', dry_run=True)
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_dry_run_respects_from_seq(self, tmp_path):
+        wal_dir = tmp_path / 'wal'
+        wal_dir.mkdir()
+        _write_wal_file(
+            wal_dir,
+            '20260324_000000_abc123_0000.jsonl',
+            [_make_entry(i) for i in range(5)],
+        )
+
+        count = await replay_wal_ladybug(wal_dir, db=':memory:', from_seq=3, dry_run=True)
+        assert count == 2  # seq 3 and 4
+
+    @pytest.mark.asyncio
+    async def test_missing_directory_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            await replay_wal_ladybug(tmp_path / 'nonexistent', db=':memory:', dry_run=True)

--- a/tests/driver/test_wal_replay_ladybug.py
+++ b/tests/driver/test_wal_replay_ladybug.py
@@ -61,10 +61,12 @@ class TestReplayWalLadybug:
     @pytest.mark.asyncio
     @pytest.mark.timeout(30)
     async def test_dry_run_does_not_block_event_loop(self, tmp_path):
-        """The event loop must remain schedulable while replay runs.
+        """The event loop must remain schedulable while replay is still running.
 
-        A concurrent coroutine that increments a counter with asyncio.sleep()
-        should advance during replay — not be starved until replay completes.
+        Replay is started as a background task. A short sleep gives replay time
+        to start but not finish. At that point the counter must have advanced
+        (proving the event loop ran concurrently) and replay must still be
+        in-progress (proving the check happened mid-replay, not post-completion).
         """
         wal_dir = tmp_path / 'wal'
         wal_dir.mkdir()
@@ -82,17 +84,25 @@ class TestReplayWalLadybug:
                 counter['value'] += 1
                 await asyncio.sleep(0.01)
 
-        task = asyncio.create_task(increment_while_running())
+        counter_task = asyncio.create_task(increment_while_running())
+        replay_task = asyncio.create_task(
+            replay_wal_ladybug(wal_dir, db=':memory:', dry_run=True)
+        )
         try:
-            count = await replay_wal_ladybug(wal_dir, db=':memory:', dry_run=True)
+            # Give replay time to start but not finish (50k JSON lines >> 50ms)
+            await asyncio.sleep(0.05)
+            assert counter['value'] > 0, (
+                'Counter never advanced while replay was in progress — event loop was blocked'
+            )
+            assert not replay_task.done(), (
+                'Replay finished in <50ms — WAL was too small to prove concurrent scheduling'
+            )
         finally:
             done.set()
-            await task
+            count = await replay_task
+            await counter_task
 
         assert count == 50_000
-        assert counter['value'] > 0, (
-            'Counter never advanced during replay — event loop was blocked'
-        )
 
     @pytest.mark.asyncio
     async def test_dry_run_empty_directory_returns_zero(self, tmp_path):


### PR DESCRIPTION
## Summary

Move the synchronous WAL replay body off the asyncio event loop using `asyncio.to_thread()`. The sync `real_ladybug.Connection` work (JSONL parsing, `BEGIN TRANSACTION`, `conn.execute()`, `COMMIT`, binary-split retry) runs in a worker thread; the event loop remains free to schedule the progress-drain coroutine and stream `notifications/progress` events in real time. The final `build_indices_and_constraints()` call (which is already async) stays on the event loop after the thread completes.

## Problem

`replay_wal_ladybug()` is an `async def` but does mostly synchronous work — blocking `conn.execute('BEGIN TRANSACTION')`, `conn.execute(cypher, ...)`, `conn.execute('COMMIT')` on a sync `real_ladybug.Connection`. The only true `await` points are `driver.build_indices_and_constraints()` at the very end.

This means the asyncio event loop is pegged for the entire replay (20+ minutes on production workspaces) and no other coroutines can run.

## Approach

### Approach

Move `replay_wal_ladybug()`'s synchronous body to a worker thread using `asyncio.to_thread()`. This leaves the asyncio event loop free to schedule the progress-drain coroutine continuously rather than only between batch commits.

The refactor has two parts:

1. **Extract `_sync_replay_wal_ladybug()`** — a new module-level pure-sync function that takes the `kuzu.Database` handle (not the `LadybugDriver`) and owns the `ladybug.Connection` lifecycle. It contains the `_replay_batch()` nested closure unchanged. It returns `(replayed, skipped, errors)`. No `asyncio.sleep(0)` calls — those are pointless in a thread.

2. **Slim down `replay_wal_ladybug()`** — the public async function now creates `LadybugDriver` on the event loop (before the thread starts), dispatches the sync body with `await asyncio.to_thread(...)`, then runs `build_indices_and_constraints()` and `driver.close()` back on the event loop.

**Threading boundary**: `LadybugDriver(db=db)` — which creates a `kuzu.AsyncConnection` — must be constructed on the event loop before the thread is spawned. Only `driver.db` (the raw `kuzu.Database` handle) crosses into the thread. `ladybug.Connection(driver.db)` is created inside the sync helper (on the worker thread). This constraint is non-obvious and warrants an ADR.

**`dry_run=True` path**: No `LadybugDriver` is created (`driver=None`), so `None` is passed as `db_handle`. The sync helper skips `conn` creation and just parses/counts.

**WalProgressHandler thread-safety**: `emit()` calls `queue.put_nowait()` from what will now be a worker thread — an unsafe operation on `asyncio.Queue`. The fix (using `loop.call_soon_threadsafe()`) lives in `liminis-framework` and is tracked in liminis-framework#142/#148. The graphiti-core PR must document this dependency. No changes to the logging interface are needed here.

**Option B yields**: All `asyncio.sleep(0)` calls in `replay_wal_ladybug()` are removed — they are replaced by the thread handoff itself.

**Exception propagation**: `asyncio.to_thread()` re-raises worker thread exceptions on the event loop. `conn.close()` is in the sync helper's own `try/finally`. `driver.close()` is in the outer async function's `finally` (always runs whether the thread raised or not). `replayed` is initialised to 0 before the thread call so the `finally` guard `if replayed > 0` is safe even on exception.

**Documentation**: No user-facing docs change. `replay_wal_ladybug()` is internal and its signature is unchanged. The ADR covers the threading decision for future contributors.

---

### New/Modified Files

| File | Change |
|------|--------|
| `graphiti_core/driver/ladybug_driver.py` | Extract `_sync_replay_wal_ladybug()` module-level sync helper; refactor `replay_wal_ladybug()` to use `asyncio.to_thread()`; remove Option B `asyncio.sleep(0)` yields |
| `tests/driver/test_wal_replay_ladybug.py` | New test file: dry-run count correctness + event-loop non-blocking assertion |
| `adrs/004-wal-replay-threading-boundary.md` | New ADR: why the sync body runs in a thread and why `LadybugDriver` must be constructed on the event loop |

---

### Key Decisions

- **`LadybugDriver` created on the event loop, not in the thread.** `LadybugDriver.__init__()` creates a `kuzu.AsyncConnection`, which may capture or require the running event loop. Creating it from a worker thread is unsafe. Only `driver.db` (a `kuzu.Database` handle) is passed into the thread. The `ladybug.Connection` for sync transactions is created inside the thread.

- **`_sync_replay_wal_ladybug()` is module-level, not a closure.** A top-level function is needed because `asyncio.to_thread()` takes a callable, and a module-level function is simpler and more testable than a lambda or closure capturing the outer scope.

- **`_replay_batch()` remains nested inside `_sync_replay_wal_ladybug()`.** It receives `conn` as an explicit parameter (not via closure), so no structural change is needed — it can stay nested for encapsulation.

- **All `asyncio.sleep(0)` yields removed from the sync helper.** They are vestigial from Option B. A function running in a worker thread does not need to yield to the event loop.

- **No change to `WalProgressHandler`.** The thread-safety fix (`loop.call_soon_threadsafe()`) is in `liminis-framework`, not this repo. The PR description documents this dependency explicitly.

- **ADR warranted** for the threading boundary (LadybugDriver on event loop; worker thread gets only `driver.db`). This constraint is non-obvious, not encoded in types, and would be easy to violate in future refactors.

---

### Task Checklist

- [ ] Task 1: Extract `_sync_replay_wal_ladybug(db_handle, wal_files, from_seq, dry_run, batch_size) -> tuple[int, int, int]` as a module-level sync function in `graphiti_core/driver/ladybug_driver.py`, containing the unchanged `_replay_batch()` nested closure, a `try/finally` that closes `conn`, and no `asyncio.sleep(0)` calls
- [ ] Task 2: Refactor `replay_wal_ladybug()` to create `LadybugDriver(db=db)` on the event loop (only when `not dry_run`), dispatch via `await asyncio.to_thread(_sync_replay_wal_ladybug, driver.db if driver else None, wal_files, from_seq, dry_run, batch_size)`, and run `build_indices_and_constraints()` + `driver.close()` on the event loop in `finally`
- [ ] Task 3: Remove all `asyncio.sleep(0)` calls from the refactored `replay_wal_ladybug()` (lines ~599, ~631, ~654, ~661 in the pre-refactor code)
- [ ] Task 4: Add `tests/driver/test_wal_replay_ladybug.py` with `TestReplayWalLadybug` class containing `test_dry_run_returns_correct_count` (synthetic WAL with 5 entries, assert return value = 5) and `test_dry_run_does_not_block_event_loop` (50,000-entry WAL, concurrent `asyncio.sleep(0.01)` counter coroutine runs alongside dry-run replay, assert counter advanced > 0)
- [ ] Task 5: Create `adrs/004-wal-replay-threading-boundary.md` documenting: (a) why `asyncio.to_thread()` rather than `asyncio.sleep(0)` yields, (b) why `LadybugDriver` must be constructed on the event loop before the thread starts, and (c) the cross-repo dependency on `liminis-framework` for `WalProgressHandler` thread-safety

---

### Risks

- **`WalProgressHandler` still unsafe after this PR ships.** Progress events from the worker thread will call `emit()` → `queue.put_nowait()` from a non-event-loop thread. Until liminis-framework is updated with `call_soon_threadsafe()`, events may be silently dropped or corrupt the queue. The event loop is unblocked by this PR; live streaming only works end-to-end once liminis-framework#142/#148 also land. Document in PR description.

- **`replayed` used in `finally` before thread completes.** Mitigated by initialising `replayed = 0` before the `asyncio.to_thread()` call. If the thread raises, `finally` runs with `replayed == 0` and skips `build_indices_and_constraints()` safely.

- **`build_indices_and_constraints()` raises inside `finally`.** If index building fails, `driver.close()` must still be called. Structure the `finally` block as a nested `try/finally` or use a flag, so `driver.close()` always executes even if `build_indices_and_constraints()` raises.

- **Non-blocking test reliability.** The `test_dry_run_does_not_block_event_loop` test depends on 50,000 JSON lines taking more than 10ms to parse. This is extremely likely on any real machine, but could theoretically fail on exotic hardware. If flakiness is observed, increase the entry count or the counter sleep interval.

---
Used 8/50 turns, 5k input / 8k output tokens.

## Verification

Refactored `replay_wal_ladybug()` to run its synchronous body (JSONL parsing, BEGIN/COMMIT batching, binary-split retry) in a worker thread via `asyncio.to_thread()`, freeing the event loop throughout replay. `LadybugDriver` is still constructed on the event loop before the thread starts (its `__init__` creates a `kuzu.AsyncConnection`); only `driver.db` crosses the threading boundary. All `asyncio.sleep(0)` Option B yields were removed. Added `tests/driver/test_wal_replay_ladybug.py` with 5 tests including a concurrent-counter test that asserts the event loop is not blocked, and `adrs/004-wal-replay-threading-boundary.md` documenting the threading boundary and the cross-repo `WalProgressHandler` dependency on `liminis-framework`.

---

Closes #48