### PR TITLE
LadybugDB driver: `unordered_map::at: key not found` mid-chunk leads to partial ingestion (and occasionally segfault)

### DIFF
--- a/adrs/005-ladybug-connection-health-probe-on-exception.md
+++ b/adrs/005-ladybug-connection-health-probe-on-exception.md
@@ -26,8 +26,17 @@ loudly is strongly preferable.
 
 ## Decision
 
-After **any** exception raised by `LadybugDriver.execute_query`, immediately
-probe the connection by executing `RETURN 1` on the same `AsyncConnection`.
+After any `Exception` raised by the underlying `self.client.execute()` call within
+`LadybugDriver.execute_query`, immediately probe the connection by executing
+`RETURN 1` on the same `AsyncConnection`.
+
+**Scope**: The probe covers the `except Exception` block that wraps
+`self.client.execute(cypher_query_, parameters=params)`. It does **not** fire for:
+- `BaseException` subclasses that are not `Exception` (e.g. `asyncio.CancelledError`)
+- Exceptions raised during result-processing after a successful execute call
+
+This scope matches the primary risk: connection corruption caused by a failed
+database-level operation surfacing through the `real_ladybug` C boundary.
 
 - If the probe succeeds: the connection is healthy. Re-raise the original
   exception unchanged. The caller can catch it, skip the chunk, and continue.
@@ -36,8 +45,8 @@ probe the connection by executing `RETURN 1` on the same `AsyncConnection`.
   `graphiti_core/errors.py`). Callers must treat the driver session as unusable
   and not issue further queries.
 
-The probe runs after **all** exceptions, not just those matching `unordered_map`
-in the message string. Reasons:
+The probe runs after **all** `Exception`-typed failures from the execute call,
+not just those matching `unordered_map` in the message string. Reasons:
 
 1. **Future-proofing**: KuzuDB C++ exception messages are internal implementation
    details and may change across versions. A string-match guard creates a

--- a/adrs/005-ladybug-connection-health-probe-on-exception.md
+++ b/adrs/005-ladybug-connection-health-probe-on-exception.md
@@ -1,0 +1,72 @@
+# ADR 005: LadybugDB Connection Health Probe on Exception
+
+**Status**: Accepted  
+**Date**: 2026-05-04  
+**Related**: verveguy/graphiti#74
+
+## Context
+
+`real_ladybug` (the PyPI package wrapping a community fork of KuzuDB) surfaces
+C++ `std::out_of_range` exceptions — such as `unordered_map::at: key not found`
+— as standard Python `RuntimeError` instances. Python cannot distinguish these
+native C++ exceptions from ordinary Python-level `RuntimeError` by type alone;
+only the exception message string identifies the origin.
+
+During large-scale ingestion (~40K+ entities), these exceptions were observed
+mid-chunk, typically correlated with HNSW vector index operations in
+`hnsw_safe_writes.py`. In four confirmed cases the caught exception was
+recoverable — the `LadybugDriver` instance remained usable and subsequent docs
+ingested successfully. In one case the error escalated to SIGSEGV, corrupting
+the database WAL file.
+
+The risk profile is asymmetric: a silently corrupted connection that is not
+detected will cause the next HNSW write to potentially SIGSEGV, killing the
+process and corrupting the database. Detecting the corruption early and failing
+loudly is strongly preferable.
+
+## Decision
+
+After **any** exception raised by `LadybugDriver.execute_query`, immediately
+probe the connection by executing `RETURN 1` on the same `AsyncConnection`.
+
+- If the probe succeeds: the connection is healthy. Re-raise the original
+  exception unchanged. The caller can catch it, skip the chunk, and continue.
+- If the probe fails: the connection is poisoned. Log at `CRITICAL` level and
+  raise `LadybugConnectionError` (a new `GraphitiError` subclass defined in
+  `graphiti_core/errors.py`). Callers must treat the driver session as unusable
+  and not issue further queries.
+
+The probe runs after **all** exceptions, not just those matching `unordered_map`
+in the message string. Reasons:
+
+1. **Future-proofing**: KuzuDB C++ exception messages are internal implementation
+   details and may change across versions. A string-match guard creates a
+   maintenance burden and would silently miss new exception variants.
+2. **Negligible overhead**: One lightweight `RETURN 1` round-trip on the error
+   path, which is already failing. The common (non-error) path has zero overhead.
+3. **Simplicity**: A single consistent policy is easier to reason about than a
+   conditional probe.
+
+The `unordered_map` substring match is retained solely for log messaging — to
+distinguish a known native C++ exception from a generic Python error in the log
+output — and does not gate the probe.
+
+## Consequences
+
+- **`LadybugConnectionError`** is raised from `execute_query` only when the
+  connection health probe itself fails. Callers that previously caught `Exception`
+  broadly will continue to work; callers that need to distinguish a poisoned
+  connection can now `except LadybugConnectionError`.
+- **SIGSEGV residual risk**: If KuzuDB's internal HNSW index state is silently
+  corrupted after a caught exception, the `RETURN 1` probe may succeed (it does
+  not exercise the HNSW path) while the next HNSW write still SIGSEGVs. The
+  probe guards against an obviously broken connection, not against silent internal
+  state corruption. This risk is documented and accepted; a deeper fix would
+  require upstream KuzuDB changes.
+- **ADR 004 threading boundary**: The health probe uses `self.client.execute()`
+  (the `AsyncConnection`), which is event-loop-bound. This is correct: the probe
+  only runs in `execute_query`, which is always called from the async path. The
+  WAL replay path uses a separate synchronous `ladybug.Connection` and is
+  unaffected.
+- **No user-facing changes**: The probe is entirely internal to the driver layer.
+  No new configuration, environment variables, or CLI flags are introduced.

--- a/graphiti_core/driver/ladybug_driver.py
+++ b/graphiti_core/driver/ladybug_driver.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import traceback
 from contextlib import nullcontext
 from datetime import datetime, timezone
 from pathlib import Path
@@ -53,6 +54,7 @@ from graphiti_core.driver.operations.saga_node_ops import SagaNodeOperations
 from graphiti_core.driver.operations.search_ops import SearchOperations
 from graphiti_core.driver.wal_replay_helpers import expand_bulk_property_set, strip_vecf32_wrappers
 from graphiti_core.embedder.client import EMBEDDING_DIM
+from graphiti_core.errors import LadybugConnectionError
 
 logger = logging.getLogger(__name__)
 
@@ -282,7 +284,26 @@ class LadybugDriver(GraphDriver):
             results = await self.client.execute(cypher_query_, parameters=params)
         except Exception as e:
             params = {k: (v[:5] if isinstance(v, list) else v) for k, v in params.items()}
-            logger.error(f'Error executing LadybugDB query: {e}\n{cypher_query_}\n{params}')
+            tb = traceback.format_exc()
+            is_cpp = 'unordered_map' in str(e) or 'key not found' in str(e)
+            origin = 'native C++ (real_ladybug)' if is_cpp else 'Python'
+            logger.error(
+                f'Error executing LadybugDB query ({origin} exception): {e}\n'
+                f'{cypher_query_}\n{params}\n{tb}'
+            )
+            # Probe the connection after any exception. If the probe itself fails,
+            # the connection is poisoned and callers must not issue further queries.
+            try:
+                probe_result = await self.client.execute('RETURN 1')
+                _close_query_result(probe_result)
+            except Exception as probe_exc:
+                logger.critical(
+                    f'LadybugDB connection health probe failed; '
+                    f'connection is poisoned: {probe_exc}'
+                )
+                raise LadybugConnectionError(
+                    f'LadybugDB connection is unhealthy after exception: {probe_exc}'
+                ) from probe_exc
             raise
 
         # Log mutation to WAL after successful execution, before checking results.

--- a/graphiti_core/driver/wal.py
+++ b/graphiti_core/driver/wal.py
@@ -288,7 +288,9 @@ class WalWriter:
             # between here and the assignment, so CancelledError cannot preempt it.
             # Using `async with self._lock` here would itself be an await point where
             # CancelledError could fire, leaving _chunk_buffer non-None and breaking
-            # the next chunk() call. This relies on CPython's single-threaded event loop.
+            # the next chunk() call. Assumes WalWriter is accessed from a single
+            # event-loop thread; calling WalWriter methods from multiple threads
+            # concurrently is not supported and would bypass this guarantee.
             self._chunk_buffer = None
             raise
         else:

--- a/graphiti_core/driver/wal.py
+++ b/graphiti_core/driver/wal.py
@@ -284,9 +284,12 @@ class WalWriter:
         try:
             yield
         except BaseException:
-            # Discard buffer on any exception (including CancelledError)
-            async with self._lock:
-                self._chunk_buffer = None
+            # No lock needed: asyncio cooperative concurrency guarantees no await
+            # between here and the assignment, so CancelledError cannot preempt it.
+            # Using `async with self._lock` here would itself be an await point where
+            # CancelledError could fire, leaving _chunk_buffer non-None and breaking
+            # the next chunk() call. This relies on CPython's single-threaded event loop.
+            self._chunk_buffer = None
             raise
         else:
             # Flush buffer to disk on clean exit

--- a/graphiti_core/errors.py
+++ b/graphiti_core/errors.py
@@ -93,3 +93,14 @@ class NodeLabelValidationError(GraphitiError, ValueError):
             f'alphanumeric characters or underscores: {label_list}'
         )
         super().__init__(self.message)
+
+
+class LadybugConnectionError(GraphitiError):
+    """Raised when the LadybugDB connection is in an unhealthy state after a native exception.
+
+    Callers should treat the driver session as poisoned and not attempt further queries.
+    """
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(self.message)

--- a/graphiti_core/errors.py
+++ b/graphiti_core/errors.py
@@ -96,9 +96,11 @@ class NodeLabelValidationError(GraphitiError, ValueError):
 
 
 class LadybugConnectionError(GraphitiError):
-    """Raised when the LadybugDB connection is in an unhealthy state after a native exception.
+    """Raised when the LadybugDB connection health probe fails after an exception in execute_query.
 
-    Callers should treat the driver session as poisoned and not attempt further queries.
+    The probe (a lightweight `RETURN 1` query) runs after any exception from the underlying
+    database call. If the probe itself fails, the connection is treated as poisoned.
+    Callers should treat the driver session as unusable and not attempt further queries.
     """
 
     def __init__(self, message: str):

--- a/tests/driver/test_close_query_result.py
+++ b/tests/driver/test_close_query_result.py
@@ -117,9 +117,8 @@ class TestNativeExceptionHandling:
             probe_result = MagicMock()
             with patch.object(
                 driver.client, 'execute', side_effect=[cpp_exc, probe_result]
-            ):
-                with pytest.raises(RuntimeError, match='unordered_map::at: key not found'):
-                    await driver.execute_query('MATCH (n) RETURN n')
+            ), pytest.raises(RuntimeError, match='unordered_map::at: key not found'):
+                await driver.execute_query('MATCH (n) RETURN n')
         finally:
             await driver.close()
 
@@ -131,9 +130,8 @@ class TestNativeExceptionHandling:
             probe_exc = RuntimeError('connection is dead')
             with patch.object(
                 driver.client, 'execute', side_effect=[cpp_exc, probe_exc]
-            ):
-                with pytest.raises(LadybugConnectionError):
-                    await driver.execute_query('MATCH (n) RETURN n')
+            ), pytest.raises(LadybugConnectionError):
+                await driver.execute_query('MATCH (n) RETURN n')
         finally:
             await driver.close()
 
@@ -145,8 +143,7 @@ class TestNativeExceptionHandling:
             probe_result = MagicMock()
             with patch.object(
                 driver.client, 'execute', side_effect=[generic_exc, probe_result]
-            ):
-                with pytest.raises(RuntimeError, match='some internal error'):
-                    await driver.execute_query('MATCH (n) RETURN n')
+            ), pytest.raises(RuntimeError, match='some internal error'):
+                await driver.execute_query('MATCH (n) RETURN n')
         finally:
             await driver.close()

--- a/tests/driver/test_close_query_result.py
+++ b/tests/driver/test_close_query_result.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from graphiti_core.driver.ladybug_driver import LadybugDriver, _close_query_result
+from graphiti_core.errors import LadybugConnectionError
 
 
 class _FakeQR:
@@ -96,5 +97,56 @@ class TestExecuteQueryClosesResult:
             with patch.object(driver.client, 'execute', return_value=[]):
                 rows, _, _ = await driver.execute_query('RETURN 1')
             assert rows == []
+        finally:
+            await driver.close()
+
+
+class TestNativeExceptionHandling:
+    """Tests for A2/A3/A4: native C++ exception interception and connection health probe.
+
+    The actual graph-size trigger (~40K+ entities) cannot be reproduced in CI without
+    the operator's WAL files. These tests exercise the exception-handling code path by
+    injecting RuntimeError at the client.execute call site.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cpp_exception_reraises_when_probe_succeeds(self) -> None:
+        driver = LadybugDriver(db=':memory:')
+        try:
+            cpp_exc = RuntimeError('unordered_map::at: key not found')
+            probe_result = MagicMock()
+            with patch.object(
+                driver.client, 'execute', side_effect=[cpp_exc, probe_result]
+            ):
+                with pytest.raises(RuntimeError, match='unordered_map::at: key not found'):
+                    await driver.execute_query('MATCH (n) RETURN n')
+        finally:
+            await driver.close()
+
+    @pytest.mark.asyncio
+    async def test_cpp_exception_raises_connection_error_when_probe_fails(self) -> None:
+        driver = LadybugDriver(db=':memory:')
+        try:
+            cpp_exc = RuntimeError('unordered_map::at: key not found')
+            probe_exc = RuntimeError('connection is dead')
+            with patch.object(
+                driver.client, 'execute', side_effect=[cpp_exc, probe_exc]
+            ):
+                with pytest.raises(LadybugConnectionError):
+                    await driver.execute_query('MATCH (n) RETURN n')
+        finally:
+            await driver.close()
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_also_probes_connection(self) -> None:
+        driver = LadybugDriver(db=':memory:')
+        try:
+            generic_exc = RuntimeError('some internal error')
+            probe_result = MagicMock()
+            with patch.object(
+                driver.client, 'execute', side_effect=[generic_exc, probe_result]
+            ):
+                with pytest.raises(RuntimeError, match='some internal error'):
+                    await driver.execute_query('MATCH (n) RETURN n')
         finally:
             await driver.close()

--- a/tests/driver/test_wal.py
+++ b/tests/driver/test_wal.py
@@ -812,3 +812,31 @@ class TestChunkBatching:
         assert cyphers0 == ['CREATE (n:Before)'], f'Non-chunk file corrupted: {cyphers0}'
         # Second file must contain all chunk mutations
         assert len(cyphers1) == 3, f'Chunk file has wrong line count: {cyphers1}'
+
+
+class TestChunkCancelledError:
+    """B2: WalWriter.chunk() must reset _chunk_buffer on CancelledError."""
+
+    @pytest.fixture
+    def wal_dir(self, tmp_path):
+        return tmp_path / 'wal'
+
+    @pytest.mark.asyncio
+    async def test_chunk_buffer_reset_on_cancelled_error(self, wal_dir):
+        writer = WalWriter(wal_dir)
+        try:
+            try:
+                async with writer.chunk():
+                    raise asyncio.CancelledError()
+            except asyncio.CancelledError:
+                pass
+
+            assert writer._chunk_buffer is None, (
+                '_chunk_buffer should be None after CancelledError'
+            )
+
+            # A subsequent chunk() call must succeed without RuntimeError
+            async with writer.chunk():
+                pass
+        finally:
+            await writer.close()


### PR DESCRIPTION
## Summary

**Failure A — `unordered_map::at` in real_ladybug internals (confirmed, hot)**: The `real_ladybug` Python package (a community fork of KuzuDB) throws a `std::out_of_range` C++ exception from an internal `unordered_map::at(key)` call. This exception is usually catchable, and the `LadybugDriver` instance remains usable after it is caught — subsequent docs ingest normally. However, at least once the error escalated to SIGSEGV, corrupting the database. The failure is graph-size-correlated, pointing to HNSW index operations on the `hnsw_safe_writes.py` DELETE→CREATE path as the most likely trigger.

**Failure B — WAL chunk state machine (low-confidence, defensive)**: `WalWriter.chunk()` has an asyncio edge case where a `CancelledError` during lock acquisition in the cleanup path could leave `_chunk_buffer` non-None, causing subsequent `chunk()` calls to raise `RuntimeError`. This has not been confirmed in production but is a real code-level concern that should be hardened.

The fix must: (1) identify which real_ladybug call site throws `unordered_map::at`, ideally by re-running ingestion against the known failing docs with full traceback capture; (2) prevent the catchable variant from ever escalating to SIGSEGV (likely by ensuring the database connection is probed/validated after catching the error); and (3) defensively harden `WalWriter.chunk()` against the asyncio cleanup race.

## Problem

During large-scale ingestion against a LadybugDB-backed graphiti instance (RFC-ADR corpus, ~760 docs), individual chunks periodically fail with a native C++ exception surfacing through the Python wrapper:

```
graphiti-service: Error ingesting chunk <doc>#chunk-<N>: unordered_map::at: key not found
```

The chunks before the failed one are committed to the graph; chunks at and after the failed one are skipped. The doc ends up partially ingested. Worse, on at least one occurrence the error escalated to a hard SIGSEGV (exit 139) of the entire service, corrupting `db.wal` and requiring move-aside-and-restart.

Five confirmed reproducible docs from the seed-orac run (revised from initial report):

| Doc (RFC-ADR pageId) | Failed chunk | Total chunks | Date |
|---|---|---|---|
| `PSET-RFC-VS-Enabling-Visualization-Service-CloudFront-Endpoint-for-Clients` | 6 | 16 | 2026-05-02 |
| `PSET-RFC-Use-operationTime-as-authoritative` | 7 | 20 | 2026-05-02 |
| `PSET-RFC-MCP-Tools-Guidance` | 22 | 63 | 2026-05-02 |
| `PSET-RFC-Remote-Access-Solutions-for-Azure-VMs` | 54 | 95 | 2026-05-02 |
| `PSET-RFC-Customer-to-AI-Agent-Chain-Logging` | 71 | 159 | 2026-05-02 |
| `PSET-RFC-Restrict-image-deployment-on-KaaR-cluster-to-autodesk-signed-images` | unknown — escalated to SIGSEGV | 40 | 2026-05-03 |

The SIGSEGV case is a distinct and more severe outcome: it killed the writer process and left `db.wal` corrupted. All other cases were catchable — the per-job error was logged, the chunk was skipped, and ingestion of the next doc proceeded normally with the same `LadybugDriver` instance (confirmed: 760 docs ingested successfully after the first such failure).

Critically, the failure is **correlated with graph size** (the first failure occurred after ~40K+ entities were in the graph), not with doc length. Docs as short as 16 chunks are affected once the graph is large enough. The failed chunks span a range of 6–71, all mid-doc. The most plausible trigger based on available evidence is the HNSW vector index operations that grow more expensive as the entity count increases.

A related symptom was initially reported but has **zero confirmed occurrences** in production logs:

```
graphiti-service: Error ingesting chunk <doc>#chunk-0: WAL: Cannot start a chunk while another chunk is already active
```

This originates in graphiti's Python-side `WalWriter.chunk()` state machine. It is not a confirmed hot bug but represents a real asyncio edge case that warrants defensive hardening.

## Approach

### Approach

The implementation has two independent tracks:

**Track A (LadybugDB driver hardening)**: Modify `execute_query` to intercept native C++ exceptions, emit a full traceback to logs, probe connection health using a lightweight `RETURN 1` query on the same `AsyncConnection`, and raise a distinct `LadybugConnectionError` if the probe itself fails. The probe runs after **any** exception (not just `unordered_map::at`), because the probe cost is negligible and future KuzuDB C++ exceptions may surface with different message strings. The `unordered_map` string match is used only to select log level — it doesn't gate the probe.

**Track B (WAL writer hardening)**: Remove the `async with self._lock:` from the `except BaseException:` cleanup path in `WalWriter.chunk()`. Set `self._chunk_buffer = None` directly, without acquiring the lock. This is safe under CPython's asyncio cooperative concurrency model because `self._chunk_buffer = None` is not an await point and cannot be interrupted by `CancelledError`. A comment documents this CPython-specific assumption.

The two tracks are independent and can be implemented in either order. Track B is simpler; Track A has more moving parts.

### New/Modified Files

| File | Change |
|------|--------|
| `graphiti_core/errors.py` | Add `LadybugConnectionError(GraphitiError)` |
| `graphiti_core/driver/ladybug_driver.py` | Rewrite `execute_query` exception handler: capture full traceback, run health probe, raise `LadybugConnectionError` on probe failure |
| `graphiti_core/driver/wal.py` | Remove lock from `except BaseException:` path; set `_chunk_buffer = None` directly with CPython comment |
| `tests/driver/test_close_query_result.py` | Add `TestNativeExceptionHandling` and `TestConnectionHealthProbe` test classes (A2/A3/A4) |
| `tests/driver/test_wal.py` | Add `TestChunkCancelledError` test class (B2) |
| `adrs/NNN-ladybug-connection-health-probe-on-exception.md` | New ADR for the "probe on any exception" policy |

### Key Decisions

- **Probe on all exceptions, not just C++ ones**: The probe overhead is one `RETURN 1` query, which is negligible. Scoping the probe to `'unordered_map' in str(e)` would miss future KuzuDB C++ exception messages and creates a maintenance burden. The broader approach is more defensively correct. (Resolves research open question 1.)

- **`LadybugConnectionError` in `errors.py`**: Callers that need to catch a poisoned-connection error should not have to import `ladybug_driver`. The error belongs in the shared exception hierarchy. (Resolves research open question 2.)

- **A4 test is mock-based**: The graph-size trigger (~40K+ entities) cannot be reproduced in CI without the operator's WAL files. A mock-based test that injects `RuntimeError('unordered_map::at: key not found')` at `client.execute` and verifies the probe runs and the original exception propagates is the correct approximation. A note in the test docstring explains what would be needed for a full regression test. (Resolves research open question 3.)

- **No lock in `WalWriter.chunk()` except path**: `self._chunk_buffer = None` is not an await point, so `CancelledError` cannot interrupt it. Removing the `async with self._lock:` from the cleanup path eliminates the bug without introducing a data race under CPython asyncio. A comment documents the CPython cooperative-concurrency assumption so future contributors understand the constraint.

- **ADR warranted**: The "probe connection health after any C++ exception" policy constrains future changes to `execute_query` (e.g., adding a fast path that skips the probe) in a non-obvious way. It also establishes precedent for how graphiti handles C++ exceptions from real_ladybug. New ADR is appropriate.

- **No documentation updates**: The research confirms no user-facing docs or external API documentation are affected. No README or config reference updates needed.

### Task Checklist

- [ ] **Task 1**: Add `LadybugConnectionError(GraphitiError)` to `graphiti_core/errors.py` — a simple subclass with a message parameter. This is the distinct exception A3 requires callers to catch when the connection is poisoned.

- [ ] **Task 2**: Rewrite the `except Exception` block in `LadybugDriver.execute_query` (`ladybug_driver.py:281–286`):
  - Capture `traceback.format_exc()` and include it in the log message (A1)
  - Log at `ERROR` level with the C++ message identified (`unordered_map` substring) vs a generic Python exception (both still log at ERROR, but the message makes the source clear)
  - After logging, run `await self.client.execute('RETURN 1')` as the health probe
  - If the probe succeeds: re-raise the original exception unchanged
  - If the probe raises: log the probe failure at CRITICAL level, raise `LadybugConnectionError` wrapping the probe exception
  - Import `traceback` and `LadybugConnectionError` at the top of the file

- [ ] **Task 3**: Add `TestNativeExceptionHandling` class to `tests/driver/test_close_query_result.py` (A2/A3/A4):
  - `test_cpp_exception_reraises_when_probe_succeeds`: patch `client.execute` to raise `RuntimeError('unordered_map::at: key not found')` on first call, return a mock result on second call (probe) — assert original `RuntimeError` propagates
  - `test_cpp_exception_raises_connection_error_when_probe_fails`: patch `client.execute` to raise on both calls — assert `LadybugConnectionError` is raised (not the original exception)
  - `test_generic_exception_also_probes_connection`: patch `client.execute` to raise `RuntimeError('some internal error')` on first call, succeed on probe — assert original exception propagates (confirms probe is not gated on C++ message)
  - All tests use `@pytest.mark.asyncio` and `LadybugDriver(db=':memory:')` per the existing pattern

- [ ] **Task 4**: Harden `WalWriter.chunk()` in `graphiti_core/driver/wal.py` (B1):
  - In the `except BaseException:` block (line 286–290), replace `async with self._lock: self._chunk_buffer = None` with a bare `self._chunk_buffer = None`
  - Add a single-line comment: `# No lock needed: asyncio cooperative concurrency guarantees no await between here and the assignment`

- [ ] **Task 5**: Add `TestChunkCancelledError` class to `tests/driver/test_wal.py` (B2):
  - `test_chunk_buffer_reset_on_cancelled_error`: create a `WalWriter(tmp_path)`, enter the chunk context, inject `asyncio.CancelledError`, catch it, assert `_chunk_buffer is None`, then assert a subsequent `chunk()` call succeeds without `RuntimeError`
  - Use `@pytest.mark.asyncio`

- [ ] **Task 6**: Create ADR for the connection-health-probe-on-exception policy in `adrs/NNN-ladybug-connection-health-probe-on-exception.md` (pick next sequential number by checking `adrs/` at implementation time):
  - Context: real_ladybug surfaces C++ `std::out_of_range` as `RuntimeError`; Python cannot distinguish by type
  - Decision: run `RETURN 1` probe on any exception from `execute_query`, not just `unordered_map::at`
  - Consequences: negligible overhead on error paths; future KuzuDB C++ exceptions are automatically probed; `LadybugConnectionError` signals a poisoned connection to callers

### Risks

- **Probe cannot prevent SIGSEGV from silent internal corruption**: If KuzuDB's internal HNSW index state is silently corrupted after a caught exception, the `RETURN 1` probe may succeed while the next HNSW write still crashes. The probe guards against an obviously broken connection, not against silent state corruption. This residual risk is acknowledged and documented in the ADR.

- **Probe adds latency on error paths**: Every exception from `execute_query` now triggers an additional database round-trip. In the common case (no exception), there is no overhead. On error paths, the additional query is acceptable — the chunk is already failing.

- **B1 comment is load-bearing documentation**: Removing the lock from the cleanup path is correct under CPython asyncio's cooperative concurrency model. If the project ever moves to true multi-threaded asyncio execution, this assumption would break. The comment must be written clearly enough that a future contributor adding threads would recognize the dependency.

- **A4 mock test cannot catch graph-size regressions**: The test validates the exception-handling code path, not the root cause. A regression at ~40K+ entities would not be caught by this test. The only way to catch such a regression in CI would be the operator's WAL files, which are not in the repository. This is documented as a known gap.

---
Used 10/50 turns, 8k input / 5k output tokens.

## Verification

All 6 plan tasks are implemented, tested, and pushed. Track A adds `LadybugConnectionError` to `errors.py`, rewrites the `execute_query` exception handler in `ladybug_driver.py` to capture full tracebacks and run a `RETURN 1` connection health probe after any exception (raising `LadybugConnectionError` if the probe fails), and covers all three behaviors with new tests in `test_close_query_result.py`. Track B removes the `async with self._lock:` from `WalWriter.chunk()`'s exception cleanup path so `CancelledError` cannot leave `_chunk_buffer` non-None, with a new `TestChunkCancelledError` test verifying the reset and successful subsequent re-entry. ADR 005 documents the "probe on all exceptions" policy and its residual SIGSEGV risk.

---

Closes #74