### PR TITLE
Dedup performance degrades on large graphs — chunks routinely exceed 5min inactivity windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,105 @@ order. Existing code that reads `labels[0]` as a stable anchor continues to work
 > **Note:** A `suggest_duplicates → human review → merge_entities` end-to-end example will be added
 > in a future release once `suggest_duplicates` is implemented.
 
+## Performance at Scale
+
+### Deduplication latency at 50K+ entities
+
+When a single `group_id` accumulates 50 000 or more entities, the node deduplication step inside
+`add_episode` can become slow:
+
+- Each extracted entity triggers a parallel HNSW vector search **and** a BM25 full-text search
+  against all entities in the group.
+- Ambiguous candidates that aren't resolved by exact-name or MinHash/LSH matching are sent to the
+  LLM in a single batched call. At large cardinality, more candidates are ambiguous, and the LLM
+  prompt grows proportionally.
+- On LadybugDB, the HNSW `DELETE→CREATE` write pattern (required because HNSW-indexed columns
+  cannot be updated in place) adds further per-entity write cost that grows with graph size.
+
+The result is a non-linear cost curve: dedup that took ~2 s per chunk at 5K entities can exceed
+5 minutes per chunk at 80K+ entities.
+
+### DeduplicationConfig — bulk-seed mode
+
+`add_episode` accepts an optional `dedup_config` parameter that lets you trade dedup quality for
+throughput:
+
+```python
+from graphiti_core import Graphiti, DeduplicationConfig
+
+# Mode 1: skip LLM dedup entirely — MinHash/LSH deterministic matching only
+#   Fastest option for bulk ingestion where entity names are distinctive.
+#   SLO: p95 ≤ 60 s at 50K+ entities (subject to DB write latency).
+result = await graphiti.add_episode(
+    name='chunk-001',
+    episode_body=content,
+    source_description='RFC/ADR document',
+    reference_time=reference_time,
+    group_id='rfc-adr',
+    dedup_config=DeduplicationConfig(skip_llm_dedup=True),
+)
+
+# Mode 2: raise the HNSW cosine floor — fewer candidates reach the LLM
+#   Reduces prompt size and LLM latency without skipping LLM entirely.
+#   Entities with cosine similarity below the floor are not considered as candidates.
+result = await graphiti.add_episode(
+    ...
+    dedup_config=DeduplicationConfig(cosine_min_score=0.85),
+)
+
+# Mode 3: combine both — smallest candidate pool, no LLM calls
+result = await graphiti.add_episode(
+    ...
+    dedup_config=DeduplicationConfig(skip_llm_dedup=True, cosine_min_score=0.85),
+)
+```
+
+`dedupe_nodes_bulk` (used in batch-ingest paths) accepts the same parameter:
+
+```python
+from graphiti_core.utils.bulk_utils import dedupe_nodes_bulk
+from graphiti_core import DeduplicationConfig
+
+nodes_by_ep, uuid_map = await dedupe_nodes_bulk(
+    clients,
+    extracted_nodes,
+    episode_tuples,
+    dedup_config=DeduplicationConfig(skip_llm_dedup=True),
+)
+```
+
+### Trade-offs
+
+| Config | LLM calls | Candidate pool | Dedup quality |
+|--------|-----------|----------------|---------------|
+| Default (`None`) | 1 per `add_episode` | Up to 10 per node | Highest |
+| `cosine_min_score=0.85` | 1 per `add_episode` (fewer nodes) | Smaller | Misses duplicates with cosine < 0.85 |
+| `skip_llm_dedup=True` | 0 | Up to 10 per node | Deterministic only (exact + MinHash/LSH) |
+
+**When to use bulk-seed mode:** Bulk-seed mode is appropriate when:
+- Entity names in your corpus are highly distinctive (e.g., RFC/ADR titles, proper nouns).
+- You can tolerate residual duplicates and plan to run `merge_entities` for post-hoc cleanup.
+- The alternative (a stalled or timed-out ingestion) is worse than imperfect dedup.
+
+**Post-hoc cleanup:** After a bulk seed with `skip_llm_dedup=True`, use `merge_entities` or
+`merge_entities_batch` to collapse any residual duplicates that deterministic matching missed.
+See [Cleaning up duplicate entities](#cleaning-up-duplicate-entities).
+
+### Running the benchmark
+
+A benchmark integration test ships in `tests/driver/test_dedup_benchmark_int.py`. It measures
+per-chunk `add_episode` wall time against a real LadybugDB instance pre-populated with 50K+
+entities. To run it:
+
+```bash
+GRAPHITI_BENCH_LADYBUG_DB=/path/to/seeded/db \
+OPENAI_API_KEY=sk-... \
+pytest tests/driver/test_dedup_benchmark_int.py -v -s \
+    --timeout=600 -m benchmark
+```
+
+The test is **skipped by default** when `GRAPHITI_BENCH_LADYBUG_DB` is absent.
+
 ## MCP Server
 
 The `mcp_server` directory contains a Model Context Protocol (MCP) server implementation for Graphiti. This server

--- a/adrs/005-dedup-config-api.md
+++ b/adrs/005-dedup-config-api.md
@@ -1,0 +1,141 @@
+# ADR 005 — DeduplicationConfig: configurable dedup intensity for bulk-seed workloads
+
+**Date:** 2026-05-05
+**Status:** Accepted
+
+## Context
+
+At 50K–80K+ entities in a single `group_id`, individual `add_episode` calls can exceed 5 minutes
+of wall-clock time. The root cause is a non-linear cost curve in the node deduplication pipeline:
+
+1. **HNSW + BM25 query latency** grows with graph cardinality. On LadybugDB (a KuzuDB-derived
+   embedded graph), the HNSW DELETE→CREATE write pattern (required because HNSW-indexed columns
+   cannot be updated in place) adds per-entity write cost that compounds at large scale.
+2. **Candidate pool ambiguity** grows with the graph. With `NODE_DEDUP_COSINE_MIN_SCORE = 0.3`,
+   more entities fall in the 0.3–0.7 cosine range as the graph grows. These are escalated to the
+   LLM.
+3. **LLM prompt size** scales with ambiguous candidates. With 15 unresolved nodes × 10 candidates
+   each, the prompt can reach 150 candidate entries — slow to generate even with Anthropic prompt
+   caching.
+
+Research confirmed that HNSW/BM25 parallelism across extracted nodes (via `semaphore_gather`) and
+LLM batching (single call per `add_episode`) are **already implemented**. The cliff is not a missing
+optimization — it is a scaling property of the underlying database and candidate pool growth.
+
+The lever is reducing the work the dedup pipeline does per episode at large scale.
+
+### Design options considered
+
+**Option A — DeduplicationConfig dataclass:**
+A single `DeduplicationConfig(skip_llm_dedup=True, cosine_min_score=0.85)` object passed to
+`add_episode`. Callers import one type; the dataclass is extensible without signature churn.
+
+**Option B — Individual keyword arguments on `add_episode`:**
+`add_episode(..., skip_llm_dedup=True, cosine_min_score=0.85)`. Simpler to land; no new type.
+
+**Option C — Enum `dedup_mode` on `add_episode`:**
+`add_episode(..., dedup_mode=DedupMode.SKIP_LLM)`. Finite set of named modes; easier to document.
+
+### Threshold semantics: "3-bucket" vs "raise the floor"
+
+Within the `cosine_min_score` dimension, two approaches were considered:
+
+**"3-bucket"** — retrieve all candidates, then:
+  - Auto-resolve candidates with cosine > threshold as duplicates (no LLM)
+  - Auto-reject candidates with cosine < inverse threshold (no LLM)
+  - Send ambiguous candidates to LLM
+
+This requires propagating per-candidate cosine scores through
+`_semantic_candidate_search → _merge_candidate_nodes → _build_candidate_indexes`.
+The current return type is `list[EntityNode]` with no score attached. Adding scores
+would touch 5+ internal functions and change the internal data model.
+
+**"Raise the floor"** — set `cosine_min_score=0.85` to exclude low-scoring entities from the
+HNSW retrieval entirely. Fewer candidates return, fewer nodes escalate to LLM, and the LLM prompt
+shrinks. No internal restructuring is needed.
+
+## Decision
+
+**Option A (DeduplicationConfig dataclass) was chosen.**
+
+Two fields are implemented:
+- `skip_llm_dedup: bool = False` — gates the `_resolve_with_llm` call entirely
+- `cosine_min_score: float = NODE_DEDUP_COSINE_MIN_SCORE` — HNSW retrieval floor
+- `candidate_limit: int = NODE_DEDUP_CANDIDATE_LIMIT` — max candidates per node
+
+**"Raise the floor"** was chosen over "3-bucket" for `cosine_min_score`.
+
+## Rationale
+
+### Why a dataclass over individual params
+
+`add_episode` is a public API with an already-long signature. Adding two unrelated bool/float
+params (`skip_llm_dedup`, `cosine_min_score`) would make the signature harder to read and harder
+to extend. A dataclass groups the semantically related fields, gives them a discoverable import
+path (`from graphiti_core import DeduplicationConfig`), and can absorb future fields (e.g., a
+`candidate_limit` override, a `dedup_timeout` budget) without further signature changes.
+
+Option C (enum) was rejected because the two modes are orthogonal — a caller might want
+`skip_llm_dedup=True` with default cosine floor, or raised cosine floor with LLM still enabled.
+An enum would require a combinatorial explosion of named modes (`SKIP_LLM`, `HIGH_THRESHOLD`,
+`SKIP_LLM_HIGH_THRESHOLD`, etc.) or lose expressiveness.
+
+### Why "raise the floor" over "3-bucket"
+
+The "3-bucket" approach is conceptually cleaner — it would auto-resolve near-certain matches
+without LLM — but it requires:
+
+1. Changing `_semantic_candidate_search` to return `list[tuple[EntityNode, float]]` instead of
+   `list[EntityNode]`.
+2. Updating `_merge_candidate_nodes` to preserve scores through deduplication.
+3. Updating `_build_candidate_indexes` to accept and propagate scores.
+4. Adding a new resolution path in `resolve_extracted_nodes` between "similarity" and "LLM".
+
+This touches 5+ internal functions and changes the established internal data model. The "raise the
+floor" approach achieves the same practical outcome for the target corpus (RFC/ADR): by setting
+`cosine_min_score=0.85`, ambiguous low-similarity candidates are excluded from the pool, which
+both shrinks the LLM prompt and reduces the number of nodes escalated to LLM. The trade-off is
+symmetrical: entities whose true duplicate scores below 0.85 are missed entirely — but for
+corpora with distinctive entity names, this is acceptable.
+
+A future ADR may revisit "3-bucket" if the internal scoring data model is changed for other
+reasons (e.g., cross-encoder reranking of candidates).
+
+### Why the SLO is `skip_llm_dedup` only
+
+The 60-second p95 SLO (R2) is asserted by the benchmark for the `skip_llm_dedup=True` path only.
+With full LLM dedup at 80K+ entities, the SLO may not be achievable — the LadybugDB HNSW write
+overhead (DELETE→CREATE per entity) is a floor that application-level changes cannot fully address.
+The `cosine_min_score=0.85` path is benchmarked and logged but not asserted. Deeper LadybugDB-side
+fixes are tracked separately (sister issue: `unordered_map::at` errors at 80K+ entities).
+
+## Consequences
+
+### For callers
+
+- `add_episode` gains an optional `dedup_config: DeduplicationConfig | None = None` parameter.
+  Existing call sites are unaffected (default is `None`, which preserves current behavior).
+- `DeduplicationConfig` is re-exported from `graphiti_core` for a clean import path.
+- `dedupe_nodes_bulk` in `bulk_utils.py` gains the same optional parameter, enabling bulk paths
+  to be accelerated without requiring callers to thread the config through manually.
+
+### For contributors
+
+- `_semantic_candidate_search` now accepts `cosine_min_score` and `candidate_limit` as explicit
+  parameters (defaulting to the module-level constants). The constants remain as canonical defaults.
+- Future additions to dedup configuration belong in `DeduplicationConfig`, not as new keyword
+  arguments on `add_episode`.
+- The "raise the floor" semantics for `cosine_min_score` must be documented clearly: raising the
+  value **excludes** low-similarity entities from HNSW retrieval, not from LLM consideration.
+  A future contributor who assumes the threshold auto-resolves high-cosine candidates as duplicates
+  would implement incorrect behavior.
+
+### Dedup quality trade-off
+
+| Config | Dedup quality | Latency at 80K entities |
+|--------|---------------|------------------------|
+| Default (`None`) | Highest | May exceed 5 min |
+| `cosine_min_score=0.85` | Misses duplicates with cosine < 0.85 | Reduced |
+| `skip_llm_dedup=True` | Deterministic only (exact + MinHash/LSH) | p95 ≤ 60 s (target) |
+
+Post-hoc dedup cleanup is available via `merge_entities` and `merge_entities_batch`.

--- a/graphiti_core/__init__.py
+++ b/graphiti_core/__init__.py
@@ -1,3 +1,4 @@
 from .graphiti import Graphiti
+from .utils.maintenance.node_operations import DeduplicationConfig
 
-__all__ = ['Graphiti']
+__all__ = ['DeduplicationConfig', 'Graphiti']

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -102,6 +102,7 @@ from graphiti_core.utils.maintenance.graph_data_operations import (
     retrieve_episodes,
 )
 from graphiti_core.utils.maintenance.node_operations import (
+    DeduplicationConfig,
     _build_entity_types_context,
     extract_attributes_from_nodes,
     extract_nodes,
@@ -1043,6 +1044,7 @@ class Graphiti:
         custom_extraction_instructions: str | None = None,
         saga: str | SagaNode | None = None,
         saga_previous_episode_uuid: str | None = None,
+        dedup_config: DeduplicationConfig | None = None,
     ) -> AddEpisodeResults:
         """
         Process an episode and update the graph.
@@ -1090,6 +1092,25 @@ class Graphiti:
             query to find the most recent episode. Useful for efficiently adding multiple episodes
             to the same saga in sequence. The returned AddEpisodeResults.episode.uuid can be passed
             as this parameter for the next episode.
+        dedup_config : DeduplicationConfig | None
+            Optional. Configuration for node deduplication intensity. When ``None`` (default),
+            full LLM deduplication is used with standard thresholds. Provide a
+            :class:`~graphiti_core.DeduplicationConfig` to reduce LLM usage for bulk-seed
+            workloads where throughput is more important than perfect dedup quality.
+
+            Two key modes:
+
+            - ``DeduplicationConfig(skip_llm_dedup=True)`` — MinHash/LSH deterministic
+              matching only; no LLM calls during dedup. Fastest option. Residual duplicates
+              can be remediated post-hoc with ``merge_entities``.
+            - ``DeduplicationConfig(cosine_min_score=0.85)`` — Raise the HNSW retrieval
+              floor so only near-certain embedding matches are considered candidates.
+              Fewer candidates reach the LLM, reducing prompt size and latency.
+
+            **Trade-off**: Both modes may leave residual duplicates in the graph. For
+            corpora with distinctive entity names (e.g. RFC/ADR titles), this is acceptable.
+            Use ``merge_entities`` for post-hoc cleanup. See the "Performance at Scale"
+            section of the README for guidance.
 
         Returns
         -------
@@ -1182,6 +1203,7 @@ class Graphiti:
                     episode,
                     previous_episodes,
                     entity_types,
+                    dedup_config=dedup_config,
                 )
 
                 # Extract and resolve edges in parallel with attribute extraction

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -837,6 +837,7 @@ class Graphiti:
         entity_types: dict[str, type[BaseModel]] | None,
         excluded_entity_types: list[str] | None,
         custom_extraction_instructions: str | None = None,
+        dedup_config: DeduplicationConfig | None = None,
     ) -> tuple[
         dict[str, list[EntityNode]],
         dict[str, str],
@@ -856,7 +857,8 @@ class Graphiti:
 
         # Dedupe extracted nodes in memory
         nodes_by_episode, uuid_map = await dedupe_nodes_bulk(
-            self.clients, extracted_nodes_bulk, episode_context, entity_types
+            self.clients, extracted_nodes_bulk, episode_context, entity_types,
+            dedup_config=dedup_config,
         )
 
         return nodes_by_episode, uuid_map, extracted_edges_bulk
@@ -1312,6 +1314,7 @@ class Graphiti:
         edge_type_map: dict[tuple[str, str], list[str]] | None = None,
         custom_extraction_instructions: str | None = None,
         saga: str | SagaNode | None = None,
+        dedup_config: DeduplicationConfig | None = None,
     ) -> AddBulkEpisodeResults:
         """
         Process multiple episodes in bulk and update the graph.
@@ -1342,6 +1345,10 @@ class Graphiti:
             If a string is provided and a saga with this name already exists in the group, the episodes
             will be added to it. Otherwise, a new saga will be created. Sagas are connected to episodes
             via HAS_EPISODE edges, and consecutive episodes are linked via NEXT_EPISODE edges.
+        dedup_config : DeduplicationConfig | None
+            Optional. Configuration for node deduplication intensity. When ``None`` (default),
+            full LLM deduplication is used. Pass a :class:`~graphiti_core.DeduplicationConfig`
+            to reduce LLM usage for large bulk-seed workloads. See ``add_episode`` for details.
 
         Returns
         -------
@@ -1441,6 +1448,7 @@ class Graphiti:
                         entity_types,
                         excluded_entity_types,
                         custom_extraction_instructions,
+                        dedup_config=dedup_config,
                     )
 
                     # Create Episodic Edges

--- a/graphiti_core/utils/bulk_utils.py
+++ b/graphiti_core/utils/bulk_utils.py
@@ -62,6 +62,7 @@ from graphiti_core.utils.maintenance.graph_data_operations import (
     retrieve_episodes,
 )
 from graphiti_core.utils.maintenance.node_operations import (
+    DeduplicationConfig,
     extract_nodes,
     resolve_extracted_nodes,
 )
@@ -300,6 +301,7 @@ async def dedupe_nodes_bulk(
     extracted_nodes: list[list[EntityNode]],
     episode_tuples: list[tuple[EpisodicNode, list[EpisodicNode]]],
     entity_types: dict[str, type[BaseModel]] | None = None,
+    dedup_config: DeduplicationConfig | None = None,
 ) -> tuple[dict[str, list[EntityNode]], dict[str, str]]:
     """Resolve entity duplicates across an in-memory batch using a two-pass strategy.
 
@@ -308,6 +310,12 @@ async def dedupe_nodes_bulk(
     2. Re-run the deterministic similarity heuristics across the union of resolved nodes to catch
        duplicates that only co-occur inside this batch, emitting a canonical UUID map that callers
        can apply to edges and persistence.
+
+    Parameters
+    ----------
+    dedup_config:
+        Optional configuration to tune dedup intensity. See
+        :class:`~graphiti_core.utils.maintenance.node_operations.DeduplicationConfig`.
     """
 
     first_pass_results = await semaphore_gather(
@@ -318,6 +326,7 @@ async def dedupe_nodes_bulk(
                 episode_tuples[i][0],
                 episode_tuples[i][1],
                 entity_types,
+                dedup_config=dedup_config,
             )
             for i, nodes in enumerate(extracted_nodes)
         ]

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -18,6 +18,7 @@ import asyncio
 import logging
 import re
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
 from time import time
 from typing import Any, cast
 
@@ -65,6 +66,44 @@ NODE_DEDUP_CANDIDATE_LIMIT = 10
 # 0.3 floor replaces the old 0.6 (too aggressive for short names on bge-base-en-v1.5).
 # BM25 provides the recall safety net for true duplicates that fall below 0.3.
 NODE_DEDUP_COSINE_MIN_SCORE = 0.3
+
+
+@dataclass
+class DeduplicationConfig:
+    """Configuration for controlling node deduplication intensity during ingestion.
+
+    Use this to trade dedup quality for throughput when ingesting large graphs.
+
+    Attributes
+    ----------
+    skip_llm_dedup : bool
+        When True, skip the LLM deduplication step entirely. Only MinHash/LSH and
+        exact-name matching are used to identify duplicates. This is the fastest
+        option for bulk-seed workloads where entity names are distinctive.
+        Residual duplicates can be remediated post-hoc with ``merge_entities``.
+        Default: False (LLM dedup is performed as normal).
+    cosine_min_score : float
+        Minimum cosine similarity score for HNSW candidate retrieval. Raising this
+        value (e.g. from the default 0.3 to 0.85) reduces the candidate pool by
+        excluding semantically distant entities, which in turn shrinks the LLM
+        prompt and reduces API latency.
+
+        **Trade-off**: Entities whose true duplicate scores below this floor will
+        not appear as candidates and will therefore not be deduplicated. For the
+        default corpus (RFC/ADR), entity names are distinctive enough that 0.85
+        is safe; for general corpora, lower values are recommended.
+        Default: NODE_DEDUP_COSINE_MIN_SCORE (0.3).
+    candidate_limit : int
+        Maximum number of HNSW + BM25 candidates retrieved per extracted node.
+        Reducing this value (e.g. from the default 10 to 5) decreases the LLM
+        context size and API cost.
+        Default: NODE_DEDUP_CANDIDATE_LIMIT (10).
+    """
+
+    skip_llm_dedup: bool = False
+    cosine_min_score: float = field(default_factory=lambda: NODE_DEDUP_COSINE_MIN_SCORE)
+    candidate_limit: int = field(default_factory=lambda: NODE_DEDUP_CANDIDATE_LIMIT)
+
 
 NodeSummaryFilter = Callable[[EntityNode], Awaitable[bool]]
 
@@ -366,9 +405,18 @@ async def _collect_candidate_nodes(
     clients: GraphitiClients,
     extracted_nodes: list[EntityNode],
     existing_nodes_override: list[EntityNode] | None,
+    dedup_config: 'DeduplicationConfig | None' = None,
 ) -> list[list[EntityNode]]:
     """Search per extracted name and return ordered candidates for each extracted node."""
-    search_results = await _semantic_candidate_search(clients, extracted_nodes)
+    cosine_min_score = (
+        dedup_config.cosine_min_score if dedup_config is not None else NODE_DEDUP_COSINE_MIN_SCORE
+    )
+    candidate_limit = (
+        dedup_config.candidate_limit if dedup_config is not None else NODE_DEDUP_CANDIDATE_LIMIT
+    )
+    search_results = await _semantic_candidate_search(
+        clients, extracted_nodes, cosine_min_score, candidate_limit
+    )
 
     return [_merge_candidate_nodes(result, existing_nodes_override) for result in search_results]
 
@@ -387,11 +435,22 @@ def _build_dedup_search_filter(_node: EntityNode) -> SearchFilters:
 async def _semantic_candidate_search(
     clients: GraphitiClients,
     extracted_nodes: list[EntityNode],
+    cosine_min_score: float = NODE_DEDUP_COSINE_MIN_SCORE,
+    candidate_limit: int = NODE_DEDUP_CANDIDATE_LIMIT,
 ) -> list[list[EntityNode]]:
     """Run hybrid HNSW+BM25 candidate search per extracted node without label filtering.
 
     For each node, HNSW and BM25 results are fetched concurrently, merged HNSW-first,
-    deduplicated by UUID, and capped at NODE_DEDUP_CANDIDATE_LIMIT.
+    deduplicated by UUID, and capped at ``candidate_limit``.
+
+    Parameters
+    ----------
+    cosine_min_score:
+        Minimum cosine similarity for HNSW retrieval. Raising this value reduces
+        the candidate pool, which shrinks LLM prompt size at the cost of potentially
+        missing true duplicates with lower embedding similarity.
+    candidate_limit:
+        Maximum candidates returned per node (across HNSW + BM25 combined).
     """
     if not extracted_nodes:
         return []
@@ -414,15 +473,15 @@ async def _semantic_candidate_search(
                 query_vector,
                 search_filter,
                 [node.group_id],
-                NODE_DEDUP_CANDIDATE_LIMIT,
-                NODE_DEDUP_COSINE_MIN_SCORE,
+                candidate_limit,
+                cosine_min_score,
             ),
             node_fulltext_search(
                 clients.driver,
                 node.name.replace('\n', ' '),
                 search_filter,
                 [node.group_id],
-                NODE_DEDUP_CANDIDATE_LIMIT,
+                candidate_limit,
             ),
         )
         seen: set[str] = set()
@@ -431,7 +490,7 @@ async def _semantic_candidate_search(
             if result.uuid not in seen:
                 seen.add(result.uuid)
                 merged.append(result)
-                if len(merged) == NODE_DEDUP_CANDIDATE_LIMIT:
+                if len(merged) == candidate_limit:
                     break
         return merged
 
@@ -638,13 +697,24 @@ async def resolve_extracted_nodes(
     previous_episodes: list[EpisodicNode] | None = None,
     entity_types: dict[str, type[BaseModel]] | None = None,
     existing_nodes_override: list[EntityNode] | None = None,
+    dedup_config: DeduplicationConfig | None = None,
 ) -> tuple[list[EntityNode], dict[str, str], list[tuple[EntityNode, EntityNode]]]:
-    """Resolve nodes with semantic retrieval first, then deterministic and LLM dedup."""
+    """Resolve nodes with semantic retrieval first, then deterministic and LLM dedup.
+
+    Parameters
+    ----------
+    dedup_config:
+        Optional configuration to tune dedup intensity. When ``None``, defaults
+        are used (full LLM dedup, standard cosine floor 0.3, candidate limit 10).
+        Pass a :class:`DeduplicationConfig` instance to reduce LLM usage during
+        bulk ingestion. See :class:`DeduplicationConfig` for details and trade-offs.
+    """
     llm_client = clients.llm_client
     candidate_nodes_by_extracted = await _collect_candidate_nodes(
         clients,
         extracted_nodes,
         existing_nodes_override,
+        dedup_config,
     )
 
     state = DedupResolutionState(
@@ -676,7 +746,8 @@ async def resolve_extracted_nodes(
 
         state.unresolved_indices.append(idx)
 
-    if state.unresolved_indices:
+    skip_llm = dedup_config is not None and dedup_config.skip_llm_dedup
+    if state.unresolved_indices and not skip_llm:
         llm_candidate_nodes = _merge_candidate_nodes(
             [
                 candidate
@@ -693,6 +764,11 @@ async def resolve_extracted_nodes(
             episode,
             previous_episodes,
             entity_types,
+        )
+    elif state.unresolved_indices and skip_llm:
+        logger.debug(
+            'DEDUP_LLM_SKIP: skipping LLM dedup for %d unresolved nodes (skip_llm_dedup=True)',
+            len(state.unresolved_indices),
         )
 
     if not state.unresolved_indices and not any(candidate_nodes_by_extracted):

--- a/graphiti_core/utils/maintenance/node_operations.py
+++ b/graphiti_core/utils/maintenance/node_operations.py
@@ -18,7 +18,7 @@ import asyncio
 import logging
 import re
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from time import time
 from typing import Any, cast
 
@@ -101,8 +101,8 @@ class DeduplicationConfig:
     """
 
     skip_llm_dedup: bool = False
-    cosine_min_score: float = field(default_factory=lambda: NODE_DEDUP_COSINE_MIN_SCORE)
-    candidate_limit: int = field(default_factory=lambda: NODE_DEDUP_CANDIDATE_LIMIT)
+    cosine_min_score: float = NODE_DEDUP_COSINE_MIN_SCORE
+    candidate_limit: int = NODE_DEDUP_CANDIDATE_LIMIT
 
 
 NodeSummaryFilter = Callable[[EntityNode], Awaitable[bool]]
@@ -405,14 +405,14 @@ async def _collect_candidate_nodes(
     clients: GraphitiClients,
     extracted_nodes: list[EntityNode],
     existing_nodes_override: list[EntityNode] | None,
-    dedup_config: 'DeduplicationConfig | None' = None,
+    dedup_config: DeduplicationConfig | None = None,
 ) -> list[list[EntityNode]]:
     """Search per extracted name and return ordered candidates for each extracted node."""
     cosine_min_score = (
-        dedup_config.cosine_min_score if dedup_config is not None else NODE_DEDUP_COSINE_MIN_SCORE
+        dedup_config.cosine_min_score if dedup_config else NODE_DEDUP_COSINE_MIN_SCORE
     )
     candidate_limit = (
-        dedup_config.candidate_limit if dedup_config is not None else NODE_DEDUP_CANDIDATE_LIMIT
+        dedup_config.candidate_limit if dedup_config else NODE_DEDUP_CANDIDATE_LIMIT
     )
     search_results = await _semantic_candidate_search(
         clients, extracted_nodes, cosine_min_score, candidate_limit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,9 @@ build-backend = "hatchling.build"
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
+markers = [
+    "benchmark: performance benchmark test (skipped by default; requires GRAPHITI_BENCH_LADYBUG_DB)",
+]
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,9 +70,6 @@ build-backend = "hatchling.build"
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
-markers = [
-    "benchmark: performance benchmark test (skipped by default; requires GRAPHITI_BENCH_LADYBUG_DB)",
-]
 
 [tool.ruff]
 line-length = 100

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 markers =
     integration: marks tests as integration tests
+    benchmark: performance benchmark test (skipped by default; requires GRAPHITI_BENCH_LADYBUG_DB)
 asyncio_default_fixture_loop_scope = function
 asyncio_mode = auto
 timeout = 60

--- a/tests/driver/test_dedup_benchmark_int.py
+++ b/tests/driver/test_dedup_benchmark_int.py
@@ -8,21 +8,27 @@ Running the benchmark
 ---------------------
 The test is **skipped by default** unless ``GRAPHITI_BENCH_LADYBUG_DB`` is set.
 Set it to a path to a pre-seeded LadybugDB ``db/`` directory (the directory
-that contains ``graphiti.kz``)::
+that contains ``graphiti.kz``).
+
+**Important:** the pre-seeded database must already contain ≥ 50 000 entities
+under the group ID specified by ``GRAPHITI_BENCH_GROUP_ID`` (default: ``bench-group``).
+The scale check counts only entities in that group, because dedup latency is governed
+by per-group HNSW search cardinality, not total DB size. If your pre-seeded DB uses
+a different group ID (e.g. ``rfc-adr``), set ``GRAPHITI_BENCH_GROUP_ID`` to match::
 
     GRAPHITI_BENCH_LADYBUG_DB=/path/to/seeded/db \\
+    GRAPHITI_BENCH_GROUP_ID=rfc-adr \\
     OPENAI_API_KEY=sk-... \\
     pytest tests/driver/test_dedup_benchmark_int.py -v -s --timeout=600 -m benchmark
 
-The test will also skip if the configured database contains fewer than
-``BENCH_MIN_ENTITY_COUNT`` (50 000) entities — which avoids false passes on an
-under-populated fixture.
+The test will skip if the configured database contains fewer than
+``BENCH_MIN_ENTITY_COUNT`` (50 000) entities in the target group.
 
 Seeding the database
 --------------------
-If you do not have a pre-seeded database, you can create one by running the
-main graphiti ingest pipeline against a large corpus and pointing
+Run the main graphiti ingest pipeline against a large corpus and point
 ``GRAPHITI_BENCH_LADYBUG_DB`` at the resulting ``db/`` directory.
+Then set ``GRAPHITI_BENCH_GROUP_ID`` to the group_id used during ingestion.
 
 SLO
 ---
@@ -51,7 +57,7 @@ logger = logging.getLogger(__name__)
 
 BENCH_MIN_ENTITY_COUNT = 50_000
 BENCH_P95_TARGET_SECONDS = 60.0
-BENCH_GROUP_ID = 'bench-group'
+BENCH_GROUP_ID = os.environ.get('GRAPHITI_BENCH_GROUP_ID', 'bench-group')
 BENCH_NUM_CHUNKS = 50
 
 # Simulated RFC/ADR style chunks — realistic enough to extract 10–20 entities each
@@ -179,7 +185,9 @@ async def test_add_episode_latency_at_scale(tmp_path):
 
     Skips if:
     - ``GRAPHITI_BENCH_LADYBUG_DB`` is not set in the environment, OR
-    - The database contains fewer than ``BENCH_MIN_ENTITY_COUNT`` entities.
+    - The group ``GRAPHITI_BENCH_GROUP_ID`` (default: ``bench-group``) contains
+      fewer than ``BENCH_MIN_ENTITY_COUNT`` entities in that database. Set
+      ``GRAPHITI_BENCH_GROUP_ID`` to the group_id of your pre-seeded corpus.
     """
     # -- Prerequisites -------------------------------------------------------
     pytest.importorskip(
@@ -201,10 +209,14 @@ async def test_add_episode_latency_at_scale(tmp_path):
 
     driver = LadybugDriver(db=db_path)
 
-    # Count entities in the database (across all groups) to verify scale
+    # Count entities in the target group to verify scale.
+    # Dedup latency is governed by per-group HNSW cardinality, not total DB size,
+    # so we count only within BENCH_GROUP_ID to avoid false passes on a pre-seeded
+    # DB where the large corpus lives under a different group_id.
     try:
         records, _, _ = await driver.execute_query(
-            'MATCH (n:Entity) RETURN count(n) AS cnt'
+            'MATCH (n:Entity) WHERE n.group_id = $group_id RETURN count(n) AS cnt',
+            {'group_id': BENCH_GROUP_ID},
         )
         entity_count = records[0]['cnt'] if records else 0
     except Exception as exc:
@@ -213,11 +225,12 @@ async def test_add_episode_latency_at_scale(tmp_path):
 
     if entity_count < BENCH_MIN_ENTITY_COUNT:
         pytest.skip(
-            f'Database at {db_path!r} contains only {entity_count:,} entities '
-            f'(need ≥ {BENCH_MIN_ENTITY_COUNT:,}) — populate the DB first'
+            f'Group {BENCH_GROUP_ID!r} in {db_path!r} contains only {entity_count:,} entities '
+            f'(need ≥ {BENCH_MIN_ENTITY_COUNT:,}). '
+            f'Set GRAPHITI_BENCH_GROUP_ID to match your pre-seeded group, or populate the DB first.'
         )
 
-    logger.info('Benchmark: %d entities found in %s', entity_count, db_path)
+    logger.info('Benchmark: %d entities in group %r at %s', entity_count, BENCH_GROUP_ID, db_path)
 
     # -- LLM + embedder setup ------------------------------------------------
     if openai_api_key:
@@ -232,17 +245,23 @@ async def test_add_episode_latency_at_scale(tmp_path):
         from graphiti_core.llm_client.config import LLMConfig
 
         # Embedder still requires OpenAI for text-embedding-* models;
-        # if only Anthropic key is present, use a voyageai embedder if available.
+        # if only Anthropic key is present, use a VoyageAI embedder if available.
+        voyage_key = os.environ.get('VOYAGE_API_KEY', '')
+        if not voyage_key:
+            pytest.skip(
+                'Anthropic key set but VOYAGE_API_KEY is missing — '
+                'benchmark requires OPENAI_API_KEY or VOYAGE_API_KEY for embeddings'
+            )
+            return
         try:
-            voyage_key = os.environ.get('VOYAGE_API_KEY', '')
             from graphiti_core.embedder.voyage import VoyageAIEmbedder, VoyageAIEmbedderConfig
 
             embedder = VoyageAIEmbedder(config=VoyageAIEmbedderConfig(api_key=voyage_key))
             logger.info('Benchmark: using VoyageAI embedder')
         except Exception:
             pytest.skip(
-                'Anthropic key set but no embedder available '
-                '(need OPENAI_API_KEY or VOYAGE_API_KEY)'
+                'Anthropic key set but voyageai package not available '
+                '(need OPENAI_API_KEY or install voyageai)'
             )
             return
 
@@ -290,34 +309,40 @@ async def test_add_episode_latency_at_scale(tmp_path):
 
         return latencies
 
-    # Pass 1: skip_llm_dedup=True — fastest; this is the SLO-asserted path
-    skip_config = DeduplicationConfig(skip_llm_dedup=True)
-    latencies_skip = await _run_pass('skip_llm_dedup', skip_config)
+    try:
+        # Pass 1: skip_llm_dedup=True — fastest; this is the SLO-asserted path
+        skip_config = DeduplicationConfig(skip_llm_dedup=True)
+        latencies_skip = await _run_pass('skip_llm_dedup', skip_config)
 
-    p50_skip = statistics.median(latencies_skip)
-    p95_skip = statistics.quantiles(latencies_skip, n=20)[18]  # 95th percentile
-    p99_skip = max(latencies_skip)
+        p50_skip = statistics.median(latencies_skip)
+        p95_skip = statistics.quantiles(latencies_skip, n=20)[18]  # 95th percentile
+        p99_skip = max(latencies_skip)
 
-    logger.info(
-        'BENCH skip_llm_dedup=True | n=%d | p50=%.2fs | p95=%.2fs | p99=%.2fs',
-        len(latencies_skip),
-        p50_skip,
-        p95_skip,
-        p99_skip,
-    )
+        logger.info(
+            'BENCH skip_llm_dedup=True | n=%d | p50=%.2fs | p95=%.2fs | p99=%.2fs',
+            len(latencies_skip),
+            p50_skip,
+            p95_skip,
+            p99_skip,
+        )
 
-    # Pass 2: cosine_min_score=0.85 — threshold-based; logged but not asserted
-    threshold_config = DeduplicationConfig(cosine_min_score=0.85)
-    latencies_threshold = await _run_pass('cosine_min_score=0.85', threshold_config)
+        # Pass 2: cosine_min_score=0.85 — threshold-based; logged but not asserted.
+        # Note: pass 2 runs after pass 1 has already written BENCH_NUM_CHUNKS episodes
+        # into BENCH_GROUP_ID, so the graph state is slightly larger. The pass-2
+        # numbers are directionally useful but not directly comparable to pass 1.
+        threshold_config = DeduplicationConfig(cosine_min_score=0.85)
+        latencies_threshold = await _run_pass('cosine_min_score=0.85', threshold_config)
 
-    p95_threshold = statistics.quantiles(latencies_threshold, n=20)[18]
-    logger.info(
-        'BENCH cosine_min_score=0.85 | n=%d | p50=%.2fs | p95=%.2fs | p99=%.2fs',
-        len(latencies_threshold),
-        statistics.median(latencies_threshold),
-        p95_threshold,
-        max(latencies_threshold),
-    )
+        p95_threshold = statistics.quantiles(latencies_threshold, n=20)[18]
+        logger.info(
+            'BENCH cosine_min_score=0.85 | n=%d | p50=%.2fs | p95=%.2fs | p99=%.2fs',
+            len(latencies_threshold),
+            statistics.median(latencies_threshold),
+            p95_threshold,
+            max(latencies_threshold),
+        )
+    finally:
+        await graphiti.close()
 
     # -- SLO assertion (skip_llm_dedup path only) ----------------------------
     assert p95_skip <= BENCH_P95_TARGET_SECONDS, (

--- a/tests/driver/test_dedup_benchmark_int.py
+++ b/tests/driver/test_dedup_benchmark_int.py
@@ -1,0 +1,334 @@
+"""Benchmark integration test: node deduplication latency at scale with LadybugDB.
+
+This test measures ``add_episode`` wall-clock time when the graph already contains
+50 000+ entities in a single group, which is the scale at which the 70K→80K timeout
+cliff was observed in production.
+
+Running the benchmark
+---------------------
+The test is **skipped by default** unless ``GRAPHITI_BENCH_LADYBUG_DB`` is set.
+Set it to a path to a pre-seeded LadybugDB ``db/`` directory (the directory
+that contains ``graphiti.kz``)::
+
+    GRAPHITI_BENCH_LADYBUG_DB=/path/to/seeded/db \\
+    OPENAI_API_KEY=sk-... \\
+    pytest tests/driver/test_dedup_benchmark_int.py -v -s --timeout=600 -m benchmark
+
+The test will also skip if the configured database contains fewer than
+``BENCH_MIN_ENTITY_COUNT`` (50 000) entities — which avoids false passes on an
+under-populated fixture.
+
+Seeding the database
+--------------------
+If you do not have a pre-seeded database, you can create one by running the
+main graphiti ingest pipeline against a large corpus and pointing
+``GRAPHITI_BENCH_LADYBUG_DB`` at the resulting ``db/`` directory.
+
+SLO
+---
+p95 ``add_episode`` wall time ≤ 60 seconds at 50K+ entities in a single group
+(see :data:`BENCH_P95_TARGET_SECONDS`).
+
+With *full* LLM dedup (default config), this SLO may not be achievable at
+80K+ entities due to LadybugDB HNSW write overhead combined with large LLM
+prompt size. Use ``DeduplicationConfig(skip_llm_dedup=True)`` or
+``DeduplicationConfig(cosine_min_score=0.85)`` to reduce latency.
+"""
+
+import logging
+import os
+import statistics
+import time
+from datetime import datetime, timezone
+
+import pytest
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration constants
+# ---------------------------------------------------------------------------
+
+BENCH_MIN_ENTITY_COUNT = 50_000
+BENCH_P95_TARGET_SECONDS = 60.0
+BENCH_GROUP_ID = 'bench-group'
+BENCH_NUM_CHUNKS = 50
+
+# Simulated RFC/ADR style chunks — realistic enough to extract 10–20 entities each
+_BENCH_CHUNKS = [
+    """\
+RFC-ADR-{i}: Service-to-Service Authentication Design
+Status: Accepted | Authors: Platform Engineering Team | Date: 2024-0{m}-15
+
+Context: The DynamoDB Global Tables API requires mutual TLS authentication for
+cross-region replication. The AWS IAM service controls authorization. The
+Kong Gateway handles rate limiting. The Auth Service issues JWT tokens.
+
+Decision: Use OAuth2 client credentials flow via the Auth Service, with token
+caching via Redis. The API Gateway validates tokens before forwarding requests.
+The Certificate Manager handles mTLS certificate rotation.
+
+Consequences: The Token Validator must be deployed in each availability zone.
+The Redis Cache requires high availability configuration. The Load Balancer
+must support sticky sessions for WebSocket connections.
+""",
+    """\
+RFC-ADR-{i}: Data Pipeline Observability Requirements
+Status: Proposed | Authors: Data Platform Team | Date: 2024-0{m}-20
+
+Context: The Kafka Consumer Group processes events from the Event Bus. The
+ClickHouse Analytics database stores aggregated metrics. The Prometheus Metrics
+Collector scrapes all service endpoints. The Grafana Dashboard visualizes
+pipeline health. The PagerDuty integration handles alerting.
+
+Decision: Implement OpenTelemetry distributed tracing across all pipeline
+components. The Jaeger Backend stores trace data. The Tempo Service correlates
+logs and traces. The SLO Tracker enforces latency budgets.
+
+Consequences: The Data Exporter requires instrumentation updates. The Schema
+Registry must expose health endpoints. The Flink Job Cluster needs trace context
+propagation.
+""",
+    """\
+RFC-ADR-{i}: Multi-Region Failover Strategy
+Status: Accepted | Authors: Infrastructure Team | Date: 2024-0{m}-10
+
+Context: The Route53 DNS Service manages global traffic routing. The CloudFront
+Distribution handles edge caching. The S3 Bucket stores static assets with
+cross-region replication. The RDS Aurora Global Database provides multi-region
+reads. The Elastic Load Balancer distributes traffic across availability zones.
+
+Decision: Implement active-active failover using Route53 health checks and
+weighted routing policies. The Health Check Lambda monitors endpoint availability.
+The SNS Topic triggers failover notifications. The CloudWatch Alarm detects
+latency breaches.
+
+Consequences: The Terraform Module for DNS must be updated. The Runbook
+requires failover procedure documentation. The On-Call Engineer rotation needs
+regional coverage.
+""",
+    """\
+RFC-ADR-{i}: API Gateway Rate Limiting Policy
+Status: Accepted | Authors: Security Engineering Team | Date: 2024-0{m}-05
+
+Context: The Kong Gateway currently enforces no per-client rate limits. The
+Abuse Detection Service flags suspicious traffic patterns. The API Key Manager
+issues credentials to third-party developers. The Quota Service tracks usage.
+
+Decision: Implement token bucket rate limiting at the Kong Gateway level.
+The Redis Rate Limiter stores per-client counters. The Billing Service charges
+for API calls above the free tier. The Developer Portal shows usage dashboards.
+
+Consequences: The SDK Documentation must explain rate limit headers. The
+Integration Test Suite needs rate limit simulation. The Client Library must
+implement exponential backoff.
+""",
+    """\
+RFC-ADR-{i}: Search Infrastructure Migration
+Status: In Progress | Authors: Search Platform Team | Date: 2024-0{m}-25
+
+Context: The Elasticsearch Cluster currently handles all full-text search.
+The OpenSearch Service offers managed upgrades. The Vector Search Engine
+enables semantic queries. The Document Ingestion Pipeline feeds search indexes.
+
+Decision: Migrate from Elasticsearch to OpenSearch Service, adding a Vector
+Search Engine alongside for hybrid retrieval. The Index Manager handles
+schema migration. The Query Router directs queries to the appropriate engine.
+
+Consequences: The Search API must support both query types during migration.
+The Re-indexing Job requires a maintenance window. The Relevance Tuner needs
+retraining on OpenSearch query syntax.
+""",
+]
+
+
+def _make_chunk_content(chunk_index: int) -> str:
+    template = _BENCH_CHUNKS[chunk_index % len(_BENCH_CHUNKS)]
+    month = (chunk_index % 12) + 1
+    return template.format(i=1000 + chunk_index, m=f'{month:02d}')
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_env(name: str) -> str:
+    val = os.environ.get(name)
+    if not val:
+        pytest.skip(f'Environment variable {name!r} is not set — skipping benchmark')
+    return val
+
+
+# ---------------------------------------------------------------------------
+# Benchmark test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark
+@pytest.mark.timeout(600)
+@pytest.mark.asyncio
+async def test_add_episode_latency_at_scale(tmp_path):
+    """Measure add_episode wall time at 50K+ entity scale using LadybugDB.
+
+    The test asserts that p95 latency is within ``BENCH_P95_TARGET_SECONDS``
+    (60 s) for episodes using ``DeduplicationConfig(skip_llm_dedup=True)``.
+    A second pass with ``DeduplicationConfig(cosine_min_score=0.85)`` is also
+    measured and logged for comparison, but is not asserted (the SLO for full
+    dedup depends on the underlying LadybugDB HNSW performance at scale).
+
+    Skips if:
+    - ``GRAPHITI_BENCH_LADYBUG_DB`` is not set in the environment, OR
+    - The database contains fewer than ``BENCH_MIN_ENTITY_COUNT`` entities.
+    """
+    # -- Prerequisites -------------------------------------------------------
+    real_ladybug = pytest.importorskip(
+        'real_ladybug',
+        reason='real_ladybug package not installed — skipping benchmark',
+    )
+    db_path = _require_env('GRAPHITI_BENCH_LADYBUG_DB')
+    openai_api_key = os.environ.get('OPENAI_API_KEY')
+    anthropic_api_key = os.environ.get('ANTHROPIC_API_KEY')
+
+    if not openai_api_key and not anthropic_api_key:
+        pytest.skip(
+            'Neither OPENAI_API_KEY nor ANTHROPIC_API_KEY is set — '
+            'benchmark requires a real LLM client'
+        )
+
+    # -- Driver setup --------------------------------------------------------
+    from graphiti_core.driver.ladybug_driver import LadybugDriver
+
+    driver = LadybugDriver(db=db_path)
+
+    # Count entities in the database (across all groups) to verify scale
+    try:
+        records, _, _ = await driver.execute_query(
+            'MATCH (n:Entity) RETURN count(n) AS cnt'
+        )
+        entity_count = records[0]['cnt'] if records else 0
+    except Exception as exc:
+        pytest.skip(f'Could not count entities in {db_path!r}: {exc}')
+        return
+
+    if entity_count < BENCH_MIN_ENTITY_COUNT:
+        pytest.skip(
+            f'Database at {db_path!r} contains only {entity_count:,} entities '
+            f'(need ≥ {BENCH_MIN_ENTITY_COUNT:,}) — populate the DB first'
+        )
+
+    logger.info('Benchmark: %d entities found in %s', entity_count, db_path)
+
+    # -- LLM + embedder setup ------------------------------------------------
+    if openai_api_key:
+        from graphiti_core.embedder.openai import OpenAIEmbedder, OpenAIEmbedderConfig
+        from graphiti_core.llm_client import LLMConfig, OpenAIClient
+
+        llm_client = OpenAIClient(LLMConfig(api_key=openai_api_key))
+        embedder = OpenAIEmbedder(config=OpenAIEmbedderConfig(api_key=openai_api_key))
+        logger.info('Benchmark: using OpenAI LLM + embedder')
+    else:
+        from graphiti_core.llm_client.anthropic_client import AnthropicClient
+        from graphiti_core.llm_client.config import LLMConfig
+
+        # Embedder still requires OpenAI for text-embedding-* models;
+        # if only Anthropic key is present, use a voyageai embedder if available.
+        try:
+            voyage_key = os.environ.get('VOYAGE_API_KEY', '')
+            from graphiti_core.embedder.voyage import VoyageAIEmbedder, VoyageAIEmbedderConfig
+
+            embedder = VoyageAIEmbedder(config=VoyageAIEmbedderConfig(api_key=voyage_key))
+            logger.info('Benchmark: using VoyageAI embedder')
+        except Exception:
+            pytest.skip(
+                'Anthropic key set but no embedder available '
+                '(need OPENAI_API_KEY or VOYAGE_API_KEY)'
+            )
+            return
+
+        llm_client = AnthropicClient(LLMConfig(api_key=anthropic_api_key))
+        logger.info('Benchmark: using Anthropic LLM')
+
+    # -- Graphiti setup ------------------------------------------------------
+    from graphiti_core import Graphiti, DeduplicationConfig
+    from graphiti_core.nodes import EpisodeType
+
+    graphiti = Graphiti(graph_driver=driver, llm_client=llm_client, embedder=embedder)
+    await graphiti.build_indices_and_constraints()
+
+    # -- Benchmark run -------------------------------------------------------
+    async def _run_pass(
+        label: str,
+        dedup_config: DeduplicationConfig | None,
+        num_chunks: int = BENCH_NUM_CHUNKS,
+    ) -> list[float]:
+        latencies: list[float] = []
+        ref_time = datetime.now(tz=timezone.utc)
+
+        for i in range(num_chunks):
+            content = _make_chunk_content(i)
+            t0 = time.monotonic()
+            await graphiti.add_episode(
+                name=f'bench-chunk-{i:03d}',
+                episode_body=content,
+                source_description='Benchmark RFC/ADR document chunk',
+                reference_time=ref_time,
+                source=EpisodeType.text,
+                group_id=BENCH_GROUP_ID,
+                dedup_config=dedup_config,
+            )
+            elapsed = time.monotonic() - t0
+            latencies.append(elapsed)
+
+            logger.info(
+                '%s chunk %d/%d: %.2f s',
+                label,
+                i + 1,
+                num_chunks,
+                elapsed,
+            )
+
+        return latencies
+
+    # Pass 1: skip_llm_dedup=True — fastest; this is the SLO-asserted path
+    skip_config = DeduplicationConfig(skip_llm_dedup=True)
+    latencies_skip = await _run_pass('skip_llm_dedup', skip_config)
+
+    p50_skip = statistics.median(latencies_skip)
+    p95_skip = statistics.quantiles(latencies_skip, n=20)[18]  # 95th percentile
+    p99_skip = max(latencies_skip)
+
+    logger.info(
+        'BENCH skip_llm_dedup=True | n=%d | p50=%.2fs | p95=%.2fs | p99=%.2fs',
+        len(latencies_skip),
+        p50_skip,
+        p95_skip,
+        p99_skip,
+    )
+
+    # Pass 2: cosine_min_score=0.85 — threshold-based; logged but not asserted
+    threshold_config = DeduplicationConfig(cosine_min_score=0.85)
+    latencies_threshold = await _run_pass('cosine_min_score=0.85', threshold_config)
+
+    p95_threshold = statistics.quantiles(latencies_threshold, n=20)[18]
+    logger.info(
+        'BENCH cosine_min_score=0.85 | n=%d | p50=%.2fs | p95=%.2fs | p99=%.2fs',
+        len(latencies_threshold),
+        statistics.median(latencies_threshold),
+        p95_threshold,
+        max(latencies_threshold),
+    )
+
+    # -- SLO assertion (skip_llm_dedup path only) ----------------------------
+    assert p95_skip <= BENCH_P95_TARGET_SECONDS, (
+        f'SLO BREACH: skip_llm_dedup p95={p95_skip:.2f}s exceeds '
+        f'{BENCH_P95_TARGET_SECONDS}s target at {entity_count:,} entities. '
+        f'Latencies: {[f"{l:.2f}" for l in latencies_skip]}'
+    )
+
+    logger.info(
+        'BENCH PASS: skip_llm_dedup p95=%.2fs ≤ %.0fs SLO at %d entities',
+        p95_skip,
+        BENCH_P95_TARGET_SECONDS,
+        entity_count,
+    )

--- a/tests/driver/test_dedup_benchmark_int.py
+++ b/tests/driver/test_dedup_benchmark_int.py
@@ -182,7 +182,7 @@ async def test_add_episode_latency_at_scale(tmp_path):
     - The database contains fewer than ``BENCH_MIN_ENTITY_COUNT`` entities.
     """
     # -- Prerequisites -------------------------------------------------------
-    real_ladybug = pytest.importorskip(
+    pytest.importorskip(
         'real_ladybug',
         reason='real_ladybug package not installed — skipping benchmark',
     )
@@ -250,7 +250,7 @@ async def test_add_episode_latency_at_scale(tmp_path):
         logger.info('Benchmark: using Anthropic LLM')
 
     # -- Graphiti setup ------------------------------------------------------
-    from graphiti_core import Graphiti, DeduplicationConfig
+    from graphiti_core import DeduplicationConfig, Graphiti
     from graphiti_core.nodes import EpisodeType
 
     graphiti = Graphiti(graph_driver=driver, llm_client=llm_client, embedder=embedder)
@@ -323,7 +323,7 @@ async def test_add_episode_latency_at_scale(tmp_path):
     assert p95_skip <= BENCH_P95_TARGET_SECONDS, (
         f'SLO BREACH: skip_llm_dedup p95={p95_skip:.2f}s exceeds '
         f'{BENCH_P95_TARGET_SECONDS}s target at {entity_count:,} entities. '
-        f'Latencies: {[f"{l:.2f}" for l in latencies_skip]}'
+        f'Latencies: {[f"{lat:.2f}" for lat in latencies_skip]}'
     )
 
     logger.info(

--- a/tests/utils/maintenance/test_bulk_utils.py
+++ b/tests/utils/maintenance/test_bulk_utils.py
@@ -59,6 +59,7 @@ async def test_dedupe_nodes_bulk_reuses_canonical_nodes(monkeypatch):
         previous_episodes_arg,
         entity_types_arg,
         existing_nodes_override=None,
+        dedup_config=None,
     ):
         call_queue.append(existing_nodes_override)
 
@@ -146,6 +147,7 @@ async def test_dedupe_nodes_bulk_uuid_map_respects_direction(monkeypatch):
         previous_episodes_arg,
         entity_types_arg,
         existing_nodes_override=None,
+        dedup_config=None,
     ):
         if nodes_arg == [extracted_one]:
             return [canonical], {canonical.uuid: canonical.uuid}, []

--- a/tests/utils/maintenance/test_node_operations.py
+++ b/tests/utils/maintenance/test_node_operations.py
@@ -26,6 +26,7 @@ from graphiti_core.utils.maintenance.dedup_helpers import (
 )
 from graphiti_core.utils.maintenance.node_operations import (
     NODE_DEDUP_CANDIDATE_LIMIT,
+    DeduplicationConfig,
     _build_dedup_search_filter,
     _collect_candidate_nodes,
     _extract_entity_summaries_batch,
@@ -1243,3 +1244,147 @@ def test_create_entity_nodes_freeform_filter_not_skip():
     assert len(nodes) == 1
     assert nodes[0].name == 'Vis Service'
     assert set(nodes[0].labels) == {'Entity', 'Technology'}
+
+
+# ---------------------------------------------------------------------------
+# DeduplicationConfig tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_nodes_skip_llm_dedup_suppresses_llm_call(monkeypatch):
+    """With skip_llm_dedup=True, unresolved nodes are kept as-is and LLM is never called."""
+    clients, llm_generate = _make_clients()
+
+    # Provide a candidate that won't match deterministically (different name, no exact match)
+    candidate = EntityNode(name='Joseph', group_id='group', labels=['Entity'])
+    extracted = EntityNode(name='Joe', group_id='group', labels=['Entity'])
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations._semantic_candidate_search',
+        _semantic_candidates([[candidate]]),
+    )
+
+    config = DeduplicationConfig(skip_llm_dedup=True)
+    resolved, uuid_map, _ = await resolve_extracted_nodes(
+        clients,
+        [extracted],
+        episode=_make_episode(),
+        previous_episodes=[],
+        dedup_config=config,
+    )
+
+    # Node should be kept as a new entity (no LLM to resolve)
+    assert resolved[0].uuid == extracted.uuid
+    assert uuid_map[extracted.uuid] == extracted.uuid
+    llm_generate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resolve_nodes_skip_llm_dedup_still_resolves_exact_matches(monkeypatch):
+    """With skip_llm_dedup=True, deterministic exact matches are still resolved."""
+    clients, llm_generate = _make_clients()
+
+    candidate = EntityNode(name='Alice Smith', group_id='group', labels=['Entity'])
+    extracted = EntityNode(name='Alice Smith', group_id='group', labels=['Entity'])
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations._semantic_candidate_search',
+        _semantic_candidates([[candidate]]),
+    )
+
+    config = DeduplicationConfig(skip_llm_dedup=True)
+    resolved, uuid_map, _ = await resolve_extracted_nodes(
+        clients,
+        [extracted],
+        episode=_make_episode(),
+        previous_episodes=[],
+        dedup_config=config,
+    )
+
+    # Exact match should be resolved even without LLM
+    assert resolved[0].uuid == candidate.uuid
+    assert uuid_map[extracted.uuid] == candidate.uuid
+    llm_generate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_semantic_candidate_search_uses_custom_cosine_min_score(monkeypatch):
+    """_semantic_candidate_search passes cosine_min_score to node_similarity_search."""
+    captured_min_scores: list[float] = []
+
+    async def fake_similarity_search(driver, vector, search_filter, group_ids, limit, min_score):
+        captured_min_scores.append(min_score)
+        return []
+
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations.node_similarity_search',
+        fake_similarity_search,
+    )
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations.node_fulltext_search',
+        AsyncMock(return_value=[]),
+    )
+
+    clients, _ = _make_clients()
+    clients.embedder.create_batch = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+
+    extracted = EntityNode(name='Test', group_id='group', labels=['Entity'])
+    await _semantic_candidate_search(clients, [extracted], cosine_min_score=0.85)
+
+    assert len(captured_min_scores) == 1
+    assert captured_min_scores[0] == pytest.approx(0.85)
+
+
+@pytest.mark.asyncio
+async def test_semantic_candidate_search_uses_custom_candidate_limit(monkeypatch):
+    """_semantic_candidate_search caps merged results at the custom candidate_limit."""
+    hnsw_nodes = [
+        EntityNode(name=f'H{i}', group_id='group', labels=['Entity']) for i in range(10)
+    ]
+    bm25_nodes = [
+        EntityNode(name=f'B{i}', group_id='group', labels=['Entity']) for i in range(10)
+    ]
+
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations.node_similarity_search',
+        AsyncMock(return_value=hnsw_nodes),
+    )
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations.node_fulltext_search',
+        AsyncMock(return_value=bm25_nodes),
+    )
+
+    clients, _ = _make_clients()
+    clients.embedder.create_batch = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+
+    extracted = EntityNode(name='Test', group_id='group', labels=['Entity'])
+    results = await _semantic_candidate_search(clients, [extracted], candidate_limit=5)
+
+    assert len(results[0]) == 5
+
+
+@pytest.mark.asyncio
+async def test_dedup_config_defaults_behave_as_before(monkeypatch):
+    """Passing DeduplicationConfig() with defaults is identical to passing None."""
+    clients, llm_generate = _make_clients()
+
+    candidate = EntityNode(name='Joseph', group_id='group', labels=['Entity'])
+    extracted = EntityNode(name='Joe', group_id='group', labels=['Entity'])
+    monkeypatch.setattr(
+        'graphiti_core.utils.maintenance.node_operations._semantic_candidate_search',
+        _semantic_candidates([[candidate]]),
+    )
+
+    llm_generate.return_value = {'entity_resolutions': [{'id': 0, 'name': 'Joe', 'duplicate_candidate_id': -1}]}
+
+    # With explicit defaults config, LLM should still be called for ambiguous nodes
+    config = DeduplicationConfig()
+    resolved, _, _ = await resolve_extracted_nodes(
+        clients,
+        [extracted],
+        episode=_make_episode(),
+        previous_episodes=[],
+        dedup_config=config,
+    )
+
+    assert resolved[0].uuid == extracted.uuid
+    llm_generate.assert_awaited_once()


### PR DESCRIPTION
## Summary

This issue requires measurably improving deduplication throughput at large graph scale (50K+ entities in a single group), with the goal that a single `add_episode` call completes well within the downstream 300-second inactivity window. The fix may combine: tighter candidate-count limits or scoring thresholds, parallelism improvements within dedup, reduced or deferred LLM usage, and/or a configurable "bulk seed mode" that reduces or eliminates per-chunk LLM dedup.

## Problem

As a graphiti instance accumulates entities (in our case ~50K-100K entities across ~700 docs), individual chunk-ingestion calls routinely exceed 5 minutes of wall-clock time, which breaks downstream consumers with inactivity-timeout policies.

In a real-world RFC-ADR seed run, failure count scaled sharply with graph size — all entities in a **single group_id** (`rfc-adr`):

| Date range | Cumulative entities (approx) | Inactivity-timeout failures |
|---|---|---|
| 2026-04-29 (early) | <500 | 0 |
| 2026-04-30 | ~5,000 | 1 (outlier) |
| 2026-05-01 | ~30,000 | 2 |
| 2026-05-02 | ~70,000 | 4-5 |
| **2026-05-03 evening → 2026-05-04 morning** | **~80,000+** | **~145 (sustained pattern)** |

By May 3 evening, back-to-back docs were timing out — 145 of 1015 total docs (94% of all failures) hit the inactivity-timeout pattern. Ingestion pace dropped from ~10 docs/hour to effectively zero on affected docs. The cliff between ~70K and ~80K is striking: performance degraded smoothly until that point, then collapsed — suggesting O(n²) or worse behavior somewhere in the dedup path, rather than linear scaling.

The downstream consumer (tarial's `process_queue.py`) has a 300-second inactivity timeout. It counts seconds since the last progress event from the layer above graphiti (`chunk_started` / `chunk_done`). Those events are emitted only when a `graphiti.add_episode()` call completes. When a single `add_episode` call takes >300 seconds, the downstream connection is aborted and the document lands in `failed/` with:

```
No response from service for 300.0s on method 'knowledge_ingest_document' (inactivity timeout)
```

Graphiti itself is still working internally — it just isn't completing chunks fast enough to keep the consumer's connection alive.

## Approach

### Approach

The research confirmed that HNSW/BM25 parallelism and LLM batching are **already implemented** — the 70K→80K cliff is a scaling property of LadybugDB's HNSW + KuzuDB FTS queries at large cardinality, compounded by the `hnsw_safe_writes.py` DELETE→CREATE pattern that LadybugDB requires (HNSW-indexed columns can't be updated in place). Combined with a low cosine floor (0.3) causing large, ambiguous candidate pools that drive long LLM prompts, this creates a non-linear cost curve as the graph grows. There is no missing concurrency optimization to add; the lever is **reducing the work the dedup pipeline does per episode at large scale**.

The plan implements two complementary knobs via a new `DeduplicationConfig` type threaded through the dedup pipeline:

1. **`skip_llm_dedup: bool`** — skip `_resolve_with_llm` entirely; MinHash/LSH deterministic matching only. The fastest option for bulk-seed workloads where entity names are distinctive and post-hoc `merge_entities` is available.

2. **`cosine_min_score: float`** — raise the HNSW retrieval floor (default `NODE_DEDUP_COSINE_MIN_SCORE = 0.3`). Raising to 0.85 slashes the candidate pool: fewer candidates enter the merged pool, fewer nodes escalate to LLM, and the LLM prompt shrinks. Combined with `skip_llm_dedup=False`, this is the `llm_dedup_threshold` mode from the spec.

The "3-bucket" approach (auto-resolve candidates above threshold as duplicates, pass ambiguous to LLM) is **not** implemented because cosine scores are not currently carried through the candidate list — only node ordering is preserved. Carrying scores would require changing the internal return type of `_semantic_candidate_search` and all downstream merging logic. The simpler "raise the floor" approach achieves the same practical outcome for the RFC-ADR use case (fewer candidates reach the LLM) with no structural changes to the scoring plumbing.

The benchmark test targets LadybugDB (the operator's actual backend) and gates on `'GRAPHITI_BENCH_LADYBUG_DB' in os.environ` — a path to a pre-seeded LadybugDB `db/` directory. LadybugDB is embedded, so no service URI is needed; the driver is initialized as `LadybugDriver(db=os.environ['GRAPHITI_BENCH_LADYBUG_DB'])`. If that env var is absent, the test may auto-seed in `tmp_path` using synthetic data with real embeddings, which is acceptable per operator sign-off as long as the embedding distribution mimics real-corpus density to exercise genuine HNSW traversal paths.

### New/Modified Files

| File | Change |
|------|--------|
| `graphiti_core/utils/maintenance/node_operations.py` | Add `DeduplicationConfig` dataclass; add `dedup_config` param to `resolve_extracted_nodes`, `_collect_candidate_nodes`, `_semantic_candidate_search`; implement `skip_llm_dedup` and `cosine_min_score` logic |
| `graphiti_core/graphiti.py` | Add `dedup_config: DeduplicationConfig \| None = None` to `add_episode`; thread to `resolve_extracted_nodes` at line ~1179; update `_resolve_nodes_and_edges_bulk` call site (~line 893) and `add_triplet` call sites (~lines 1715, 1724) with `dedup_config=None` defaults |
| `graphiti_core/utils/bulk_utils.py` | Add optional `dedup_config: DeduplicationConfig \| None = None` to `dedupe_nodes_bulk`; thread to `resolve_extracted_nodes` at line ~313 |
| `graphiti_core/__init__.py` | Re-export `DeduplicationConfig` alongside `Graphiti` |
| `tests/utils/maintenance/test_node_operations.py` | Add unit tests for `skip_llm_dedup=True` (LLM not called) and `cosine_min_score=0.85` (candidates filtered) |
| `tests/driver/test_dedup_benchmark_int.py` | New LadybugDB-specific benchmark test (matches `test_wal_replay_ladybug.py` pattern): gate on `GRAPHITI_BENCH_LADYBUG_DB` in env (pre-seeded db path), fall back to auto-seed with real embeddings; require ≥ 50K entities; measure per-chunk `add_episode` wall time; assert p95 ≤ 60 s; `@pytest.mark.timeout(600)` |
| `adrs/NNN-dedup-config-api.md` | New ADR documenting the DeduplicationConfig design decision and threshold semantics |
| `README.md` | Add "Performance at Scale" section under bulk ingestion guidance (R5) |

### Key Decisions

- **`DeduplicationConfig` dataclass over individual params**: Grouping `skip_llm_dedup` and `cosine_min_score` into a dataclass keeps `add_episode`'s signature clean as dedup tuning evolves. Callers import one type rather than remembering two unrelated bool/float params. The alternative (individual keyword args on `add_episode`) was rejected because the spec explicitly anticipates multiple modes and future expansion (e.g., post-hoc `merge_entities` integration).

- **"Raise the floor" over "3-bucket" threshold**: The 3-bucket approach (retrieve all candidates, auto-resolve above threshold, send ambiguous to LLM) requires propagating per-candidate cosine scores through `_semantic_candidate_search` → `_merge_candidate_nodes` → `_build_candidate_indexes`. The current return type is `list[EntityNode]` with no score attached. Changing the return type would touch 5+ internal functions. The "raise the floor" approach achieves the same goal at the call site (users set `cosine_min_score=0.85`) with zero internal restructuring. The trade-off is noted in the ADR and docstring.

- **`DeduplicationConfig` placed in `node_operations.py`, re-exported from `__init__.py`**: The type lives with the code that uses it. Re-exporting from `graphiti_core` gives callers a clean `from graphiti_core import DeduplicationConfig` import path, matching the existing pattern for `Graphiti` itself.

- **Benchmark test skips silently if graph is under-populated**: Rather than failing noisily when `GRAPHITI_BENCH_LADYBUG_DB` is set but the configured LadybugDB path doesn't exist or holds an under-populated graph, the test logs a warning and skips. This avoids false-positive failures in CI where the path is configured but not seeded. The 50K-entity threshold check must query the DB count before running the benchmark.

- **Auto-seeding allowed when GRAPHITI_BENCH_LADYBUG_DB is absent**: Per operator correction, synthetic data with real embeddings is acceptable for LadybugDB's embedded backend — the test may auto-seed 50K synthetic entities in `tmp_path` when no pre-seeded db is provided. The embeddings must be drawn from a real embedding model (not random) so HNSW traversal follows genuine ANN paths.

- **Benchmark placed in `tests/driver/`**: Driver-specific tests (LadybugDB backend behavior) belong in `tests/driver/`, matching the existing `test_wal_replay_ladybug.py` pattern. The benchmark exercises LadybugDB HNSW scaling characteristics, not general graphiti logic.

- **All 4 call sites of `resolve_extracted_nodes` updated**: `add_episode` (primary path), `_resolve_nodes_and_edges_bulk`, and `add_triplet` (×2) all pass `dedup_config=None` by default, preserving existing behavior. `dedupe_nodes_bulk` in `bulk_utils.py` gets its own `dedup_config` parameter so the bulk path can also be accelerated.

- **ADR warranted**: The `DeduplicationConfig` design introduces a new public type, a non-obvious "raise the floor" threshold semantics decision, and constraints future contributors who might assume the threshold auto-resolves high-cosine candidates as duplicates. It warrants an ADR.

### Task Checklist

- [ ] **Task 1**: Define `DeduplicationConfig` dataclass in `graphiti_core/utils/maintenance/node_operations.py` with `skip_llm_dedup: bool = False` and `cosine_min_score: float = NODE_DEDUP_COSINE_MIN_SCORE`; add `DeduplicationConfig` to `graphiti_core/__init__.py` exports
- [ ] **Task 2**: Add `cosine_min_score` and `candidate_limit` parameters to `_semantic_candidate_search` and `_search_node` (replacing the hardcoded module-level constants `NODE_DEDUP_COSINE_MIN_SCORE` and `NODE_DEDUP_CANDIDATE_LIMIT`); keep constants as defaults
- [ ] **Task 3**: Add `dedup_config: DeduplicationConfig | None = None` to `_collect_candidate_nodes`; thread `cosine_min_score` from config to `_semantic_candidate_search`
- [ ] **Task 4**: Add `dedup_config: DeduplicationConfig | None = None` to `resolve_extracted_nodes`; thread to `_collect_candidate_nodes`; gate the `_resolve_with_llm` block on `not (dedup_config and dedup_config.skip_llm_dedup)`; verify existing unit tests still pass (`make test`)
- [ ] **Task 5**: Add `dedup_config: DeduplicationConfig | None = None` to `Graphiti.add_episode()` signature; thread to the `resolve_extracted_nodes` call at line ~1179; update `add_episode` docstring describing both modes and the dedup quality tradeoff (R5)
- [ ] **Task 6**: Update remaining 3 call sites of `resolve_extracted_nodes` in `graphiti.py` (`_resolve_nodes_and_edges_bulk` at line ~893, `add_triplet` at lines ~1715 and ~1724) to pass `dedup_config=None`; add optional `dedup_config: DeduplicationConfig | None = None` to `dedupe_nodes_bulk` in `bulk_utils.py` and thread to its `resolve_extracted_nodes` call
- [ ] **Task 7**: Add unit tests in `tests/utils/maintenance/test_node_operations.py` for: (a) `skip_llm_dedup=True` — assert `_resolve_with_llm` is never called even when unresolved nodes exist; (b) `cosine_min_score=0.85` — assert `node_similarity_search` is called with `min_score=0.85`
- [ ] **Task 8**: Create `tests/driver/test_dedup_benchmark_int.py` targeting LadybugDB with a benchmark test that: (a) skips unless `'GRAPHITI_BENCH_LADYBUG_DB' in os.environ`; falls back to auto-seeding 50K synthetic entities with real embeddings in `tmp_path` if absent; (b) initializes `LadybugDriver(db=os.environ['GRAPHITI_BENCH_LADYBUG_DB'])` when env var is set; (c) counts entities in the target group and skips with a warning if < 50K; (d) calls `graphiti.add_episode()` for a 50-chunk representative document; (e) measures wall time per chunk; (f) logs all per-chunk timings; (g) asserts p95 ≤ 60 s; annotated `@pytest.mark.timeout(600)` and `@pytest.mark.benchmark`
- [ ] **Task 9**: Add "Performance at Scale" section to `README.md` covering: what causes dedup slowdown at 50K+ entities; how to use `DeduplicationConfig(skip_llm_dedup=True)` and `DeduplicationConfig(cosine_min_score=0.85)`; what dedup quality is sacrificed; and how to remediate residual duplicates with `merge_entities` (R5)
- [ ] **Task 10**: Create ADR `NNN-dedup-config-api.md` (use next sequential number from `adrs/`) documenting: why `DeduplicationConfig` dataclass over individual params; the "raise the floor" semantics for `cosine_min_score`; what the 3-bucket approach would have required and why it was rejected; when to use each mode

### Risks

- **60-second SLO may not be achievable by code changes alone.** On LadybugDB at 80K+ entities, per-query cost includes both the HNSW traversal and the `hnsw_safe_writes.py` DELETE→CREATE overhead (no in-place HNSW updates). If a chunk has 15 extracted nodes and each resolves to a merge, the accumulated write cost may exceed 60 s regardless of LLM savings. With `cosine_min_score=0.85`, fewer candidates return and fewer nodes trigger writes — but there's no guarantee. The `skip_llm_dedup=True` mode eliminates LLM time entirely and reduces merges; if DB time alone still exceeds 60 s, the benchmark will capture this and the SLO becomes a documented best-effort target with notes in the ADR. Deeper LadybugDB-side fix is tracked in the `unordered_map::at` sister issue.

- **Quality regression on shared-name entities.** With `cosine_min_score=0.85`, entities whose true duplicate scores between 0.3 and 0.85 will not appear as candidates — they fall below the retrieval floor and are never considered for dedup. This is explicitly acceptable for the RFC-ADR corpus per operator sign-off, but must be clearly documented in the docstring and README.

- **Benchmark test maintenance.** The test is only useful if run against a populated database or with the auto-seeding path. It will appear to "pass" (by skipping) if `GRAPHITI_BENCH_LADYBUG_DB` is absent and auto-seeding fails. The README section should note this and provide the command to run it explicitly.

- **Auto-seeding embeds real model calls.** If the benchmark auto-seeds with real embeddings, this requires a real embedder (not a mock) and will make actual API calls during seeding. The test should document that `OPENAI_API_KEY` (or equivalent) must be set when using the auto-seed path.

- **Call-site consistency.** Four call sites of `resolve_extracted_nodes` must all be updated. Missing one would leave the `add_triplet` path ignoring `dedup_config`. The unit tests for the new config won't cover `add_triplet` specifically — Implement should grep for `resolve_extracted_nodes` to confirm all sites are found.

---
Used 18/50 turns, 8k input / 11k output tokens.

## Verification

Added `DeduplicationConfig` — a new public dataclass with `skip_llm_dedup`, `cosine_min_score`, and `candidate_limit` fields — threaded through `resolve_extracted_nodes`, `Graphiti.add_episode()`, and `dedupe_nodes_bulk()`. With `skip_llm_dedup=True`, the LLM dedup call is bypassed entirely (MinHash/LSH only); with `cosine_min_score=0.85`, the HNSW retrieval floor is raised to shrink the candidate pool and LLM prompt size. A LadybugDB benchmark integration test (`tests/driver/test_dedup_benchmark_int.py`) was added that skips by default and gates on `GRAPHITI_BENCH_LADYBUG_DB`, alongside 5 new unit tests, a "Performance at Scale" README section, and ADR 005 documenting the design rationale. All 52 existing unit tests continue to pass.

---

Closes #75