### PR TITLE
Pydantic validation error on `ExtractedEntitiesFreeform` from extraction LLM call

### DIFF
--- a/graphiti_core/llm_client/anthropic_client.py
+++ b/graphiti_core/llm_client/anthropic_client.py
@@ -560,7 +560,7 @@ class AnthropicClient(LLMClient):
                     if retry_count >= max_retries:
                         if isinstance(e, ValidationError):
                             logger.error(
-                                f'Validation error after {retry_count}/{max_retries} attempts: {e}'
+                                f'Validation error after {retry_count}/{max_retries} attempts: {e.errors()}'
                             )
                         else:
                             logger.error(f'Max retries ({max_retries}) exceeded. Last error: {e}')
@@ -582,8 +582,9 @@ class AnthropicClient(LLMClient):
                     # Common retry logic
                     retry_count += 1
                     messages.append(Message(role='user', content=error_context))
+                    error_detail = e.errors() if isinstance(e, ValidationError) else e
                     logger.warning(
-                        f'Retrying after error (attempt {retry_count}/{max_retries}): {e}'
+                        f'Retrying after error (attempt {retry_count}/{max_retries}): {error_detail}'
                     )
 
             # If we somehow get here, raise the last error

--- a/graphiti_core/llm_client/anthropic_client.py
+++ b/graphiti_core/llm_client/anthropic_client.py
@@ -560,7 +560,7 @@ class AnthropicClient(LLMClient):
                     if retry_count >= max_retries:
                         if isinstance(e, ValidationError):
                             logger.error(
-                                f'Validation error after {retry_count}/{max_retries} attempts: {e.errors()}'
+                                f'Validation error after {retry_count}/{max_retries} attempts: {e.errors()} | response={str(response)[:500]}'
                             )
                         else:
                             logger.error(f'Max retries ({max_retries}) exceeded. Last error: {e}')
@@ -582,7 +582,7 @@ class AnthropicClient(LLMClient):
                     # Common retry logic
                     retry_count += 1
                     messages.append(Message(role='user', content=error_context))
-                    error_detail = e.errors() if isinstance(e, ValidationError) else e
+                    error_detail = f'{e.errors()} | response={str(response)[:500]}' if isinstance(e, ValidationError) else e
                     logger.warning(
                         f'Retrying after error (attempt {retry_count}/{max_retries}): {error_detail}'
                     )

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -21,7 +21,7 @@ from collections.abc import Awaitable, Callable
 from time import time
 from typing import Any, cast
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from graphiti_core.edges import EntityEdge
 from graphiti_core.graphiti_types import GraphitiClients
@@ -192,9 +192,18 @@ async def _extract_nodes_single(
     context: dict,
 ) -> list[ExtractedEntity]:
     """Extract entities using a single LLM call with predefined entity types."""
-    llm_response = await _call_extraction_llm(llm_client, episode, context, freeform=False)
-    response_object = ExtractedEntities(**llm_response)
-    return response_object.extracted_entities
+    llm_response: dict = {}
+    try:
+        llm_response = await _call_extraction_llm(llm_client, episode, context, freeform=False)
+        response_object = ExtractedEntities(**llm_response)
+        return response_object.extracted_entities
+    except ValidationError as e:
+        logger.error(
+            f'Entity extraction validation failed: {e.errors()} | '
+            f'llm_response={str(llm_response)[:500]} | '
+            f'chunk={episode.content[:200]}'
+        )
+        return []
 
 
 async def _extract_nodes_single_freeform(
@@ -203,9 +212,18 @@ async def _extract_nodes_single_freeform(
     context: dict,
 ) -> list[ExtractedEntityFreeform]:
     """Extract entities using a single LLM call with freeform type classification."""
-    llm_response = await _call_extraction_llm(llm_client, episode, context, freeform=True)
-    response_object = ExtractedEntitiesFreeform(**llm_response)
-    return response_object.extracted_entities
+    llm_response: dict = {}
+    try:
+        llm_response = await _call_extraction_llm(llm_client, episode, context, freeform=True)
+        response_object = ExtractedEntitiesFreeform(**llm_response)
+        return response_object.extracted_entities
+    except ValidationError as e:
+        logger.error(
+            f'Entity extraction validation failed: {e.errors()} | '
+            f'llm_response={str(llm_response)[:500]} | '
+            f'chunk={episode.content[:200]}'
+        )
+        return []
 
 
 async def _call_extraction_llm(

--- a/tests/utils/maintenance/test_entity_extraction.py
+++ b/tests/utils/maintenance/test_entity_extraction.py
@@ -26,6 +26,8 @@ from graphiti_core.utils.datetime_utils import utc_now
 from graphiti_core.utils.maintenance.node_operations import (
     _build_entity_types_context,
     _extract_entity_summaries_batch,
+    _extract_nodes_single,
+    _extract_nodes_single_freeform,
     _sanitize_label,
     extract_nodes,
     reclassify_entity,
@@ -900,3 +902,57 @@ class TestReprocessEntityTypes:
         log_messages = [r.message for r in caplog.records]
         assert any('Reclassified 1/1' in msg for msg in log_messages)
         assert any('Alice' in msg for msg in log_messages)
+
+
+class TestExtractionValidationFailure:
+    """Tests for graceful degradation when LLM returns invalid structured output."""
+
+    @pytest.mark.asyncio
+    async def test_freeform_validation_failure_returns_empty_list(self, caplog, monkeypatch):
+        """When LLM returns {} (missing required field), freeform extraction returns []."""
+        import graphiti_core.utils.maintenance.node_operations as node_ops
+
+        monkeypatch.setattr(
+            node_ops, '_call_extraction_llm', AsyncMock(return_value={})
+        )
+
+        llm_client = MagicMock()
+        episode = _make_episode(
+            content='Alice talked to Bob about the project timeline and deliverables.'
+        )
+
+        with caplog.at_level(logging.ERROR):
+            result = await _extract_nodes_single_freeform(llm_client, episode, context={})
+
+        assert result == []
+
+        error_logs = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert error_logs, 'Expected at least one ERROR log entry'
+        log_text = error_logs[0].message
+        assert 'extracted_entities' in log_text
+        assert 'missing' in log_text
+
+    @pytest.mark.asyncio
+    async def test_structured_validation_failure_returns_empty_list(self, caplog, monkeypatch):
+        """When LLM returns {} (missing required field), structured extraction returns []."""
+        import graphiti_core.utils.maintenance.node_operations as node_ops
+
+        monkeypatch.setattr(
+            node_ops, '_call_extraction_llm', AsyncMock(return_value={})
+        )
+
+        llm_client = MagicMock()
+        episode = _make_episode(
+            content='Alice talked to Bob about the project timeline and deliverables.'
+        )
+
+        with caplog.at_level(logging.ERROR):
+            result = await _extract_nodes_single(llm_client, episode, context={})
+
+        assert result == []
+
+        error_logs = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert error_logs, 'Expected at least one ERROR log entry'
+        log_text = error_logs[0].message
+        assert 'extracted_entities' in log_text
+        assert 'missing' in log_text

--- a/tests/utils/maintenance/test_entity_extraction.py
+++ b/tests/utils/maintenance/test_entity_extraction.py
@@ -956,3 +956,73 @@ class TestExtractionValidationFailure:
         log_text = error_logs[0].message
         assert 'extracted_entities' in log_text
         assert 'missing' in log_text
+
+    @pytest.mark.asyncio
+    async def test_freeform_client_raises_validation_error_returns_empty_list(
+        self, caplog, monkeypatch
+    ):
+        """Production path: when LLM client raises ValidationError, freeform extraction returns []."""
+        from pydantic import ValidationError
+
+        import graphiti_core.utils.maintenance.node_operations as node_ops
+        from graphiti_core.prompts.extract_nodes import ExtractedEntitiesFreeform
+
+        try:
+            ExtractedEntitiesFreeform(**{})
+        except ValidationError as exc:
+            validation_error = exc
+
+        monkeypatch.setattr(
+            node_ops, '_call_extraction_llm', AsyncMock(side_effect=validation_error)
+        )
+
+        llm_client = MagicMock()
+        episode = _make_episode(
+            content='Alice talked to Bob about the project timeline and deliverables.'
+        )
+
+        with caplog.at_level(logging.ERROR):
+            result = await _extract_nodes_single_freeform(llm_client, episode, context={})
+
+        assert result == []
+
+        error_logs = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert error_logs, 'Expected at least one ERROR log entry'
+        log_text = error_logs[0].message
+        assert 'extracted_entities' in log_text
+        assert 'missing' in log_text
+
+    @pytest.mark.asyncio
+    async def test_structured_client_raises_validation_error_returns_empty_list(
+        self, caplog, monkeypatch
+    ):
+        """Production path: when LLM client raises ValidationError, structured extraction returns []."""
+        from pydantic import ValidationError
+
+        import graphiti_core.utils.maintenance.node_operations as node_ops
+        from graphiti_core.prompts.extract_nodes import ExtractedEntities
+
+        try:
+            ExtractedEntities(**{})
+        except ValidationError as exc:
+            validation_error = exc
+
+        monkeypatch.setattr(
+            node_ops, '_call_extraction_llm', AsyncMock(side_effect=validation_error)
+        )
+
+        llm_client = MagicMock()
+        episode = _make_episode(
+            content='Alice talked to Bob about the project timeline and deliverables.'
+        )
+
+        with caplog.at_level(logging.ERROR):
+            result = await _extract_nodes_single(llm_client, episode, context={})
+
+        assert result == []
+
+        error_logs = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert error_logs, 'Expected at least one ERROR log entry'
+        log_text = error_logs[0].message
+        assert 'extracted_entities' in log_text
+        assert 'missing' in log_text


### PR DESCRIPTION
## Summary

Two improvements: (1) when `ExtractedEntitiesFreeform` or `ExtractedEntities` validation fails, log the full Pydantic error detail — field name, received value, expected type — along with the first ~500 chars of the raw LLM response and the first ~200 chars of the chunk content; (2) when all retries are exhausted, return an empty entity list and continue rather than propagating an exception that drops the chunk.

## Problem

During chunk ingestion, the entity-extraction LLM call (Anthropic Sonnet) returned a structured response that failed Pydantic validation against `ExtractedEntitiesFreeform`. The error surfaced as:

```
graphiti-service: Error ingesting chunk <doc>#chunk-22: 1 validation error for ExtractedEntitiesFreeform
```

The doc continued processing but chunk 22 was dropped — partial ingestion. The error message was truncated: it said "1 validation error for ExtractedEntitiesFreeform" but did not indicate which field, what value was received, or what was expected. This makes the failure opaque and unactionable.

Observed in a 1015-doc RFC-ADR seed run (doc: `PSET-RFC-MCP-Tools-Guidance`, chunk 22/63, 2026-05-02). Single occurrence, so rare but real — Markdown chunks containing code blocks, tables, or dense punctuation are suspected triggers.

## Approach

### Approach

Three targeted changes across three files. The core pattern for both extraction functions is: initialize `llm_response = {}` before a try block, wrap both the `await _call_extraction_llm(...)` and the subsequent Pydantic instantiation in that block, and in the except handler log the field-level detail plus response/chunk snippets, then return `[]`. The Anthropic client change is simpler: swap `str(e)` for `e.errors()` at two log sites.

The double-validation pattern (client validates at instantiation time, `node_operations.py` re-instantiates from the returned dict) is left in place as explicitly out of scope. The try-except must cover both sites because: (a) in production, the client raises before returning; (b) in the mock test path, the client returns `{}` and `node_operations.py` raises. Both paths must reach the same handler.

No decomposition. No ADR. No documentation updates (confirmed by Research's Documentation Impact section).

### New/Modified Files

| File | Change |
|------|--------|
| `graphiti_core/llm_client/anthropic_client.py` | Replace `str(e)` with `e.errors()` at lines 563 and 586 in the ValidationError log calls |
| `graphiti_core/utils/maintenance/node_operations.py` | Add `ValidationError` to pydantic import; refactor `_extract_nodes_single` and `_extract_nodes_single_freeform` bodies with try-except, pre-initialized `llm_response`, ERROR log, and `return []` |
| `tests/utils/maintenance/test_entity_extraction.py` | Add imports for private extraction functions; add `TestExtractionValidationFailure` class covering freeform and structured paths |

### Key Decisions

- **`e.errors()` over formatted string**: Pydantic V2's `e.errors()` returns `list[ErrorDict]` with `loc`, `msg`, `type`, `input` per field — all the operator-useful detail missing from `str(e)`. No additional imports or formatting helpers are needed; passing it directly to the f-string logger produces a readable list representation.

- **`llm_response = {}` initialized before try**: Both exception sites (client-side raise vs. `node_operations.py` re-instantiation) can fire from within the same function. Pre-initializing ensures the except handler can always log `str(llm_response)[:500]` regardless of which path triggered the error. If the client raises before returning, the logged value is `{}` which is still informative (confirms no response was received).

- **try-except scope spans both `await _call_extraction_llm(...)` and `ExtractedEntities*(**llm_response)`**: Required because the two exception sites are sequential, and both must converge to the same handler. Narrowing the scope to only one site would leave the other unhandled.

- **Tests in `test_entity_extraction.py`**: This file already imports and tests private extraction helpers (`_sanitize_label`, `reclassify_entity`) and has the established `AsyncMock` / `MagicMock` patterns for `llm_client.generate_response`. Consistent with codebase conventions; `test_node_operations.py` is an alternative but less natural fit since it targets a different cluster of helpers.

- **No test added for `anthropic_client.py` R1 change**: The R1 fix is a one-line substitution at two log sites. Existing `test_validation_error_retry` covers the retry path; the final-failure log format change doesn't need its own assertion since R4 tests (which mock at the `node_operations.py` level) assert the `node_operations.py` ERROR log, not the client-level log.

- **No ADR warranted**: All changes are bug fixes (better log formatting, graceful degradation). No new patterns, no architectural decisions, no constraints on future contributors that wouldn't be obvious from reading the code.

### Task Checklist

- [ ] **Task 1 — Fix `anthropic_client.py` ValidationError log calls**: At line 563, replace `f'Validation error after {retry_count}/{max_retries} attempts: {e}'` with `f'Validation error after {retry_count}/{max_retries} attempts: {e.errors()}'`. At line 586, replace `f'Retrying after error (attempt {retry_count}/{max_retries}): {e}'` with `f'Retrying after error (attempt {retry_count}/{max_retries}): {e.errors()}'` (guard this with `isinstance(e, ValidationError)` to preserve the existing behavior for non-ValidationError exceptions at that log site).

- [ ] **Task 2 — Refactor `_extract_nodes_single` and `_extract_nodes_single_freeform` in `node_operations.py`**: Add `ValidationError` to the `from pydantic import BaseModel` line. For each function: initialize `llm_response: dict = {}` before the try block; wrap the `await _call_extraction_llm(...)` assignment and the `ExtractedEntities*(**llm_response)` instantiation in `try`; in `except ValidationError as e:` log at ERROR level with `e.errors()`, `str(llm_response)[:500]`, and `episode.content[:200]`; then `return []`.

- [ ] **Task 3 — Add R4 tests to `test_entity_extraction.py`**: Import `_extract_nodes_single` and `_extract_nodes_single_freeform` from `node_operations`. Add `TestExtractionValidationFailure` class with two async test methods: `test_freeform_validation_failure_returns_empty_list` and `test_structured_validation_failure_returns_empty_list`. Each test must: build a minimal `EpisodicNode` with non-empty `content`; mock `llm_client.generate_response` as `AsyncMock(return_value={})` (the confirmed production failure shape); call the target function; assert the return value is `[]`; use `caplog.at_level(logging.ERROR)` to assert the ERROR log record contains the field-level detail (e.g., `'extracted_entities'` and `'missing'` appear in the log text).

### Risks

- **The retry warning log at line 586 is inside a broad `except Exception` block**, so `e` is not guaranteed to be a `ValidationError` at that site. The fix for line 586 must check `isinstance(e, ValidationError)` before calling `e.errors()` to avoid `AttributeError` on other exception types. The final-failure log at line 563 is already inside `if isinstance(e, ValidationError):` so no guard needed there.

- **Test mock path vs. production path divergence**: The mock path exercises the `node_operations.py` re-instantiation site; the production path exercises the client-side raise site. Both paths must reach the same `except ValidationError` handler. The try-except scope specified in Task 2 covers both.

- **`episode.content` access**: `EpisodicNode.content` is a string field. Slicing `episode.content[:200]` on an empty string is safe. Tests must supply a non-empty `content` to confirm the snippet appears in the log.

---
Used 9/50 turns, 6k input / 4k output tokens.

## Verification

Implemented all three planned tasks for issue #76. In `anthropic_client.py`, replaced `str(e)` with `e.errors()` at both ValidationError log sites (final failure and retry warning), exposing full field-level Pydantic detail. In `node_operations.py`, wrapped both `_extract_nodes_single` and `_extract_nodes_single_freeform` in try/except `ValidationError` with pre-initialized `llm_response = {}`, ERROR-level logging of error detail + raw response snippet + chunk snippet, and graceful `return []` on failure. Added `TestExtractionValidationFailure` covering both extraction paths, verifying `[]` return and ERROR log field-level content when LLM returns `{}`. All 211 relevant tests pass; linting is clean.

---

Closes #76